### PR TITLE
fix: correct license to Unlicense (public domain)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The Rust implementation uses:
 
 ## License
 
-UNLICENSED (JavaScript) / Unlicense (Rust)
+[Unlicense](LICENSE) — This is free and unencumbered software released into the public domain. You are free to copy, modify, publish, use, compile, sell, or distribute this software for any purpose, commercial or non-commercial, and by any means. See [https://unlicense.org](https://unlicense.org) for details.
 
 ## Related Projects
 

--- a/js/README.md
+++ b/js/README.md
@@ -369,4 +369,4 @@ await browser.close();
 
 ## License
 
-UNLICENSED
+[Unlicense](../LICENSE) — This is free and unencumbered software released into the public domain. You are free to copy, modify, publish, use, compile, sell, or distribute this software for any purpose, commercial or non-commercial, and by any means. See [https://unlicense.org](https://unlicense.org) for details.

--- a/js/package.json
+++ b/js/package.json
@@ -71,7 +71,7 @@
     "screenshot",
     "microservice"
   ],
-  "license": "UNLICENSED",
+  "license": "Unlicense",
   "engines": {
     "node": ">=22.0.0 <23.0.0"
   },

--- a/rust/README.md
+++ b/rust/README.md
@@ -192,4 +192,4 @@ web-capture --serve
 
 ## License
 
-Unlicense (Public Domain)
+[Unlicense](../LICENSE) — This is free and unencumbered software released into the public domain. You are free to copy, modify, publish, use, compile, sell, or distribute this software for any purpose, commercial or non-commercial, and by any means. See [https://unlicense.org](https://unlicense.org) for details.


### PR DESCRIPTION
## Summary

Fixes #31 — The project uses the [Unlicense](https://unlicense.org) (public domain dedication), but several files incorrectly stated the license as `UNLICENSED`, which is an npm placeholder meaning "all rights reserved / proprietary".

Changes:
- `js/package.json`: `"license": "UNLICENSED"` → `"license": "Unlicense"` (correct SPDX identifier)
- `README.md`: Replace `UNLICENSED (JavaScript) / Unlicense (Rust)` with a clear explanation of the Unlicense and a link to the LICENSE file and https://unlicense.org
- `js/README.md`: Replace `UNLICENSED` with the same consistent Unlicense explanation
- `rust/README.md`: Expand `Unlicense (Public Domain)` with the same consistent explanation

## How to reproduce the issue

```bash
cat js/package.json | grep license
# "license": "UNLICENSED"  <-- wrong, implies proprietary
```

npm tools and registries interpret `UNLICENSED` as "no license / all rights reserved". The correct SPDX identifier for the Unlicense is `"Unlicense"`.

## Test plan

- [x] `js/package.json` now uses the correct SPDX identifier `"Unlicense"`
- [x] All README files consistently explain the public domain dedication with link to https://unlicense.org
- [x] The `LICENSE` file and `rust/Cargo.toml` were already correct — no changes needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)