### PR TITLE
fix: correct CI/CD release pipeline and add comprehensive package manager badges

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
-# Updated: 2026-04-10T15:22:12.209Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
+# Updated: 2026-04-10T15:22:12.209Z

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # web-capture
 
-[![npm version](https://img.shields.io/npm/v/@link-assistant/web-capture?label=npm&color=blue)](https://www.npmjs.com/package/@link-assistant/web-capture)
-[![crates.io version](https://img.shields.io/crates/v/web-capture?label=crates.io&color=orange)](https://crates.io/crates/web-capture)
-[![GitHub Release](https://img.shields.io/github/v/release/link-assistant/web-capture?label=GitHub%20Release)](https://github.com/link-assistant/web-capture/releases)
-[![CI - JavaScript](https://img.shields.io/github/actions/workflow/status/link-assistant/web-capture/js.yml?branch=main&label=JS%20CI)](https://github.com/link-assistant/web-capture/actions/workflows/js.yml)
-[![CI - Rust](https://img.shields.io/github/actions/workflow/status/link-assistant/web-capture/rust.yml?branch=main&label=Rust%20CI)](https://github.com/link-assistant/web-capture/actions/workflows/rust.yml)
-[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-green)](https://unlicense.org)
+**JavaScript:** [![npm version](https://img.shields.io/npm/v/@link-assistant/web-capture?label=npm&color=blue)](https://www.npmjs.com/package/@link-assistant/web-capture) [![npm downloads](https://img.shields.io/npm/dm/@link-assistant/web-capture?label=downloads&color=blue)](https://www.npmjs.com/package/@link-assistant/web-capture) [![CI - JavaScript](https://img.shields.io/github/actions/workflow/status/link-assistant/web-capture/js.yml?branch=main&label=JS%20CI)](https://github.com/link-assistant/web-capture/actions/workflows/js.yml)
+
+**Rust:** [![crates.io version](https://img.shields.io/crates/v/web-capture?label=crates.io&color=orange)](https://crates.io/crates/web-capture) [![crates.io downloads](https://img.shields.io/crates/d/web-capture?label=downloads&color=orange)](https://crates.io/crates/web-capture) [![docs.rs](https://img.shields.io/docsrs/web-capture?label=docs.rs)](https://docs.rs/web-capture) [![CI - Rust](https://img.shields.io/github/actions/workflow/status/link-assistant/web-capture/rust.yml?branch=main&label=Rust%20CI)](https://github.com/link-assistant/web-capture/actions/workflows/rust.yml)
+
+**Release:** [![GitHub Release](https://img.shields.io/github/v/release/link-assistant/web-capture?label=GitHub%20Release)](https://github.com/link-assistant/web-capture/releases) [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-green)](https://unlicense.org)
 
 A CLI and microservice to fetch URLs and render them as:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # web-capture
 
+[![npm version](https://img.shields.io/npm/v/@link-assistant/web-capture?label=npm&color=blue)](https://www.npmjs.com/package/@link-assistant/web-capture)
+[![crates.io version](https://img.shields.io/crates/v/web-capture?label=crates.io&color=orange)](https://crates.io/crates/web-capture)
+[![GitHub Release](https://img.shields.io/github/v/release/link-assistant/web-capture?label=GitHub%20Release)](https://github.com/link-assistant/web-capture/releases)
+[![CI - JavaScript](https://img.shields.io/github/actions/workflow/status/link-assistant/web-capture/js.yml?branch=main&label=JS%20CI)](https://github.com/link-assistant/web-capture/actions/workflows/js.yml)
+[![CI - Rust](https://img.shields.io/github/actions/workflow/status/link-assistant/web-capture/rust.yml?branch=main&label=Rust%20CI)](https://github.com/link-assistant/web-capture/actions/workflows/rust.yml)
+[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-green)](https://unlicense.org)
+
 A CLI and microservice to fetch URLs and render them as:
 
 - **HTML**: Rendered page content

--- a/docs/case-studies/issue-38/README.md
+++ b/docs/case-studies/issue-38/README.md
@@ -49,6 +49,13 @@ npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modu
 
 **Impact:** The setup-npm.mjs script is meant to update npm to >=11.5.1 for OIDC trusted publishing support. When it fails, the publish step may lack proper OIDC authentication.
 
+**External references:**
+- [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883) - npm in Node.js 22.22.2 toolcache has broken module tree (missing `promise-retry`)
+- [nodejs/node#62430](https://github.com/nodejs/node/issues/62430) - npm i -g npm@latest -> Cannot find module 'promise-retry'
+- [npm/cli#9151](https://github.com/npm/cli/issues/9151) - latest npm fails to install in latest node 22
+
+**Status:** The `promise-retry` dependency was replaced with `@gar/promise-retry` in npm 11.11.0. The issue affects Node.js 22.22.2 on GitHub Actions runner images with `ubuntu-24.04` starting from image version `20260329.72.1`. A workaround is to use `corepack enable && corepack prepare npm@latest --activate` or to gracefully handle the failure.
+
 ### Root Cause 3: Cascading Publish Failure (CONSEQUENCE)
 
 Because Root Cause 1 prevents the changeset version step from running, no version bump commit is made. The `version-and-commit.mjs` script reports "No changes to commit", the `version_committed` output is never set to `true`, and the subsequent publish step is skipped.

--- a/docs/case-studies/issue-38/README.md
+++ b/docs/case-studies/issue-38/README.md
@@ -1,0 +1,95 @@
+# Case Study: Issue #38 - npm package version lag (1.1.2 vs 1.2.0)
+
+## Problem Statement
+
+The npm published version of `@link-assistant/web-capture` is v1.1.2, while the GitHub repository source is at v1.2.0. Nine critical modules are missing from the npm package.
+
+## Timeline of Events
+
+| Date | Event | Details |
+|------|-------|---------|
+| 2025-12-22 07:16 UTC | v1.1.1 published | First CI/CD automated release (npm OIDC + changesets) |
+| 2025-12-22 09:50 UTC | v1.1.2 published | Last successful npm publish |
+| 2025-12-23 22:42 UTC | v1.1.3 GitHub Release | Created on GitHub but **never published to npm** |
+| 2025-12-28 16:43 UTC | v1.2.0 GitHub Release | Created on GitHub but **never published to npm** |
+| 2026-04-06 23:05 UTC | JS Release run fails | Run #24055582663 on main branch, same root cause |
+| 2026-04-10 14:03 UTC | JS Release run fails | Run #24246825461 on main branch, same root cause |
+| 2026-04-10 | Issue #38 opened | Version lag reported |
+
+## Root Cause Analysis
+
+### Root Cause 1: Script Path Mismatch in package.json (PRIMARY)
+
+**File:** `js/package.json` line 30
+**Script:** `"changeset:version": "node scripts/changeset-version.mjs"`
+
+The release workflow sets `working-directory: js`. When the `version-and-commit.mjs` script runs `npm run changeset:version`, npm resolves the path relative to `js/`, looking for `js/scripts/changeset-version.mjs`. However, the actual file is at the repository root: `scripts/changeset-version.mjs`.
+
+**Error from CI logs (run #24246825461):**
+```
+Error: Cannot find module '/home/runner/work/web-capture/web-capture/js/scripts/changeset-version.mjs'
+```
+
+**Why this happened:** When the repository was restructured to move scripts from `js/scripts/` to the shared `scripts/` directory at the repo root, the `package.json` script reference was not updated to use the new path (`../scripts/changeset-version.mjs`).
+
+### Root Cause 2: npm Global Update Failure (SECONDARY)
+
+**File:** `scripts/setup-npm.mjs` line 28
+**Command:** `npm install -g npm@latest`
+
+The npm global update fails with `Cannot find module 'promise-retry'` on Node.js 22.22.2 GitHub Actions runners. This is a known issue with certain Node.js + npm version combinations where the global npm installation becomes corrupted during an in-place upgrade.
+
+**Error from CI logs:**
+```
+npm error code MODULE_NOT_FOUND
+npm error Cannot find module 'promise-retry'
+npm error Require stack:
+npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
+```
+
+**Impact:** The setup-npm.mjs script is meant to update npm to >=11.5.1 for OIDC trusted publishing support. When it fails, the publish step may lack proper OIDC authentication.
+
+### Root Cause 3: Cascading Publish Failure (CONSEQUENCE)
+
+Because Root Cause 1 prevents the changeset version step from running, no version bump commit is made. The `version-and-commit.mjs` script reports "No changes to commit", the `version_committed` output is never set to `true`, and the subsequent publish step is skipped.
+
+Even in the failed run #24055582663 where publish was somehow attempted, it failed with E404 because npm OIDC was not properly configured (Root Cause 2) and/or the package version was already at 1.2.0 locally but the changeset metadata was stale.
+
+## Affected Components
+
+| Component | Issue | Fix |
+|-----------|-------|-----|
+| `js/package.json` | `changeset:version` script path wrong | Change to `node ../scripts/changeset-version.mjs` |
+| `scripts/setup-npm.mjs` | `npm install -g npm@latest` corrupts npm | Use `npm install -g npm@11` (pinned major version) with error resilience |
+| `README.md` | No package version badges | Add npm and crates.io badges |
+| GitHub Releases | No package manager badges | Add badge to release format script |
+
+## Solutions Implemented
+
+### Fix 1: Correct changeset:version script path
+Update `js/package.json` to reference `../scripts/changeset-version.mjs` instead of `scripts/changeset-version.mjs`.
+
+### Fix 2: Make npm update more resilient
+Update `scripts/setup-npm.mjs` to:
+- Pin npm to a specific major version (`npm@11`) instead of `npm@latest`
+- Handle update failure gracefully (warn but don't exit) since the current npm 10.9.7 may still work for OIDC
+
+### Fix 3: Add package manager badges to README.md
+Add npm version badge and crates.io version badge to the root README.md.
+
+### Fix 4: Add badges to GitHub Release format script
+Update `scripts/format-github-release.mjs` and `scripts/rust-create-github-release.mjs` to include package manager badges.
+
+## CI Log Evidence
+
+Relevant log files saved to `ci-logs/` directory:
+- `ci-logs/js-24055582663.log` - Failed JS release run from 2026-04-06
+- `ci-logs/js-24246825461-main-latest.log` - Failed JS release run from 2026-04-10
+
+## Verification Plan
+
+After fixes are merged to main:
+1. A new changeset exists (`meta-theory-best-practices.md`) which will trigger the release pipeline
+2. The corrected `changeset:version` path will allow the version bump to succeed
+3. The resilient npm setup will ensure OIDC publishing works
+4. The new version will be published to npm and visible via the badges

--- a/js/README.md
+++ b/js/README.md
@@ -1,5 +1,11 @@
 # web-capture (JavaScript/Node.js)
 
+[![npm version](https://img.shields.io/npm/v/@link-assistant/web-capture?label=npm&color=blue)](https://www.npmjs.com/package/@link-assistant/web-capture)
+[![npm downloads](https://img.shields.io/npm/dm/@link-assistant/web-capture?label=downloads&color=blue)](https://www.npmjs.com/package/@link-assistant/web-capture)
+[![GitHub Release](https://img.shields.io/github/v/release/link-assistant/web-capture?label=GitHub%20Release)](https://github.com/link-assistant/web-capture/releases)
+[![CI - JavaScript](https://img.shields.io/github/actions/workflow/status/link-assistant/web-capture/js.yml?branch=main&label=CI)](https://github.com/link-assistant/web-capture/actions/workflows/js.yml)
+[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-green)](https://unlicense.org)
+
 A CLI and microservice to fetch URLs and render them as:
 
 - **HTML**: Rendered page content

--- a/js/package.json
+++ b/js/package.json
@@ -27,7 +27,7 @@
     "check": "npm run lint && npm run format:check && npm run check:duplication",
     "prepare": "husky || true",
     "changeset": "changeset",
-    "changeset:version": "node scripts/changeset-version.mjs",
+    "changeset:version": "node ../scripts/changeset-version.mjs",
     "changeset:publish": "changeset publish",
     "changeset:status": "changeset status --since=origin/main"
   },

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,5 +1,12 @@
 # web-capture (Rust)
 
+[![crates.io version](https://img.shields.io/crates/v/web-capture?label=crates.io&color=orange)](https://crates.io/crates/web-capture)
+[![crates.io downloads](https://img.shields.io/crates/d/web-capture?label=downloads&color=orange)](https://crates.io/crates/web-capture)
+[![docs.rs](https://img.shields.io/docsrs/web-capture?label=docs.rs)](https://docs.rs/web-capture)
+[![GitHub Release](https://img.shields.io/github/v/release/link-assistant/web-capture?label=GitHub%20Release)](https://github.com/link-assistant/web-capture/releases)
+[![CI - Rust](https://img.shields.io/github/actions/workflow/status/link-assistant/web-capture/rust.yml?branch=main&label=CI)](https://github.com/link-assistant/web-capture/actions/workflows/rust.yml)
+[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-green)](https://unlicense.org)
+
 A CLI and microservice to fetch URLs and render them as:
 
 - **HTML**: Rendered page content

--- a/scripts/setup-npm.mjs
+++ b/scripts/setup-npm.mjs
@@ -26,19 +26,37 @@ try {
 
   // Update npm for OIDC trusted publishing (requires >= 11.5.1)
   // Pin to npm@11 to avoid breaking changes from future major versions
-  // Use a fresh install approach to avoid corrupting the running npm instance
+  //
+  // Known issue: Node.js 22.22.2 on GitHub Actions (ubuntu-24.04 image >= 20260329.72.1)
+  // ships with a broken npm 10.9.7 that is missing the 'promise-retry' module,
+  // causing `npm install -g` to fail with MODULE_NOT_FOUND.
+  // See: https://github.com/actions/runner-images/issues/13883
+  // See: https://github.com/nodejs/node/issues/62430
+  // See: https://github.com/npm/cli/issues/9151
+  //
+  // Workaround: try corepack as a fallback when npm self-update fails.
+  let updated = false;
   try {
     await $`npm install -g npm@11`;
+    updated = true;
   } catch (updateError) {
-    // npm global self-update can fail on some Node.js versions due to
-    // module resolution issues (e.g., 'promise-retry' not found).
-    // This is a known issue with in-place npm upgrades on GitHub Actions runners.
-    // See: https://github.com/npm/cli/issues/4028
-    console.warn(`Warning: npm update failed: ${updateError.message}`);
-    console.warn('Continuing with current npm version...');
+    console.warn(`Warning: npm install -g failed: ${updateError.message}`);
     console.warn(
-      'If OIDC publishing fails, the npm version may need to be >= 11.5.1'
+      'This is likely the Node.js 22.22.2 broken npm issue (actions/runner-images#13883).'
     );
+    console.warn('Trying corepack as fallback...');
+
+    try {
+      await $`corepack enable`;
+      await $`corepack prepare npm@11 --activate`;
+      updated = true;
+    } catch (corepackError) {
+      console.warn(`Warning: corepack fallback also failed: ${corepackError.message}`);
+      console.warn('Continuing with current npm version...');
+      console.warn(
+        'If OIDC publishing fails, the npm version may need to be >= 11.5.1'
+      );
+    }
   }
 
   // Get updated npm version

--- a/scripts/setup-npm.mjs
+++ b/scripts/setup-npm.mjs
@@ -24,8 +24,22 @@ try {
   const currentVersion = currentResult.stdout.trim();
   console.log(`Current npm version: ${currentVersion}`);
 
-  // Update npm to latest
-  await $`npm install -g npm@latest`;
+  // Update npm for OIDC trusted publishing (requires >= 11.5.1)
+  // Pin to npm@11 to avoid breaking changes from future major versions
+  // Use a fresh install approach to avoid corrupting the running npm instance
+  try {
+    await $`npm install -g npm@11`;
+  } catch (updateError) {
+    // npm global self-update can fail on some Node.js versions due to
+    // module resolution issues (e.g., 'promise-retry' not found).
+    // This is a known issue with in-place npm upgrades on GitHub Actions runners.
+    // See: https://github.com/npm/cli/issues/4028
+    console.warn(`Warning: npm update failed: ${updateError.message}`);
+    console.warn('Continuing with current npm version...');
+    console.warn(
+      'If OIDC publishing fails, the npm version may need to be >= 11.5.1'
+    );
+  }
 
   // Get updated npm version
   const updatedResult = await $`npm --version`.run({ capture: true });


### PR DESCRIPTION
## Summary

Fixes #38 — npm package version (1.1.2) is behind GitHub source (1.2.0) due to broken CI/CD release pipeline.

### Root Causes Found

1. **Script path mismatch (PRIMARY)**: \`js/package.json\` defined \`"changeset:version": "node scripts/changeset-version.mjs"\` but since the workflow runs with \`working-directory: js\`, this resolved to \`js/scripts/changeset-version.mjs\` which doesn't exist. The actual file is at \`scripts/changeset-version.mjs\` (repo root). Fix: changed to \`node ../scripts/changeset-version.mjs\`.

2. **npm global update failure (SECONDARY)**: \`scripts/setup-npm.mjs\` ran \`npm install -g npm@latest\` which fails with \`Cannot find module 'promise-retry'\` on Node.js 22.22.2 runners. This is a known issue: [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883), [nodejs/node#62430](https://github.com/nodejs/node/issues/62430), [npm/cli#9151](https://github.com/npm/cli/issues/9151). Fix: pin to \`npm@11\`, add \`corepack\` fallback, and handle failure gracefully.

### Changes

- **\`js/package.json\`**: Fix \`changeset:version\` script path from \`scripts/changeset-version.mjs\` to \`../scripts/changeset-version.mjs\`
- **\`scripts/setup-npm.mjs\`**: Pin npm update to \`npm@11\`, add \`corepack\` fallback for broken npm environments, add graceful error handling
- **\`README.md\`**: Reorganize badges by language (JS, Rust, Release) so release status is clearly visible for both package managers; add npm downloads and crates.io downloads badges
- **\`js/README.md\`**: Add npm version, npm downloads, GitHub Release, CI status, and license badges
- **\`rust/README.md\`**: Add crates.io version, crates.io downloads, docs.rs, GitHub Release, CI status, and license badges
- **\`docs/case-studies/issue-38/\`**: Full case study with timeline, root cause analysis, CI log evidence, external issue references, and verification plan

### CI Log Evidence

From run #24246825461 (2026-04-10):
```
Error: Cannot find module '/home/runner/work/web-capture/web-capture/js/scripts/changeset-version.mjs'
```

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

### Verification Plan

After merge to main:
1. Existing changeset (`meta-theory-best-practices.md`) will trigger the release pipeline
2. Corrected `changeset:version` path will allow the version bump to succeed
3. Resilient npm setup (with corepack fallback) will ensure OIDC publishing works
4. New version will be published to npm and visible via badges

## Test plan

- [ ] Verify `changeset:version` script path resolves correctly (`node ../scripts/changeset-version.mjs`)
- [ ] Verify `setup-npm.mjs` handles npm update failure gracefully with corepack fallback
- [ ] After merge: confirm new version appears on [npm](https://www.npmjs.com/package/@link-assistant/web-capture) — visible via npm badge in README
- [ ] After merge: confirm new version appears on [crates.io](https://crates.io/crates/web-capture) — visible via crates.io badge in README
- [ ] After merge: confirm README badges render correctly for both JS and Rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)