### PR TITLE
fix: resolve CI/CD release pipeline failure (git show path bug)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
-# Updated: 2026-04-11T03:15:04.387Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
+# Updated: 2026-04-11T03:15:04.387Z

--- a/docs/case-studies/issue-42/README.md
+++ b/docs/case-studies/issue-42/README.md
@@ -1,0 +1,126 @@
+# Case Study: CI/CD Release Pipeline Broken (Issue #42)
+
+## Summary
+
+The JavaScript release pipeline failed at the "Version packages and commit to main" step during CI run [24262572320](https://github.com/link-assistant/web-capture/actions/runs/24262572320/job/70853245788). The npm package release for version 1.4.0 did not complete through the automated pipeline. Two distinct issues were identified: a primary bug in `version-and-commit.mjs` and a secondary upstream issue with Node.js 22.22.2's broken npm.
+
+## Timeline
+
+| Date | Event | Details |
+|------|-------|---------|
+| 2026-04-10 20:24:29 | CI triggered | Push to main (merge PR #41, commit `f6c733b`) triggered JS workflow |
+| 2026-04-10 20:24:30 | Lint+Test start | Both jobs start successfully |
+| 2026-04-10 20:24:56 | Lint passes | ESLint, Prettier, duplication check all pass |
+| 2026-04-10 20:30:22 | Tests pass | Unit, integration, e2e, and Docker tests all pass |
+| 2026-04-10 20:51:08 | Release job starts | Begins after lint and test jobs complete |
+| 2026-04-10 20:51:31 | Dependencies installed | `npm install` succeeds (136 packages funded, 14 vulnerabilities noted) |
+| 2026-04-10 20:51:33 | setup-npm.mjs runs | Detects npm 10.9.7, attempts `npm install -g npm@11` |
+| 2026-04-10 20:51:36 | npm upgrade fails | `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` — known Node.js 22.22.2 issue |
+| 2026-04-10 20:51:36 | setup-npm continues | Fallbacks fail silently, npm stays at 10.9.7 |
+| 2026-04-10 20:51:36 | Changeset check | Finds 1 changeset file to process |
+| 2026-04-10 20:51:36 | version-and-commit.mjs starts | Begins version bump in changeset mode |
+| 2026-04-10 20:51:38 | Remote divergence detected | Local HEAD `f6c733b` != remote HEAD `2d5bbd1` (version 1.4.0 already pushed by previous run) |
+| 2026-04-10 20:51:38 | **FAILURE**: `git show` path error | `git show origin/main:package.json` fails with `fatal: path 'js/package.json' exists, but not 'package.json'` |
+| 2026-04-10 20:51:38 | Script crashes | `Error: Unexpected end of JSON input` — JSON.parse fails on empty git show output |
+| 2026-04-10 20:51:38 | Job fails | Process exits with code 1, publish step skipped |
+
+## Root Causes
+
+### RC1 (Primary): `git show` uses repo-root-relative paths, not working-directory-relative
+
+**Evidence** (CI log lines 230-236):
+```
+f6c733bd2b56cd935592b1be33a93fae83584328
+2d5bbd1360036ea8a74a9cba6a341fadcca27e3c
+Remote main has advanced (local: f6c733bd2b56cd935592b1be33a93fae83584328, remote: 2d5bbd1360036ea8a74a9cba6a341fadcca27e3c)
+fatal: path 'js/package.json' exists, but not 'package.json'
+This may indicate a previous attempt partially succeeded.
+hint: Did you mean 'origin/main:js/package.json' aka 'origin/main:./package.json'?
+Error: Unexpected end of JSON input
+```
+
+**Root cause**: In `scripts/version-and-commit.mjs:129`, the `getVersion('remote')` function runs:
+```javascript
+const result = await $`git show origin/main:package.json`.run({ capture: true });
+```
+
+The `git show <ref>:<path>` command **always** resolves `<path>` relative to the **repository root**, regardless of the current working directory. However, the GitHub Actions workflow sets `working-directory: js`, so `package.json` is at `js/package.json` relative to the repo root. The command should have been `git show origin/main:js/package.json`.
+
+This is documented in git's behavior: `git show` uses tree-level paths (from repo root), while filesystem commands like `readFileSync('./package.json')` use the process working directory. This asymmetry created the bug.
+
+**Trigger condition**: This bug only manifests when `localHead !== remoteHead` (i.e., when the remote main branch has advanced since the CI run was triggered). This is a race condition that occurs when:
+1. A push to main triggers CI run A
+2. Before CI run A's release job starts, another push (e.g., from a previous CI run's version bump) advances main
+3. CI run A detects the divergence and calls `getVersion('remote')` to check the remote version
+
+**Why it wasn't caught earlier**: The `getVersion('local')` path uses `readFileSync('./package.json')` which correctly reads from the `js/` working directory. The `getVersion('remote')` path is only called in the race condition scenario, making it an infrequent code path.
+
+### RC2 (Secondary): Node.js 22.22.2 ships with broken npm 10.9.7
+
+**Evidence** (CI log lines 189-203):
+```
+npm error code MODULE_NOT_FOUND
+npm error Cannot find module 'promise-retry'
+npm error Require stack:
+npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
+```
+
+**Root cause**: The pre-cached Node.js 22.22.2 on GitHub Actions runner images (ubuntu-24.04 image >= 20260329.72.1) has a broken npm installation where the `promise-retry` module is missing from npm's internal dependency tree. This causes any command that triggers `@npmcli/arborist` (including `npm install -g`) to fail with `MODULE_NOT_FOUND`.
+
+This is a known upstream issue:
+- [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883)
+- [npm/cli#9151](https://github.com/npm/cli/issues/9151)
+- [nodejs/node#62430](https://github.com/nodejs/node/issues/62430)
+
+**Impact**: The `setup-npm.mjs` script could not upgrade npm from 10.9.7 to 11.x for OIDC trusted publishing support. The existing corepack fallback also failed. However, since the version-and-commit step failed before reaching the publish step, this issue was not the direct cause of the pipeline failure. It would have caused a publish failure if the version bump had succeeded.
+
+## Solutions Applied
+
+### Fix 1: Use `git rev-parse --show-prefix` for dynamic path resolution
+
+In `scripts/version-and-commit.mjs`, the `getVersion('remote')` function now dynamically determines the repo-root-relative path:
+
+```javascript
+const prefixResult = await $`git rev-parse --show-prefix`.run({ capture: true });
+const prefix = prefixResult.stdout.trim();  // e.g., "js/"
+const gitPath = `${prefix}package.json`;    // e.g., "js/package.json"
+const result = await $`git show origin/main:${gitPath}`.run({ capture: true });
+```
+
+This approach:
+- Works from any subdirectory, not just `js/`
+- Uses a standard git command (`git rev-parse --show-prefix`) to determine the current directory relative to the repo root
+- Is forward-compatible if the repository structure changes
+
+### Fix 2: Add npx-based fallback for broken npm upgrade
+
+In `scripts/setup-npm.mjs`, added an intermediate fallback strategy between the direct `npm install -g` and the `corepack` fallback:
+
+```javascript
+// Fallback 1: npx downloads packages to a cache and runs them,
+// bypassing the broken global npm's rebuild/arborist code path
+await $`npx --yes npm@11 install -g npm@11`;
+```
+
+The `npx` approach works because it downloads npm@11 to a temporary cache directory and executes it directly, bypassing the broken global npm's `@npmcli/arborist/rebuild` code path that requires the missing `promise-retry` module.
+
+Fallback order is now:
+1. `npm install -g npm@11` (standard, works when npm is healthy)
+2. `npx --yes npm@11 install -g npm@11` (new, bypasses broken npm)
+3. `corepack enable && corepack prepare npm@11 --activate` (existing fallback)
+4. Check if current npm already >= 11 (existing fallback)
+
+## Verification
+
+The fix can be verified by:
+1. Re-running the CI/CD pipeline after merging
+2. The `version-and-commit.mjs` script should correctly resolve `js/package.json` even when remote main has advanced
+3. The `setup-npm.mjs` script should successfully upgrade npm via the npx fallback
+
+## References
+
+- [CI run 24262572320](https://github.com/link-assistant/web-capture/actions/runs/24262572320/job/70853245788) — failed release job
+- [Git documentation: git-rev-parse --show-prefix](https://git-scm.com/docs/git-rev-parse) — current directory relative to repo root
+- [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883) — broken npm on Node.js 22.22.2
+- [npm/cli#9151](https://github.com/npm/cli/issues/9151) — npm MODULE_NOT_FOUND issue
+- [nodejs/node#62430](https://github.com/nodejs/node/issues/62430) — Node.js tracking issue

--- a/docs/case-studies/issue-42/ci-run-24262572320.txt
+++ b/docs/case-studies/issue-42/ci-run-24262572320.txt
@@ -1,0 +1,2214 @@
+JS - Release	UNKNOWN STEP	﻿2026-04-10T20:51:09.0999670Z Current runner version: '2.333.1'
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1023416Z ##[group]Runner Image Provisioner
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1024171Z Hosted Compute Agent
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1024705Z Version: 20260213.493
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1025361Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1026043Z Build Date: 2026-02-13T00:28:41Z
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1026680Z Worker ID: {2ab679c2-7c7f-447e-ab25-2b680c1fddb8}
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1027404Z Azure Region: westus
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1027900Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1029297Z ##[group]Operating System
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1030270Z Ubuntu
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1030710Z 24.04.4
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1031196Z LTS
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1031985Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1032503Z ##[group]Runner Image
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1033014Z Image: ubuntu-24.04
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1033553Z Version: 20260406.80.1
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1034716Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1036270Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1037119Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1038171Z ##[group]GITHUB_TOKEN Permissions
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1040292Z Contents: write
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1040895Z Metadata: read
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1041345Z PullRequests: write
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1041955Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1044348Z Secret source: Actions
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1045204Z Prepare workflow directory
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1440235Z Prepare all required actions
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.1478125Z Getting action download info
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:09.6241004Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.3981999Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.6323398Z Complete job name: JS - Release
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7080578Z ##[group]Run actions/checkout@v4
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7081578Z with:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7082021Z   fetch-depth: 0
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7082492Z   repository: link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7083243Z   token: ***
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7083648Z   ssh-strict: true
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7084071Z   ssh-user: git
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7084498Z   persist-credentials: true
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7084983Z   clean: true
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7085413Z   sparse-checkout-cone-mode: true
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7085931Z   fetch-tags: false
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7086364Z   show-progress: true
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7086801Z   lfs: false
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7087212Z   submodules: false
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7087647Z   set-safe-directory: true
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.7088371Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.8154310Z Syncing repository: link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.8156213Z ##[group]Getting Git version info
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.8157104Z Working directory is '/home/runner/work/web-capture/web-capture'
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.8158147Z [command]/usr/bin/git version
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.9541526Z git version 2.53.0
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.9570081Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.9592408Z Temporarily overriding HOME='/home/runner/work/_temp/ed2780ad-f308-4fcd-88e9-87208ab7677b' before making global git config changes
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.9593867Z Adding repository directory to the temporary git global config as a safe directory
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.9597751Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/web-capture/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.9631251Z Deleting the contents of '/home/runner/work/web-capture/web-capture'
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.9635268Z ##[group]Initializing the repository
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:10.9640548Z [command]/usr/bin/git init /home/runner/work/web-capture/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0064362Z hint: Using 'master' as the name for the initial branch. This default branch name
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0066496Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0068452Z hint: to use in all of your new repositories, which will suppress this warning,
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0070659Z hint: call:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0071455Z hint:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0072471Z hint: 	git config --global init.defaultBranch <name>
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0073687Z hint:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0074826Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0076724Z hint: 'development'. The just-created branch can be renamed via this command:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0078329Z hint:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0079198Z hint: 	git branch -m <name>
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0080371Z hint:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0081658Z hint: Disable this message with "git config set advice.defaultBranchName false"
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0083556Z Initialized empty Git repository in /home/runner/work/web-capture/web-capture/.git/
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0086484Z [command]/usr/bin/git remote add origin https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0111129Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0112465Z ##[group]Disabling automatic garbage collection
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0116100Z [command]/usr/bin/git config --local gc.auto 0
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0144856Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0146243Z ##[group]Setting up auth
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0152922Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.0183491Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.1362125Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.1392579Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.1608490Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.1652904Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.1900575Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.1937321Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.1938769Z ##[group]Fetching the repository
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:11.1947614Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1067901Z From https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1070743Z  * [new branch]      issue-1-5017a66c05a8  -> origin/issue-1-5017a66c05a8
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1073193Z  * [new branch]      issue-11-2861fe92     -> origin/issue-11-2861fe92
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1074601Z  * [new branch]      issue-13-a8f3466f6d79 -> origin/issue-13-a8f3466f6d79
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1076133Z  * [new branch]      issue-15-ba41292e60dd -> origin/issue-15-ba41292e60dd
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1077616Z  * [new branch]      issue-17-d61fd69fb1d0 -> origin/issue-17-d61fd69fb1d0
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1079112Z  * [new branch]      issue-19-7350892c64e0 -> origin/issue-19-7350892c64e0
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1080890Z  * [new branch]      issue-21-ae540dd05ccf -> origin/issue-21-ae540dd05ccf
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1082423Z  * [new branch]      issue-24-000cedc18c0c -> origin/issue-24-000cedc18c0c
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1083910Z  * [new branch]      issue-26-f5bc08d1c062 -> origin/issue-26-f5bc08d1c062
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1085406Z  * [new branch]      issue-28-9ae2d8528d6f -> origin/issue-28-9ae2d8528d6f
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1087036Z  * [new branch]      issue-29-1750ff5496be -> origin/issue-29-1750ff5496be
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1088638Z  * [new branch]      issue-3-e1f5cfd3      -> origin/issue-3-e1f5cfd3
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1090756Z  * [new branch]      issue-31-e38e38b91777 -> origin/issue-31-e38e38b91777
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1092599Z  * [new branch]      issue-33-597c234012bd -> origin/issue-33-597c234012bd
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1094686Z  * [new branch]      issue-36-4868dc6a6cd1 -> origin/issue-36-4868dc6a6cd1
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1096434Z  * [new branch]      issue-38-1c6b407f9682 -> origin/issue-38-1c6b407f9682
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1098311Z  * [new branch]      issue-40-aea0c7bbe29d -> origin/issue-40-aea0c7bbe29d
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1100540Z  * [new branch]      issue-5-37ef445c      -> origin/issue-5-37ef445c
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1103027Z  * [new branch]      issue-7-c22ac3d5      -> origin/issue-7-c22ac3d5
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1104840Z  * [new branch]      issue-8-2bf69acf      -> origin/issue-8-2bf69acf
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1106392Z  * [new branch]      main                  -> origin/main
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1107698Z  * [new tag]         v1.1.1                -> v1.1.1
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1108934Z  * [new tag]         v1.1.2                -> v1.1.2
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1110504Z  * [new tag]         v1.1.3                -> v1.1.3
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1112006Z  * [new tag]         v1.2.0                -> v1.2.0
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1113525Z  * [new tag]         v1.3.0                -> v1.3.0
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1132500Z [command]/usr/bin/git branch --list --remote origin/main
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1158174Z   origin/main
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1168949Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1188950Z 2d5bbd1360036ea8a74a9cba6a341fadcca27e3c
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1202822Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin +f6c733bd2b56cd935592b1be33a93fae83584328:refs/remotes/origin/main
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1247902Z From https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1251840Z  + 2d5bbd1...f6c733b f6c733bd2b56cd935592b1be33a93fae83584328 -> origin/main  (forced update)
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1274448Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1276642Z ##[group]Determining the checkout info
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1279269Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1281336Z [command]/usr/bin/git sparse-checkout disable
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1314492Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1339428Z ##[group]Checking out the ref
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1342679Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1490868Z Switched to a new branch 'main'
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1493410Z branch 'main' set up to track 'origin/main'.
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1502600Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1534566Z [command]/usr/bin/git log -1 --format=%H
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1556313Z f6c733bd2b56cd935592b1be33a93fae83584328
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1873494Z ##[group]Run actions/setup-node@v4
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1874549Z with:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1875278Z   node-version: 22.x
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1876214Z   registry-url: https://registry.npmjs.org
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1877359Z   always-auth: false
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1878199Z   check-latest: false
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1879337Z   token: ***
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.1880269Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.3987136Z Found in cache @ /opt/hostedtoolcache/node/22.22.2/x64
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:12.3993996Z ##[group]Environment details
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8314969Z node: v22.22.2
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8315583Z npm: 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8315960Z yarn: 1.22.22
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8316850Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8430013Z ##[group]Run npm install
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8430388Z [36;1mnpm install[0m
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8514508Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8514747Z env:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8514982Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8515303Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:15.8515563Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:19.3334500Z npm warn deprecated supertest@6.3.4: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:20.0682772Z npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:20.2546459Z npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:21.5746326Z npm warn deprecated superagent@8.1.2: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:22.6900301Z npm warn deprecated puppeteer@24.8.2: < 24.15.0 is no longer supported
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:23.0229478Z npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8246352Z 
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8247165Z > @link-assistant/web-capture@1.3.0 prepare
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8247683Z > husky || true
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8247820Z 
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8743535Z .git can't be found
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8744279Z added 857 packages, and audited 858 packages in 16s
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8744690Z 
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8745163Z 136 packages are looking for funding
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8870136Z   run `npm fund` for details
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8870687Z 
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8875311Z 14 vulnerabilities (1 low, 5 moderate, 6 high, 2 critical)
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8875773Z 
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8876034Z To address all issues, run:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8876438Z   npm audit fix
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8878053Z 
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.8878324Z Run `npm audit` for details.
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.9459298Z ##[group]Run node ../scripts/setup-npm.mjs
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.9459646Z [36;1mnode ../scripts/setup-npm.mjs[0m
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.9480707Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.9480934Z env:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.9481161Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.9481493Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:31.9481740Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:33.4157028Z 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:33.4203062Z Current npm version: 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2413430Z npm error code MODULE_NOT_FOUND
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2414495Z npm error Cannot find module 'promise-retry'
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2414988Z npm error Require stack:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2416089Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2417675Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/index.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2419367Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/index.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2421457Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/libnpmfund/lib/index.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2422865Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-output.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2424300Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-finish.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2425631Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/commands/install.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2427115Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/npm.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2428452Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli/entry.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2432123Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2433931Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/bin/npm-cli.js
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.2436484Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-10T20_51_33_475Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3425789Z 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3470748Z Updated npm version: 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3578441Z ##[group]Run # Count changeset files (excluding README.md and config.json)
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3579375Z [36;1m# Count changeset files (excluding README.md and config.json)[0m
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3580557Z [36;1mCHANGESET_COUNT=$(find .changeset -name "*.md" ! -name "README.md" | wc -l)[0m
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3581347Z [36;1mecho "Found $CHANGESET_COUNT changeset file(s)"[0m
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3582214Z [36;1mecho "has_changesets=$([[ $CHANGESET_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT[0m
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3610579Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3610812Z env:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3611038Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3611361Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3611600Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3782399Z Found 1 changeset file(s)
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3833434Z ##[group]Run node ../scripts/version-and-commit.mjs --mode changeset
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3833934Z [36;1mnode ../scripts/version-and-commit.mjs --mode changeset[0m
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3853993Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3854222Z env:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3854445Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3854773Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:36.3855023Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.1886700Z 📝 Loaded 2 variables from .lenv
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.1986041Z Parsed configuration: { mode: 'changeset', bumpType: '', description: '(none)' }
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.2166404Z Checking for remote changes...
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5683191Z From https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5683961Z  * branch            main       -> FETCH_HEAD
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5685401Z    f6c733b..2d5bbd1  main       -> origin/main
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5814580Z f6c733bd2b56cd935592b1be33a93fae83584328
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5886554Z 2d5bbd1360036ea8a74a9cba6a341fadcca27e3c
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5892115Z Remote main has advanced (local: f6c733bd2b56cd935592b1be33a93fae83584328, remote: 2d5bbd1360036ea8a74a9cba6a341fadcca27e3c)
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5961073Z fatal: path 'js/package.json' exists, but not 'package.json'
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5961997Z This may indicate a previous attempt partially succeeded.
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5962679Z hint: Did you mean 'origin/main:js/package.json' aka 'origin/main:./package.json'?
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.5967823Z Error: Unexpected end of JSON input
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.6037508Z ##[error]Process completed with exit code 1.
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.6174146Z Post job cleanup.
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7120094Z [command]/usr/bin/git version
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7157200Z git version 2.53.0
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7201604Z Temporarily overriding HOME='/home/runner/work/_temp/2b6e1d2b-461d-4c18-a5bf-88b992ed07ab' before making global git config changes
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7202665Z Adding repository directory to the temporary git global config as a safe directory
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7215092Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/web-capture/web-capture
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7251853Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7284186Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7512947Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7534411Z http.https://github.com/.extraheader
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7546295Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7576522Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7792421Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.7822449Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.8157214Z Cleaning up orphan processes
+JS - Release	UNKNOWN STEP	2026-04-10T20:51:38.8436367Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+JS - Lint and Format Check	UNKNOWN STEP	﻿2026-04-10T20:24:33.4454340Z Current runner version: '2.333.1'
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4480842Z ##[group]Runner Image Provisioner
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4481935Z Hosted Compute Agent
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4482501Z Version: 20260213.493
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4483086Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4483803Z Build Date: 2026-02-13T00:28:41Z
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4484457Z Worker ID: {92ef33f4-81a7-46ba-a431-a0cfedac6003}
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4485316Z Azure Region: northcentralus
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4485953Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4487794Z ##[group]Operating System
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4488384Z Ubuntu
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4488950Z 24.04.4
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4489372Z LTS
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4489825Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4490316Z ##[group]Runner Image
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4490913Z Image: ubuntu-24.04
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4491406Z Version: 20260406.80.1
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4492628Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4494052Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4494976Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4496238Z ##[group]GITHUB_TOKEN Permissions
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4498421Z Contents: read
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4498971Z Metadata: read
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4499474Z Packages: read
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4500195Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4502513Z Secret source: Actions
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4503426Z Prepare workflow directory
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4918551Z Prepare all required actions
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.4958545Z Getting action download info
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:33.8748241Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.0062308Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.1972466Z Complete job name: JS - Lint and Format Check
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2710184Z ##[group]Run actions/checkout@v4
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2711118Z with:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2711574Z   repository: link-assistant/web-capture
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2712329Z   token: ***
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2712745Z   ssh-strict: true
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2713152Z   ssh-user: git
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2713583Z   persist-credentials: true
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2714059Z   clean: true
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2714485Z   sparse-checkout-cone-mode: true
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2714985Z   fetch-depth: 1
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2715697Z   fetch-tags: false
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2716141Z   show-progress: true
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2716584Z   lfs: false
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2716973Z   submodules: false
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2717404Z   set-safe-directory: true
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.2718163Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3855745Z Syncing repository: link-assistant/web-capture
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3857706Z ##[group]Getting Git version info
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3858601Z Working directory is '/home/runner/work/web-capture/web-capture'
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3859666Z [command]/usr/bin/git version
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3894330Z git version 2.53.0
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3921737Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3938657Z Temporarily overriding HOME='/home/runner/work/_temp/51fb67c0-a2d9-4828-bc79-47341833e73c' before making global git config changes
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3941332Z Adding repository directory to the temporary git global config as a safe directory
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3953256Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/web-capture/web-capture
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3987613Z Deleting the contents of '/home/runner/work/web-capture/web-capture'
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3991842Z ##[group]Initializing the repository
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.3997376Z [command]/usr/bin/git init /home/runner/work/web-capture/web-capture
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4090020Z hint: Using 'master' as the name for the initial branch. This default branch name
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4091945Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4093250Z hint: to use in all of your new repositories, which will suppress this warning,
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4094291Z hint: call:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4094858Z hint:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4097035Z hint: 	git config --global init.defaultBranch <name>
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4097712Z hint:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4098291Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4099209Z hint: 'development'. The just-created branch can be renamed via this command:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4099928Z hint:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4100323Z hint: 	git branch -m <name>
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4100794Z hint:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4101404Z hint: Disable this message with "git config set advice.defaultBranchName false"
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4102931Z Initialized empty Git repository in /home/runner/work/web-capture/web-capture/.git/
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4104685Z [command]/usr/bin/git remote add origin https://github.com/link-assistant/web-capture
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4136585Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4141930Z ##[group]Disabling automatic garbage collection
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4143269Z [command]/usr/bin/git config --local gc.auto 0
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4173205Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4174632Z ##[group]Setting up auth
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4181228Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4214508Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4512335Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4546745Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4794572Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.4837048Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.5094052Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.5129993Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.5138655Z ##[group]Fetching the repository
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.5140114Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f6c733bd2b56cd935592b1be33a93fae83584328:refs/remotes/origin/main
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.8911018Z From https://github.com/link-assistant/web-capture
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.8913735Z  * [new ref]         f6c733bd2b56cd935592b1be33a93fae83584328 -> origin/main
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.8940393Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.8941552Z ##[group]Determining the checkout info
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.8943312Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.8947970Z [command]/usr/bin/git sparse-checkout disable
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.8984466Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9010981Z ##[group]Checking out the ref
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9014303Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9153771Z Switched to a new branch 'main'
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9156219Z branch 'main' set up to track 'origin/main'.
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9163809Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9198625Z [command]/usr/bin/git log -1 --format=%H
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9220618Z f6c733bd2b56cd935592b1be33a93fae83584328
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9550055Z ##[group]Run actions/setup-node@v4
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9551172Z with:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9551960Z   node-version: 20.x
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9552868Z   always-auth: false
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9553781Z   check-latest: false
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9554995Z   token: ***
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:34.9556035Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.1418401Z Found in cache @ /opt/hostedtoolcache/node/20.20.2/x64
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.1424456Z ##[group]Environment details
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.4948725Z node: v20.20.2
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.4950031Z npm: 10.8.2
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.4951138Z yarn: 1.22.22
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.4953005Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.5092628Z ##[group]Run npm install
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.5093630Z [36;1mnpm install[0m
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.5130152Z shell: /usr/bin/bash -e {0}
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:35.5131137Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:36.4364096Z npm warn EBADENGINE Unsupported engine {
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:36.4368015Z npm warn EBADENGINE   package: '@link-assistant/web-capture@1.3.0',
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:36.4371567Z npm warn EBADENGINE   required: { node: '>=22.0.0 <23.0.0' },
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:36.4375074Z npm warn EBADENGINE   current: { node: 'v20.20.2', npm: '10.8.2' }
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:36.4378190Z npm warn EBADENGINE }
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:38.5786876Z npm warn deprecated supertest@6.3.4: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:39.7529952Z npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:39.9408401Z npm warn deprecated superagent@8.1.2: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:40.0131053Z npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:41.2802323Z npm warn deprecated puppeteer@24.8.2: < 24.15.0 is no longer supported
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:42.5298685Z npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.3653830Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.3654977Z > @link-assistant/web-capture@1.3.0 prepare
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.3660582Z > husky || true
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.3661027Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4198715Z .git can't be found
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4200798Z added 857 packages, and audited 858 packages in 15s
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4201266Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4201551Z 136 packages are looking for funding
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4202035Z   run `npm fund` for details
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4433279Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4434149Z 14 vulnerabilities (1 low, 5 moderate, 6 high, 2 critical)
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4434613Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4434753Z To address all issues, run:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4435030Z   npm audit fix
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4435467Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4435605Z Run `npm audit` for details.
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4744635Z ##[group]Run npm run lint
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4744932Z [36;1mnpm run lint[0m
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4766859Z shell: /usr/bin/bash -e {0}
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.4767135Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.5967131Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.5967761Z > @link-assistant/web-capture@1.3.0 lint
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.5968269Z > eslint .
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:50.5968451Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5505116Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5506360Z /home/runner/work/web-capture/web-capture/js/bin/web-capture.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5536602Z ##[warning]   13:10  warning  Method 'yargs' has too many lines (177). Maximum allowed is 150                   max-lines-per-function
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5546451Z ##[warning]  244:1   warning  Async function 'captureUrl' has too many lines (352). Maximum allowed is 150      max-lines-per-function
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5548300Z ##[warning]  244:1   warning  Async function 'captureUrl' has too many statements (187). Maximum allowed is 60  max-statements
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5550069Z ##[warning]  244:1   warning  Async function 'captureUrl' has a complexity of 59. Maximum allowed is 15         complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5551613Z ##[warning]  511:13  warning  Blocks are nested too deeply (6). Maximum allowed is 5                            max-depth
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5552828Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5553110Z /home/runner/work/web-capture/web-capture/js/src/animation.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5554227Z ##[warning]  93:8  warning  Async function 'captureAnimationFrames' has a complexity of 19. Maximum allowed is 15  complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5555442Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5555781Z /home/runner/work/web-capture/web-capture/js/src/archive.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5556814Z ##[warning]  29:8  warning  Async function 'archiveHandler' has a complexity of 24. Maximum allowed is 15  complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5557715Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5557961Z /home/runner/work/web-capture/web-capture/js/src/docx.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5558926Z ##[warning]  26:8   warning  Async function 'docxHandler' has a complexity of 35. Maximum allowed is 15  complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5560413Z ##[warning]  77:13  warning  Blocks are nested too deeply (6). Maximum allowed is 5                      max-depth
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5561344Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5561584Z /home/runner/work/web-capture/web-capture/js/src/image.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5562521Z ##[warning]  18:8  warning  Async function 'imageHandler' has a complexity of 17. Maximum allowed is 15  complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5563370Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5563596Z /home/runner/work/web-capture/web-capture/js/src/lib.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5564678Z ##[warning]  316:8  warning  Function 'convertHtmlToMarkdownEnhanced' has too many lines (169). Maximum allowed is 150  max-lines-per-function
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5566150Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5566426Z /home/runner/work/web-capture/web-capture/js/src/metadata.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5567443Z ##[warning]   24:8  warning  Function 'extractMetadata' has too many statements (64). Maximum allowed is 60  max-statements
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5568991Z ##[warning]   24:8  warning  Function 'extractMetadata' has a complexity of 25. Maximum allowed is 15        complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5570540Z ##[warning]  172:8  warning  Function 'formatMetadataBlock' has a complexity of 20. Maximum allowed is 15    complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5572134Z ##[warning]  264:8  warning  Function 'formatFooterBlock' has a complexity of 19. Maximum allowed is 15      complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5572978Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5573240Z /home/runner/work/web-capture/web-capture/js/src/postprocess.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5574084Z ##[warning]  104:17  warning  Arrow function has a complexity of 18. Maximum allowed is 15  complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5574867Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5575277Z /home/runner/work/web-capture/web-capture/js/src/verify.js
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5576364Z ##[warning]  91:8  warning  Function 'verifyMarkdownContent' has too many lines (190). Maximum allowed is 150     max-lines-per-function
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5578307Z ##[warning]  91:8  warning  Function 'verifyMarkdownContent' has too many statements (86). Maximum allowed is 60  max-statements
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5580000Z ##[warning]  91:8  warning  Function 'verifyMarkdownContent' has a complexity of 51. Maximum allowed is 15        complexity
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5580883Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5581297Z ✖ 19 problems (0 errors, 19 warnings)
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5581494Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5925446Z ##[group]Run npm run format:check
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5925802Z [36;1mnpm run format:check[0m
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5947622Z shell: /usr/bin/bash -e {0}
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.5947868Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.7076418Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.7077147Z > @link-assistant/web-capture@1.3.0 format:check
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.7077842Z > prettier --check .
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.7078104Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:52.7932844Z Checking formatting...
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:53.9103072Z All matched files use Prettier code style!
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:53.9440148Z ##[group]Run npm run check:duplication
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:53.9440500Z [36;1mnpm run check:duplication[0m
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:53.9461690Z shell: /usr/bin/bash -e {0}
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:53.9461945Z ##[endgroup]
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.0600130Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.0601535Z > @link-assistant/web-capture@1.3.0 check:duplication
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.0602182Z > jscpd .
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.0602385Z 
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.4579865Z Detection time:: 0.182ms
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.4797688Z Post job cleanup.
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.6473602Z Post job cleanup.
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7445112Z [command]/usr/bin/git version
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7483267Z git version 2.53.0
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7528478Z Temporarily overriding HOME='/home/runner/work/_temp/548bb4b2-bc1e-4adc-8cd5-57170e0a8b38' before making global git config changes
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7542307Z Adding repository directory to the temporary git global config as a safe directory
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7543723Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/web-capture/web-capture
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7579393Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7613518Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7840805Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7864310Z http.https://github.com/.extraheader
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7877782Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.7907989Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.8127677Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.8161044Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.8502201Z Cleaning up orphan processes
+JS - Lint and Format Check	UNKNOWN STEP	2026-04-10T20:24:54.8790511Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	﻿2026-04-10T20:24:33.4976816Z Current runner version: '2.333.1'
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5000678Z ##[group]Runner Image Provisioner
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5001747Z Hosted Compute Agent
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5002455Z Version: 20260213.493
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5003421Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5004604Z Build Date: 2026-02-13T00:28:41Z
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5005449Z Worker ID: {70e9f926-d2ea-459b-8628-61f940522315}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5006284Z Azure Region: northcentralus
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5007247Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5008656Z ##[group]Operating System
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5009244Z Ubuntu
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5009795Z 24.04.4
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5010275Z LTS
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5010703Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5011635Z ##[group]Runner Image
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5012186Z Image: ubuntu-24.04
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5012665Z Version: 20260406.80.1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5013921Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5015565Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5016601Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5017649Z ##[group]GITHUB_TOKEN Permissions
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5019746Z Contents: read
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5020325Z Metadata: read
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5020796Z Packages: read
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5021376Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5023515Z Secret source: Actions
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5024602Z Prepare workflow directory
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5420848Z Prepare all required actions
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.5460394Z Getting action download info
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:33.9096014Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.0596428Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.2518110Z Complete job name: JS - Test (Node.js on ubuntu-latest)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3227034Z ##[group]Run actions/checkout@v4
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3227896Z with:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3228331Z   repository: link-assistant/web-capture
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3229063Z   token: ***
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3229464Z   ssh-strict: true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3229884Z   ssh-user: git
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3230301Z   persist-credentials: true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3230796Z   clean: true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3231224Z   sparse-checkout-cone-mode: true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3231741Z   fetch-depth: 1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3232163Z   fetch-tags: false
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3232586Z   show-progress: true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3233030Z   lfs: false
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3233420Z   submodules: false
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3233848Z   set-safe-directory: true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.3234718Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4338729Z Syncing repository: link-assistant/web-capture
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4340981Z ##[group]Getting Git version info
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4341889Z Working directory is '/home/runner/work/web-capture/web-capture'
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4343112Z [command]/usr/bin/git version
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4375398Z git version 2.53.0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4400294Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4413181Z Temporarily overriding HOME='/home/runner/work/_temp/18c801f4-61b1-4c73-ac46-f7c123a15820' before making global git config changes
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4426007Z Adding repository directory to the temporary git global config as a safe directory
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4428094Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/web-capture/web-capture
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4460115Z Deleting the contents of '/home/runner/work/web-capture/web-capture'
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4463963Z ##[group]Initializing the repository
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4469217Z [command]/usr/bin/git init /home/runner/work/web-capture/web-capture
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4531258Z hint: Using 'master' as the name for the initial branch. This default branch name
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4533044Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4534960Z hint: to use in all of your new repositories, which will suppress this warning,
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4536699Z hint: call:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4537577Z hint:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4538424Z hint: 	git config --global init.defaultBranch <name>
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4539436Z hint:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4540404Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4541998Z hint: 'development'. The just-created branch can be renamed via this command:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4543287Z hint:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4544009Z hint: 	git branch -m <name>
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4545041Z hint:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4546109Z hint: Disable this message with "git config set advice.defaultBranchName false"
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4547894Z Initialized empty Git repository in /home/runner/work/web-capture/web-capture/.git/
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4550867Z [command]/usr/bin/git remote add origin https://github.com/link-assistant/web-capture
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4575776Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4577032Z ##[group]Disabling automatic garbage collection
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4580582Z [command]/usr/bin/git config --local gc.auto 0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4610044Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4611268Z ##[group]Setting up auth
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4617266Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4650049Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4953594Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.4985313Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.5229180Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.5271912Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.5520160Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.5556728Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.5557954Z ##[group]Fetching the repository
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.5568886Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f6c733bd2b56cd935592b1be33a93fae83584328:refs/remotes/origin/main
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9394104Z From https://github.com/link-assistant/web-capture
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9396299Z  * [new ref]         f6c733bd2b56cd935592b1be33a93fae83584328 -> origin/main
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9422485Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9425832Z ##[group]Determining the checkout info
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9426964Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9430206Z [command]/usr/bin/git sparse-checkout disable
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9467449Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9493571Z ##[group]Checking out the ref
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9496835Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9636065Z Switched to a new branch 'main'
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9638425Z branch 'main' set up to track 'origin/main'.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9645976Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9678753Z [command]/usr/bin/git log -1 --format=%H
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:34.9702370Z f6c733bd2b56cd935592b1be33a93fae83584328
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.0013206Z ##[group]Run actions/setup-node@v4
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.0014447Z with:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.0015251Z   node-version: 22.x
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.0016154Z   always-auth: false
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.0017067Z   check-latest: false
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.0018233Z   token: ***
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.0019040Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.1759425Z Found in cache @ /opt/hostedtoolcache/node/22.22.2/x64
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.1765160Z ##[group]Environment details
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.4855198Z node: v22.22.2
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.4856376Z npm: 10.9.7
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.4857384Z yarn: 1.22.22
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.4859722Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.5005276Z ##[group]Run npm install
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.5006275Z [36;1mnpm install[0m
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.5041888Z shell: /usr/bin/bash -e {0}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:35.5042839Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:37.5589512Z npm warn deprecated supertest@6.3.4: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:38.3783435Z npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:38.4900070Z npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:39.3120959Z npm warn deprecated superagent@8.1.2: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:40.5900047Z npm warn deprecated puppeteer@24.8.2: < 24.15.0 is no longer supported
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:41.1207738Z npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.6990095Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.6990908Z > @link-assistant/web-capture@1.3.0 prepare
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.6991470Z > husky || true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.6991669Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7461211Z .git can't be found
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7461841Z added 857 packages, and audited 858 packages in 13s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7462134Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7462592Z 136 packages are looking for funding
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7463109Z   run `npm fund` for details
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7586107Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7586886Z 14 vulnerabilities (1 low, 5 moderate, 6 high, 2 critical)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7587351Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7587576Z To address all issues, run:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7588091Z   npm audit fix
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7588294Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.7588492Z Run `npm audit` for details.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.8275970Z ##[group]Run npx playwright install --with-deps chromium
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.8276413Z [36;1mnpx playwright install --with-deps chromium[0m
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.8298748Z shell: /usr/bin/bash -e {0}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:48.8298996Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.6247545Z Installing dependencies...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.6311427Z Switching to root user to install dependencies...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.7296114Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.7490250Z Get:6 https://packages.microsoft.com/repos/azure-cli noble InRelease [3564 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.7677159Z Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.7691345Z Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.7715322Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.7770296Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.7785680Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.8599287Z Get:8 https://packages.microsoft.com/repos/azure-cli noble/main amd64 Packages [2135 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.9641644Z Get:9 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [114 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:49.9671161Z Get:10 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [90.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0155665Z Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1881 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0277506Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [343 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0315635Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [177 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0340016Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 c-n-f Metadata [16.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0348965Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1665 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0437862Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [323 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0467007Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [386 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0498310Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 c-n-f Metadata [34.3 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0514486Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [2911 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.0659058Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted Translation-en [674 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1114956Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Components [212 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1128181Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1140435Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [7364 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1153758Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [13.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1169912Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble-backports/restricted amd64 Components [216 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1179521Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Components [212 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1306651Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [1579 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1375019Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-security/main Translation-en [253 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1400037Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [21.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1413071Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 c-n-f Metadata [10.7 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1426163Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1170 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1490489Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble-security/universe Translation-en [225 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1516509Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [74.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1531994Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 c-n-f Metadata [22.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.1996121Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [2763 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.2166387Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [644 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.2198838Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Components [212 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:50.2212444Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse amd64 Components [212 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:59.0764827Z Fetched 15.8 MB in 2s (7998 kB/s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:59.8209038Z Reading package lists...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:24:59.8460171Z Reading package lists...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.0126555Z Building dependency tree...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.0133654Z Reading state information...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1729293Z libasound2t64 is already the newest version (1.2.11-1ubuntu0.2).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1730361Z libasound2t64 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1731183Z libatk-bridge2.0-0t64 is already the newest version (2.52.0-1build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1731961Z libatk-bridge2.0-0t64 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1732666Z libatk1.0-0t64 is already the newest version (2.52.0-1build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1733697Z libatk1.0-0t64 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1734494Z libatspi2.0-0t64 is already the newest version (2.52.0-1build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1735062Z libatspi2.0-0t64 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1735704Z libcairo2 is already the newest version (1.18.0-3build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1736264Z libcairo2 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1736989Z libcups2t64 is already the newest version (2.4.7-1.2ubuntu7.9).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1737698Z libcups2t64 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1738320Z libdbus-1-3 is already the newest version (1.14.10-4ubuntu4.1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1738923Z libdbus-1-3 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1739568Z libdrm2 is already the newest version (2.4.125-1ubuntu0.1~24.04.1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1740166Z libdrm2 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1740555Z libgbm1 is already the newest version (25.2.8-0ubuntu0.24.04.1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1740909Z libgbm1 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1741299Z libglib2.0-0t64 is already the newest version (2.80.0-6ubuntu3.8).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1741687Z libglib2.0-0t64 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1742081Z libnspr4 is already the newest version (2:4.35-1.1build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1742439Z libnspr4 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1742801Z libnss3 is already the newest version (2:3.98-1ubuntu0.1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1743153Z libnss3 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1743547Z libpango-1.0-0 is already the newest version (1.52.1+ds-1build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1743925Z libpango-1.0-0 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1744491Z libx11-6 is already the newest version (2:1.8.7-1build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1744853Z libx11-6 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1745194Z libxcb1 is already the newest version (1.15-1ubuntu2).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1745532Z libxcb1 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1745914Z libxcomposite1 is already the newest version (1:0.4.5-1build3).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1746303Z libxcomposite1 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1746695Z libxdamage1 is already the newest version (1:1.1.6-1build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1747055Z libxdamage1 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1747423Z libxext6 is already the newest version (2:1.3.4-1build2).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1747764Z libxext6 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1748350Z libxfixes3 is already the newest version (1:6.0.0-2build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1748716Z libxfixes3 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1749093Z libxkbcommon0 is already the newest version (1.6.0-1build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1749451Z libxkbcommon0 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1749823Z libxrandr2 is already the newest version (2:1.5.2-2build1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1750162Z libxrandr2 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1750543Z xvfb is already the newest version (2:21.1.12-1ubuntu1.5).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1751047Z fonts-noto-color-emoji is already the newest version (2.047-0ubuntu0.24.04.1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1751573Z libfontconfig1 is already the newest version (2.15.0-1.1ubuntu2).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1751961Z libfontconfig1 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1752375Z libfreetype6 is already the newest version (2.13.2+dfsg-1ubuntu0.1).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1752761Z libfreetype6 set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1753148Z fonts-liberation is already the newest version (1:2.1.5-3).
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1753534Z fonts-liberation set to manually installed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1753901Z The following additional packages will be installed:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1754238Z   xfonts-encodings xfonts-utils
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1754686Z Recommended packages:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1754964Z   fonts-ipafont-mincho fonts-tlwg-loma
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1981176Z The following NEW packages will be installed:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1981945Z   fonts-freefont-ttf fonts-ipafont-gothic fonts-tlwg-loma-otf fonts-unifont
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1986732Z   fonts-wqy-zenhei xfonts-cyrillic xfonts-encodings xfonts-scalable
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.1987394Z   xfonts-utils
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.2165203Z 0 upgraded, 9 newly installed, 0 to remove and 26 not upgraded.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.2165850Z Need to get 21.1 MB of archives.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.2166517Z After this operation, 79.5 MB of additional disk space will be used.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.2167294Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.2595884Z Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-ipafont-gothic all 00303-21ubuntu1 [3513 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.3200815Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 fonts-freefont-ttf all 20211204+svn4273-2 [5641 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.3962279Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-tlwg-loma-otf all 1:0.7.3-1 [107 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.4241552Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-unifont all 1:15.1.01-1build1 [2993 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.4776907Z Get:6 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-wqy-zenhei all 0.9.45-8 [7472 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.6936477Z Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-encodings all 1:1.0.5-0ubuntu2 [578 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.7258175Z Get:8 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-utils amd64 1:7.7+6build3 [94.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.7482128Z Get:9 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 xfonts-cyrillic all 1:1.0.5+nmu1 [384 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:00.7729508Z Get:10 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-scalable all 1:1.0.3-1.3 [304 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0296924Z Fetched 21.1 MB in 1s (36.9 MB/s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0516408Z Selecting previously unselected package fonts-ipafont-gothic.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0741121Z (Reading database ... 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0741544Z (Reading database ... 5%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0741948Z (Reading database ... 10%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0742314Z (Reading database ... 15%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0742719Z (Reading database ... 20%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0742967Z (Reading database ... 25%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0743322Z (Reading database ... 30%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0743542Z (Reading database ... 35%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0743776Z (Reading database ... 40%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0744006Z (Reading database ... 45%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0744225Z (Reading database ... 50%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.0803441Z (Reading database ... 55%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.2138772Z (Reading database ... 60%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.4133319Z (Reading database ... 65%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.6181770Z (Reading database ... 70%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:01.7661208Z (Reading database ... 75%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.1068112Z (Reading database ... 80%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.3146307Z (Reading database ... 85%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.5286087Z (Reading database ... 90%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.7238901Z (Reading database ... 95%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.7239233Z (Reading database ... 100%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.7239674Z (Reading database ... 220613 files and directories currently installed.)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.7286782Z Preparing to unpack .../0-fonts-ipafont-gothic_00303-21ubuntu1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.7384007Z Unpacking fonts-ipafont-gothic (00303-21ubuntu1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.9707330Z Selecting previously unselected package fonts-freefont-ttf.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.9852548Z Preparing to unpack .../1-fonts-freefont-ttf_20211204+svn4273-2_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:02.9859649Z Unpacking fonts-freefont-ttf (20211204+svn4273-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.0705677Z Selecting previously unselected package fonts-tlwg-loma-otf.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.0850457Z Preparing to unpack .../2-fonts-tlwg-loma-otf_1%3a0.7.3-1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.0856678Z Unpacking fonts-tlwg-loma-otf (1:0.7.3-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.1088605Z Selecting previously unselected package fonts-unifont.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.1226854Z Preparing to unpack .../3-fonts-unifont_1%3a15.1.01-1build1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.1234001Z Unpacking fonts-unifont (1:15.1.01-1build1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.2331676Z Selecting previously unselected package fonts-wqy-zenhei.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.2475451Z Preparing to unpack .../4-fonts-wqy-zenhei_0.9.45-8_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.2626412Z Unpacking fonts-wqy-zenhei (0.9.45-8) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.7264853Z Selecting previously unselected package xfonts-encodings.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.7408333Z Preparing to unpack .../5-xfonts-encodings_1%3a1.0.5-0ubuntu2_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.7414170Z Unpacking xfonts-encodings (1:1.0.5-0ubuntu2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.7693804Z Selecting previously unselected package xfonts-utils.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.7832930Z Preparing to unpack .../6-xfonts-utils_1%3a7.7+6build3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.7838629Z Unpacking xfonts-utils (1:7.7+6build3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.8874817Z Selecting previously unselected package xfonts-cyrillic.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.9014803Z Preparing to unpack .../7-xfonts-cyrillic_1%3a1.0.5+nmu1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.9021725Z Unpacking xfonts-cyrillic (1:1.0.5+nmu1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.9343954Z Selecting previously unselected package xfonts-scalable.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.9481340Z Preparing to unpack .../8-xfonts-scalable_1%3a1.0.3-1.3_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.9488604Z Unpacking xfonts-scalable (1:1.0.3-1.3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:03.9913033Z Setting up fonts-wqy-zenhei (0.9.45-8) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0028292Z Setting up fonts-freefont-ttf (20211204+svn4273-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0044095Z Setting up fonts-tlwg-loma-otf (1:0.7.3-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0060366Z Setting up xfonts-encodings (1:1.0.5-0ubuntu2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0076115Z Setting up fonts-ipafont-gothic (00303-21ubuntu1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0141605Z update-alternatives: using /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf to provide /usr/share/fonts/truetype/fonts-japanese-gothic.ttf (fonts-japanese-gothic.ttf) in auto mode
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0157435Z Setting up fonts-unifont (1:15.1.01-1build1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0173161Z Setting up xfonts-utils (1:7.7+6build3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0210690Z Setting up xfonts-cyrillic (1:1.0.5+nmu1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0567793Z Setting up xfonts-scalable (1:1.0.3-1.3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0917075Z Processing triggers for man-db (2.12.0-4build2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0934681Z Not building database; man-db/auto-update is not 'true'.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.0948352Z Processing triggers for fontconfig (2.15.0-1.1ubuntu2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7624943Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7626584Z Running kernel seems to be up-to-date.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7627348Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7627596Z No services need to be restarted.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7627863Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7628087Z No containers need to be restarted.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7628353Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7628618Z No user sessions are running outdated binaries.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7628831Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:04.7629105Z No VM guests are running outdated hypervisor (qemu) binaries on this host.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:05.6271878Z Downloading Chromium 141.0.7390.37 (playwright build v1194) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1194/chromium-linux.zip
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:05.7605880Z |                                                                                |   0% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:05.8766623Z |■■■■■■■■                                                                        |  10% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:05.9586443Z |■■■■■■■■■■■■■■■■                                                                |  20% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:06.0384997Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:06.1067604Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:06.1862113Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:06.2414061Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:06.2937738Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:06.3485893Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:06.4050795Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:06.4579186Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 173.9 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.7052684Z Chromium 141.0.7390.37 (playwright build v1194) downloaded to /home/runner/.cache/ms-playwright/chromium-1194
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.7056200Z Downloading FFMPEG playwright build v1011 from https://cdn.playwright.dev/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux.zip
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8275869Z |                                                                                |   0% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8324926Z |■■■■■■■■                                                                        |  10% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8349039Z |■■■■■■■■■■■■■■■■                                                                |  20% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8367870Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8382990Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8408218Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8424090Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8436358Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8454589Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8478248Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8487999Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 2.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8992729Z FFMPEG playwright build v1011 downloaded to /home/runner/.cache/ms-playwright/ffmpeg-1011
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:09.8997044Z Downloading Chromium Headless Shell 141.0.7390.37 (playwright build v1194) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1194/chromium-headless-shell-linux.zip
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.0260989Z |                                                                                |   0% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.1002989Z |■■■■■■■■                                                                        |  10% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.1500454Z |■■■■■■■■■■■■■■■■                                                                |  20% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.1980007Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.2415518Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.2838513Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.3191038Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.3526091Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.3858827Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.4199471Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:10.4535880Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 104.3 MiB
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:12.1769598Z Chromium Headless Shell 141.0.7390.37 (playwright build v1194) downloaded to /home/runner/.cache/ms-playwright/chromium_headless_shell-1194
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:12.6186134Z ##[group]Run npx puppeteer browsers install chrome
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:12.6186509Z [36;1mnpx puppeteer browsers install chrome[0m
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:12.6209068Z shell: /usr/bin/bash -e {0}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:12.6209318Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.0470948Z chrome@136.0.7103.92 /home/runner/.cache/puppeteer/chrome/linux-136.0.7103.92/chrome-linux64/chrome
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.0735264Z ##[group]Run npm test -- --testPathIgnorePatterns="docker.test.js"
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.0735766Z [36;1mnpm test -- --testPathIgnorePatterns="docker.test.js"[0m
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.0757931Z shell: /usr/bin/bash -e {0}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.0758182Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.1789352Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.1789936Z > @link-assistant/web-capture@1.3.0 test
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.1790675Z > node --experimental-vm-modules ./node_modules/.bin/jest --testPathIgnorePatterns=docker.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:13.1791077Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:14.2907752Z (node:3245) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:14.2926380Z (Use `node --trace-warnings ...` to show where the warning was created)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:14.3173046Z (node:3244) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:14.3176608Z (Use `node --trace-warnings ...` to show where the warning was created)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:14.3228149Z (node:3246) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:14.3234886Z (Use `node --trace-warnings ...` to show where the warning was created)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2624040Z (node:3244) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2765462Z PASS tests/unit/html2md.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2888395Z   convertHtmlToMarkdown
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2922658Z     ✓ removes empty links and anchor headings (30 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2923565Z     ✓ removes empty links in complex content (6 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2925218Z     ✓ removes empty links with only whitespace (3 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2926341Z     ✓ removes empty links with only child elements (4 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2927154Z     ✓ removes headings with only whitespace (6 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2928000Z     ✓ converts relative links to absolute if baseUrl is provided (5 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2929029Z     ✓ does not change links if no baseUrl is provided (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2929889Z     ✓ converts ARIA role table to Markdown table (15 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2930739Z     ✓ converts a regular HTML table to Markdown table (11 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2931524Z     ✓ handles empty tables gracefully (7 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2932251Z     ✓ handles specific ARIA table example (33 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.2932713Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.5136112Z (node:3245) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.6574496Z (node:3246) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8865932Z PASS tests/integration/api-endpoints.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8877688Z   API Endpoint Tests
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8878243Z     GET /image
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8879084Z       ✓ rejects invalid format (31 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8879626Z       ✓ returns 400 without url (4 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8880045Z     GET /markdown
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8880468Z       ✓ returns markdown (49 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8880813Z     GET /archive
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8881442Z       ✓ returns a ZIP archive with remote images (markdown format) (33 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8882225Z       ✓ returns a ZIP archive with HTML format (13 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8882999Z       ✓ returns a ZIP archive with local images and folders (13 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8883799Z       ✓ returns a ZIP archive with HTML format and local CSS (21 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8884682Z       ✓ returns 400 without url (3 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8885110Z     GET /docx
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8885541Z       ✓ returns a DOCX document (76 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8886060Z       ✓ returns 400 without url (3 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8886457Z     GET /pdf
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8887134Z       ✓ returns 400 without url (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:15.8889608Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0339941Z PASS tests/unit/gdocs.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0340411Z   gdocs
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0341081Z     isGoogleDocsUrl
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0341977Z       ✓ returns true for standard Google Docs edit URL (5 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0342686Z       ✓ returns true for URL with query parameters
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0348426Z       ✓ returns true for URL without /edit (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0349418Z       ✓ returns false for non-Google Docs URL
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0350412Z       ✓ returns false for Google Sheets URL (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0351253Z       ✓ returns false for empty string
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0351945Z       ✓ returns false for null (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0352856Z       ✓ returns false for undefined
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0363581Z       ✓ returns false for non-string input (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0364542Z     extractDocumentId
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0365317Z       ✓ extracts document ID from standard URL
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0366263Z       ✓ extracts document ID from URL with query params (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0367244Z       ✓ extracts document ID with hyphens and underscores
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0368104Z       ✓ returns null for non-Google Docs URL
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0368902Z       ✓ returns null for empty string (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0369647Z       ✓ returns null for null input
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0370279Z     buildExportUrl
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0370922Z       ✓ builds HTML export URL
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0371651Z       ✓ builds Markdown export URL
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0372386Z       ✓ builds PDF export URL (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0373102Z       ✓ builds TXT export URL
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0373835Z       ✓ defaults to html for unknown format
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0374973Z       ✓ defaults to html when format is omitted
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0376258Z       ✓ uses the real document ID from test document (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0377000Z     GDOCS_EXPORT_FORMATS
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0377747Z       ✓ contains all expected formats (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0378433Z     extractBase64Images
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0379215Z       ✓ extracts a single PNG data URI image (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0380311Z       ✓ extracts multiple images with correct numbering and extensions (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0381370Z       ✓ returns empty array when no data URI images
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0382219Z       ✓ preserves non-data-URI images (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.0382739Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2135705Z PASS tests/unit/verify.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2162333Z   verify module
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2225333Z     normalizeText
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2295251Z       ✓ lowercases text (5 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2325165Z       ✓ normalizes unicode spaces (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2355170Z       ✓ normalizes curly quotes
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2415234Z       ✓ removes LaTeX delimiters
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2445005Z       ✓ normalizes arrows (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2445528Z       ✓ removes \displaystyle
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2446032Z       ✓ extracts text from \text{}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2446445Z     normalizeCode
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2446966Z       ✓ lowercases and collapses whitespace (3 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2447654Z       ✓ normalizes multiplication sign (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2448118Z     verifyMarkdownContent
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2448602Z       ✓ verifies title presence (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2449069Z       ✓ detects missing title
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2449546Z       ✓ verifies headings (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2450019Z       ✓ detects missing headings
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2450618Z       ✓ verifies code blocks with fuzzy matching (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2451174Z       ✓ calculates pass rate
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2451803Z       ✓ checks figure images when hasLocalImages is set (4 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:16.2452217Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8958168Z PASS tests/unit/cli.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8958668Z   CLI
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8958956Z     --help
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8959723Z       ✓ shows help message with --help flag (180 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8960351Z       ✓ shows help message with -h flag (155 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8961743Z       ✓ shows error and exits with code 1 when no arguments provided (95 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8962318Z     --version
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8962759Z       ✓ shows version with --version flag (75 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8963277Z       ✓ shows version with -v flag (72 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8963641Z     URL validation
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8964033Z       ✓ rejects invalid URL (77 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8964606Z     format options
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8964964Z       ✓ accepts --format html (76 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8965446Z       ✓ accepts --format markdown (88 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8965818Z       ✓ accepts --format image (109 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8966063Z     engine options
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8966365Z       ✓ help shows engine options (164 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8966710Z       ✓ accepts --engine option (105 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8967004Z     server mode options
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8967295Z       ✓ help shows --serve option (80 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8967610Z       ✓ help shows --port option (78 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8967939Z       ✓ help shows API endpoints (75 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8968215Z     output options
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8968492Z       ✓ help shows --output option (76 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:17.8968680Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1272018Z PASS tests/unit/metadata.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1275080Z   metadata module
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1275435Z     extractMetadata
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1276157Z       ✓ extracts author information (13 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1276716Z       ✓ extracts publication date (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1277196Z       ✓ extracts hubs (4 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1277693Z       ✓ extracts tags from meta keywords (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1278254Z       ✓ extracts LD+JSON author name (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1279324Z       ✓ extracts votes and comments (3 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1279891Z       ✓ returns empty object for minimal HTML (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1280362Z     formatMetadataBlock
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1280818Z       ✓ formats author line with link (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1281330Z       ✓ formats author with full name
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1281861Z       ✓ formats publication date (20 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1282355Z       ✓ includes hubs and tags (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1282907Z       ✓ returns empty array for null metadata
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1283322Z     formatFooterBlock
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1283746Z       ✓ includes separator line (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1284182Z       ✓ formats tag links
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1284778Z       ✓ formats article stats
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:18.1285269Z       ✓ returns empty array for null metadata
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3367078Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3367799Z PASS tests/unit/browser.test.js (7.444 s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3368427Z   Browser Abstraction Layer
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3368758Z     getBrowserEngine
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3369306Z       ✓ returns puppeteer by default (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3370091Z       ✓ returns playwright when engine=playwright query param is provided (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3370986Z       ✓ returns playwright when engine=pw query param is provided
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3371788Z       ✓ returns puppeteer when engine=puppeteer query param is provided
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3372641Z       ✓ returns puppeteer when engine=pptr query param is provided (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3373555Z       ✓ returns playwright when browser=playwright query param is provided
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3374181Z       ✓ is case insensitive
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3376366Z       ✓ returns playwright from BROWSER_ENGINE env var (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3376990Z       ✓ prefers query param over env var
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3377430Z     createBrowser - Puppeteer
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3378057Z       ✓ creates a puppeteer browser with type field (1189 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3378709Z       ✓ can create and use a page (948 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3379156Z     createBrowser - Playwright
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3379785Z       ✓ creates a playwright browser with type field (1629 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3380430Z       ✓ can create and use a page (633 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3380888Z     Page Adapter Compatibility
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3381802Z       ✓ both adapters support the same interface (1453 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3382591Z       ✓ both adapters expose browser-commander v0.7.0+ APIs (1459 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:23.3383011Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8678823Z PASS tests/mock/index.test.js (10.58 s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8679402Z   Web Capture Microservice
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8679761Z     GET /html
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8680597Z       ✓ should return HTML content when URL is provided (26 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8681293Z       ✓ should return 400 when URL is missing (4 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8681926Z       ✓ should return 500 when fetch fails (6 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8682312Z     GET /markdown
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8682691Z       ✓ should convert HTML to Markdown when URL is provided (23 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8683171Z       ✓ should remove CSS from the markdown output (13 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8683577Z       ✓ should return 400 when URL is missing (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8683947Z       ✓ should return 500 when fetch fails (6 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8684244Z     GET /image
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8684903Z       ✓ should return PNG image when URL is provided (9670 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8685314Z       ✓ should return 400 when URL is missing (6 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8685582Z     GET /stream
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8685894Z       ✓ should stream content from the given URL (10 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8686278Z       ✓ should return 400 when URL is missing (3 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8686649Z       ✓ should return 500 when fetch fails (31 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8686910Z     GET /fetch
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8687230Z       ✓ should return content when URL is provided (6 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8687959Z       ✓ should return 400 when URL is missing (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8688315Z       ✓ should return 500 when fetch fails (4 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:25.8688514Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0520560Z PASS tests/unit/latex.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0521095Z   latex module
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0521418Z     extractHabrFormula
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0522352Z       ✓ extracts LaTeX from Habr formula img source attribute (6 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0523133Z       ✓ falls back to alt text when source is missing (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0523546Z       ✓ returns null when no source or alt (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0523843Z     extractKatexFormula
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0524157Z       ✓ extracts from annotation element (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0524868Z       ✓ extracts from data-tex attribute (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0525247Z       ✓ returns null when no TeX source found (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0525545Z     extractMathJaxFormula
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0525848Z       ✓ extracts from data-tex attribute
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0526131Z     isFormulaImage
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0526419Z       ✓ identifies img.formula elements (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0526785Z       ✓ identifies img with source attribute (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0527134Z       ✓ rejects regular images (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0527376Z     isMathElement
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0527638Z       ✓ identifies katex elements
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0527948Z       ✓ identifies math elements
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0528233Z       ✓ identifies mjx-container
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0528509Z       ✓ rejects regular elements
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0528727Z     extractFormula
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0528999Z       ✓ extracts from Habr formula image
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0529315Z       ✓ extracts from KaTeX element
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0529646Z       ✓ returns null for regular elements (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.0529850Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1422270Z PASS tests/unit/postprocess.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1422834Z   postprocess module
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1423182Z     applyUnicodeNormalization
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1424097Z       ✓ replaces non-breaking spaces with regular spaces (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1424772Z       ✓ normalizes curly quotes to straight quotes
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1425148Z       ✓ normalizes en-dash to hyphen (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1425459Z       ✓ normalizes ellipsis
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1425705Z     applyLatexSpacingFixes
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1426382Z       ✓ adds space before formula after word character
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1426801Z       ✓ trims whitespace inside formula delimiters (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1427163Z       ✓ does not modify block formulas
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1427523Z       ✓ does not modify blockquote block formulas
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1427909Z       ✓ handles multiple formulas on one line (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1428193Z     applyPercentSignFix
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1428508Z       ✓ fixes percent sign in inline formulas
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1428827Z       ✓ fixes \text{%} notation
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1429068Z     applyBoldFormattingFixes
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1429391Z       ✓ removes empty bold markers (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1429718Z       ✓ trims content inside bold markers
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1430025Z       ✓ adds space between word and bold
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1430285Z     postProcessMarkdown
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1430608Z       ✓ applies all transformations by default (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1430937Z       ✓ respects option flags
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1431252Z       ✓ removes stray standalone $ signs
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.1431432Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2496112Z PASS tests/unit/batch.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2496550Z   batch module
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2496796Z     getArticle
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2497430Z       ✓ returns article config by version (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2497938Z       ✓ merges defaults into article config
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2498476Z       ✓ throws for unknown version (8 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2498876Z     getAllVersions
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2499302Z       ✓ returns all version keys (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2499710Z     getAllArticles
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2500580Z       ✓ returns all articles with defaults merged
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2501004Z     createConfigFromUrls
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2501509Z       ✓ creates config from URL list (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2502024Z       ✓ sets default archive paths
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2502380Z     validateConfig
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2502820Z       ✓ validates correct config (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2503358Z       ✓ rejects config without articles
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2503851Z       ✓ rejects article without url
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2504622Z       ✓ rejects article with invalid url (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:26.2504926Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.0264860Z PASS tests/e2e/process.test.js (9.89 s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.0301883Z   E2E: Web Capture Microservice
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.0316339Z     ✓ should return HTML from /html endpoint (39 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.0339240Z     ✓ should return Markdown from /markdown endpoint (22 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.0340358Z     ✓ should return PNG from /image endpoint (9290 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.0341528Z     ✓ should stream content from /stream endpoint (14 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.0342481Z     ✓ should return content from /fetch endpoint (5 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.0343065Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1502830Z PASS tests/unit/localize-images.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1503354Z   localize-images module
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1503740Z     extractImageReferences
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1504760Z       ✓ extracts markdown image references (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1505365Z       ✓ ignores local image references (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1505887Z       ✓ ignores non-image links
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1506393Z       ✓ returns empty array for no images
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1506817Z     getExtensionFromUrl
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1507140Z       ✓ detects .png extension
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1507431Z       ✓ detects .jpg extension
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1507737Z       ✓ detects .gif extension (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1508065Z       ✓ handles query parameters
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1508411Z       ✓ defaults to .png for unknown extension
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1508715Z     generateLocalFilename
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1509006Z       ✓ generates zero-padded filename
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1509345Z       ✓ preserves file extension from URL
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.1509522Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3354929Z PASS tests/unit/figures.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3355419Z   figures module
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3356042Z     extractFigures
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3357445Z       ✓ extracts figures with captions (10 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3358283Z       ✓ handles Russian figure captions (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3359224Z       ✓ uses sequential numbering when no caption number (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3359807Z       ✓ skips SVG images
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3360260Z       ✓ resolves relative URLs (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3360798Z       ✓ returns empty array for no figures (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.3361127Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.5524863Z PASS tests/unit/convertRelativeUrls.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.5525407Z   convertRelativeUrls
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.5526267Z     ✓ should NOT inject runtimeHook if there are no <script> tags (3 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.5527115Z     ✓ should inject runtimeHook if there is a <script> tag (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.5527881Z     ✓ should inject runtimeHook if there is an inline <script>
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.5528255Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6402540Z PASS tests/unit/animation.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6403078Z   animation module
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6403405Z     compareFrames
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6404092Z       ✓ returns 1.0 for identical frames (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6404706Z       ✓ returns 0 for completely different frames
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6405108Z       ✓ returns 0 for different sized frames (1 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6405460Z       ✓ returns 0 for null frames
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6405773Z       ✓ calculates partial similarity
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6405966Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6856637Z PASS tests/unit/retry.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6857055Z   retry
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6857585Z     ✓ returns result on first success (2 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6858496Z     ✓ retries on failure and succeeds eventually (152 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6858908Z     ✓ throws after exhausting retries (170 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6859299Z     ✓ calls onRetry callback before each retry (52 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6859673Z     ✓ uses exponential backoff delays (704 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6860011Z     ✓ caps delay at maxDelay (1102 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6860357Z     ✓ passes attempt number to fn (153 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:28.6860549Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4047025Z PASS tests/integration/browser-engines.test.js (17.065 s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4047701Z   Browser Engine Integration Tests
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4048072Z     Puppeteer Engine
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4048863Z       ✓ can navigate to a page and get content (3046 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4049416Z       ✓ can take a screenshot (2899 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4049934Z       ✓ can set custom headers and user agent (2860 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4050356Z     Playwright Engine
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4050871Z       ✓ can navigate to a page and get content (1536 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4051453Z       ✓ can take a screenshot (1294 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4052024Z       ✓ can set custom headers and user agent (1235 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4052499Z     Engine Parity
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4053111Z       ✓ both engines produce similar content for the same page (4101 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.4053533Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9211901Z A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9225937Z Test Suites: 1 skipped, 18 passed, 18 of 19 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9226424Z Tests:       16 skipped, 215 passed, 231 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9226725Z Snapshots:   0 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9226952Z Time:        27.374 s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9227182Z Ran all test suites.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9407133Z ##[group]Run npm test -- --testPathPattern="habr-article" --testTimeout=120000
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9407694Z [36;1mnpm test -- --testPathPattern="habr-article" --testTimeout=120000[0m
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9430269Z shell: /usr/bin/bash -e {0}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9430505Z env:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9430693Z   HABR_INTEGRATION: true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:40.9430909Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:41.0410486Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:41.0411057Z > @link-assistant/web-capture@1.3.0 test
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:41.0412209Z > node --experimental-vm-modules ./node_modules/.bin/jest --testPathPattern=habr-article --testTimeout=120000
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:41.0412948Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:41.7146383Z (node:4957) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:41.7147080Z (Use `node --trace-warnings ...` to show where the warning was created)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:25:42.6143826Z (node:4957) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9684636Z PASS tests/integration/habr-article.test.js (123.596 s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9687096Z   Habr Article Download Tests
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9689088Z     Markdown Download (fetch only)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9689938Z       ✓ downloads article 0.0.2 as markdown (1033 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9690606Z       ✓ downloads all 3 articles as markdown (2269 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9691124Z     Screenshots with Puppeteer
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9691669Z       ✓ captures article as PNG screenshot (147 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9692280Z       ✓ captures article as JPEG screenshot (42 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9692859Z       ✓ captures full page screenshot (17033 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9693477Z       ✓ captures with custom viewport width (1920px) (248 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9693818Z     Screenshots with Playwright
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9694171Z       ✓ captures article as PNG screenshot (115 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9694779Z       ✓ captures article as JPEG screenshot (45 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9695132Z     Theme Support (Playwright)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9695492Z       ✓ captures light theme screenshot (25122 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9695876Z       ✓ captures dark theme screenshot (25227 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9696179Z     All Three Articles (Puppeteer)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9696544Z       ✓ captures article 0.0.0 as PNG screenshot (8045 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9696952Z       ✓ captures article 0.0.1 as PNG screenshot (7784 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9697340Z       ✓ captures article 0.0.2 as PNG screenshot (7068 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9697644Z     Popup Dismissal (Playwright)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9697975Z       ✓ dismisses popups before capture (8188 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9698243Z     Archive Endpoint (live)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9698576Z       ✓ creates markdown archive of article (899 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9698942Z       ✓ creates HTML archive of article (482 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9699127Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9716031Z Test Suites: 1 passed, 1 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9716481Z Tests:       16 passed, 16 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9716860Z Snapshots:   0 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9717089Z Time:        123.639 s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:44.9717384Z Ran all test suites matching /habr-article/i.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:45.9739814Z Jest did not exit one second after the test run has completed.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:45.9740286Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:27:45.9741026Z 'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:07.8757110Z ##[group]Run docker compose build
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:07.8757404Z [36;1mdocker compose build[0m
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:07.8780039Z shell: /usr/bin/bash -e {0}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:07.8780284Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.1183540Z #1 [internal] load local bake definitions
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.2603788Z #1 reading from stdin 401B done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.2604260Z #1 DONE 0.0s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.2604604Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.2604910Z #2 [internal] load build definition from Dockerfile
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.2605434Z #2 transferring dockerfile: 1.09kB done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.2605849Z #2 DONE 0.0s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.2606015Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.2606290Z #3 [auth] library/node:pull token for registry-1.docker.io
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.4108577Z #3 DONE 0.0s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.4108770Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.4109076Z #4 [internal] load metadata for docker.io/library/node:22-bullseye
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.6372355Z #4 DONE 0.5s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.7523646Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.7524689Z #5 [internal] load .dockerignore
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.7525273Z #5 transferring context: 2B done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.7525996Z #5 DONE 0.0s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.7526289Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.7527081Z #6 [1/6] FROM docker.io/library/node:22-bullseye@sha256:e5994d860b978a292f788854a3a8ec09e9c53429b96a36b19862155b04117724
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.7528132Z #6 resolve docker.io/library/node:22-bullseye@sha256:e5994d860b978a292f788854a3a8ec09e9c53429b96a36b19862155b04117724 done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.8523533Z #6 sha256:bb8817663f9f8fc978a9bbe6cec7f60bddab809530e4038a8e486f0c7b622865 6.74kB / 6.74kB done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.8525763Z #6 sha256:ced3088fc7691915325d6187786ba346149f7c9dcdbfb3772ca71be74bf87622 13.63MB / 53.76MB 0.2s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.8527083Z #6 sha256:847d9f854f908f28a433fd2d5b08b5e68ee58c9ec953dac233ca6864ced59f24 15.79MB / 15.79MB 0.2s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.8528474Z #6 sha256:14034e66ee3f8bcfd399019612c7f333cc777166161c3dee1a945ac1f0659fd6 12.58MB / 54.76MB 0.2s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.8529761Z #6 sha256:e5994d860b978a292f788854a3a8ec09e9c53429b96a36b19862155b04117724 3.92kB / 3.92kB done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.8531033Z #6 sha256:126c1e376cdfcda443c32a460d48756d45ff837044aa911e52b7f97002387096 2.50kB / 2.50kB done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.9609535Z #6 sha256:ced3088fc7691915325d6187786ba346149f7c9dcdbfb3772ca71be74bf87622 33.55MB / 53.76MB 0.3s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.9610877Z #6 sha256:847d9f854f908f28a433fd2d5b08b5e68ee58c9ec953dac233ca6864ced59f24 15.79MB / 15.79MB 0.2s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.9612142Z #6 sha256:14034e66ee3f8bcfd399019612c7f333cc777166161c3dee1a945ac1f0659fd6 27.26MB / 54.76MB 0.3s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:08.9613389Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 8.39MB / 197.25MB 0.3s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.1191050Z #6 sha256:ced3088fc7691915325d6187786ba346149f7c9dcdbfb3772ca71be74bf87622 50.33MB / 53.76MB 0.4s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.1195581Z #6 sha256:14034e66ee3f8bcfd399019612c7f333cc777166161c3dee1a945ac1f0659fd6 45.09MB / 54.76MB 0.4s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.1198501Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 26.21MB / 197.25MB 0.4s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.1199538Z #6 extracting sha256:ced3088fc7691915325d6187786ba346149f7c9dcdbfb3772ca71be74bf87622
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.2593505Z #6 sha256:ced3088fc7691915325d6187786ba346149f7c9dcdbfb3772ca71be74bf87622 53.76MB / 53.76MB 0.4s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.2645597Z #6 sha256:14034e66ee3f8bcfd399019612c7f333cc777166161c3dee1a945ac1f0659fd6 54.76MB / 54.76MB 0.5s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.2655005Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 41.94MB / 197.25MB 0.5s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.2656607Z #6 sha256:941fa5176749075d96a1ce557b60b4959e72410ac385170175d96b7e272a2460 0B / 58.46MB 0.5s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.2658018Z #6 sha256:f5e55d4deea7c919a81ea909cd63e28abab6a3e242f7f4047c382fefef695a4c 0B / 4.10kB 0.5s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.3639430Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 87.03MB / 197.25MB 0.7s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.3642562Z #6 sha256:941fa5176749075d96a1ce557b60b4959e72410ac385170175d96b7e272a2460 27.26MB / 58.46MB 0.7s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.3643566Z #6 sha256:f5e55d4deea7c919a81ea909cd63e28abab6a3e242f7f4047c382fefef695a4c 4.10kB / 4.10kB 0.5s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.3644883Z #6 sha256:151ea8be3cb7a201a692ec135bcc47ab50531c0b5a2ead08417944c331269a5c 447B / 447B 0.6s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.3646402Z #6 sha256:1b648a6cade7560887a501a5ec1d854910ea2507ca61a16a016e126c93001862 1.25MB / 1.25MB 0.6s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.5569186Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 133.17MB / 197.25MB 0.9s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.5571424Z #6 sha256:941fa5176749075d96a1ce557b60b4959e72410ac385170175d96b7e272a2460 57.67MB / 58.46MB 0.9s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.6582641Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 150.99MB / 197.25MB 1.0s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.6585545Z #6 sha256:941fa5176749075d96a1ce557b60b4959e72410ac385170175d96b7e272a2460 58.46MB / 58.46MB 0.9s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.8495453Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 174.06MB / 197.25MB 1.1s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:09.9527185Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 197.25MB / 197.25MB 1.3s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:10.1619509Z #6 sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 197.25MB / 197.25MB 1.4s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:11.8476224Z #6 ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:11.8476610Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:11.8477596Z #7 [internal] load build context
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:11.8478146Z #7 transferring context: 191.34MB 3.1s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:11.8478571Z #7 DONE 3.2s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:11.8479091Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:11.8479875Z #6 [1/6] FROM docker.io/library/node:22-bullseye@sha256:e5994d860b978a292f788854a3a8ec09e9c53429b96a36b19862155b04117724
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:12.5142510Z #6 extracting sha256:ced3088fc7691915325d6187786ba346149f7c9dcdbfb3772ca71be74bf87622 3.4s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:12.6404455Z #6 extracting sha256:847d9f854f908f28a433fd2d5b08b5e68ee58c9ec953dac233ca6864ced59f24 0.1s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:13.0612523Z #6 extracting sha256:847d9f854f908f28a433fd2d5b08b5e68ee58c9ec953dac233ca6864ced59f24 0.4s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:13.8454431Z #6 extracting sha256:14034e66ee3f8bcfd399019612c7f333cc777166161c3dee1a945ac1f0659fd6
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:15.8916869Z #6 extracting sha256:14034e66ee3f8bcfd399019612c7f333cc777166161c3dee1a945ac1f0659fd6 1.9s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:15.9805348Z #6 extracting sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:20.9581556Z #6 extracting sha256:067d6a857ea26ea67633cd59e0209cb6a54e70a1e95d19e8ae6c6b0a15b3d8d6 4.8s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:21.9379457Z #6 extracting sha256:f5e55d4deea7c919a81ea909cd63e28abab6a3e242f7f4047c382fefef695a4c
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:22.0660874Z #6 extracting sha256:f5e55d4deea7c919a81ea909cd63e28abab6a3e242f7f4047c382fefef695a4c done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:22.0662150Z #6 extracting sha256:941fa5176749075d96a1ce557b60b4959e72410ac385170175d96b7e272a2460 0.1s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:23.9509604Z #6 extracting sha256:941fa5176749075d96a1ce557b60b4959e72410ac385170175d96b7e272a2460 2.0s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.2853174Z #6 extracting sha256:1b648a6cade7560887a501a5ec1d854910ea2507ca61a16a016e126c93001862
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.4977525Z #6 extracting sha256:1b648a6cade7560887a501a5ec1d854910ea2507ca61a16a016e126c93001862 0.0s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.4978311Z #6 extracting sha256:151ea8be3cb7a201a692ec135bcc47ab50531c0b5a2ead08417944c331269a5c done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.4978751Z #6 DONE 15.7s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.4978867Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.4978976Z #8 [2/6] WORKDIR /app
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.4979191Z #8 DONE 0.0s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.4979337Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.4980879Z #9 [3/6] RUN apt-get update && apt-get install -y     chromium     fonts-liberation     libasound2     libatk-bridge2.0-0     libatk1.0-0     libatspi2.0-0     libcups2     libdbus-1-3     libdrm2     libgbm1     libgtk-3-0     libnspr4     libnss3     libxcomposite1     libxdamage1     libxfixes3     libxrandr2     libxshmfence1     xdg-utils     --no-install-recommends &&     rm -rf /var/lib/apt/lists/*
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.5114987Z #9 0.164 Get:1 http://deb.debian.org/debian bullseye InRelease [75.1 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.6134978Z #9 0.172 Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [27.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.6135681Z #9 0.172 Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.0 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.6136270Z #9 0.266 Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8066 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.7952895Z #9 0.357 Get:5 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [446 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:24.7954187Z #9 0.448 Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:25.5869661Z #9 1.240 Fetched 8677 kB in 1s (7972 kB/s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:25.9489617Z #9 1.240 Reading package lists...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.3248248Z #9 1.620 Reading package lists...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.4980303Z #9 1.987 Building dependency tree...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.4981021Z #9 2.061 Reading state information...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.4981696Z #9 2.150 The following additional packages will be installed:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.4982467Z #9 2.150   adwaita-icon-theme chromium-common dbus dbus-user-session
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.4987098Z #9 2.150   dconf-gsettings-backend dconf-service dmsetup glib-networking
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.4988953Z #9 2.150   glib-networking-common glib-networking-services gsettings-desktop-schemas
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6495083Z #9 2.151   gtk-update-icon-cache libapparmor1 libargon2-1 libasound2-data libasyncns0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6496249Z #9 2.151   libatk1.0-data libavahi-client3 libavahi-common-data libavahi-common3
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6497747Z #9 2.151   libcap2 libcolord2 libcryptsetup12 libdconf1 libdevmapper1.02.1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6498710Z #9 2.151   libdouble-conversion3 libdrm-amdgpu1 libdrm-common libdrm-intel1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6499699Z #9 2.151   libdrm-nouveau2 libdrm-radeon1 libepoxy0 libflac8 libfontenc1 libgl1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6500771Z #9 2.151   libgl1-mesa-dri libglapi-mesa libglvnd0 libglx-mesa0 libglx0 libgtk-3-common
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6501896Z #9 2.151   libip4tc2 libjson-c5 libjson-glib-1.0-0 libjson-glib-1.0-common libjsoncpp24
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6502996Z #9 2.151   libkmod2 libllvm11 libminizip1 libogg0 libopus0 libpam-systemd libpciaccess0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6504016Z #9 2.151   libproxy1v5 libpulse0 librest-0.7-0 libsensors-config libsensors5
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6505172Z #9 2.151   libsnappy1v5 libsndfile1 libsoup-gnome2.4-1 libsoup2.4-1 libvorbis0a
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6506133Z #9 2.151   libvorbisenc2 libvulkan1 libwayland-client0 libwayland-cursor0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6507141Z #9 2.151   libwayland-egl1 libwayland-server0 libwoff1 libwrap0 libx11-xcb1 libxaw7
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6508170Z #9 2.151   libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-shape0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6509154Z #9 2.151   libxcb-sync1 libxcb-xfixes0 libxcursor1 libxft2 libxi6 libxinerama1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6510152Z #9 2.151   libxkbcommon0 libxkbfile1 libxmu6 libxmuu1 libxnvctrl0 libxpm4 libxtst6
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6511171Z #9 2.151   libxv1 libxxf86dga1 libxxf86vm1 libz3-4 systemd systemd-sysv x11-utils
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6511821Z #9 2.151   xkb-data
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6512178Z #9 2.151 Suggested packages:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6512960Z #9 2.152   chromium-l10n chromium-shell chromium-driver libasound2-plugins alsa-utils
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6513973Z #9 2.152   colord cups-common gvfs opus-tools pciutils pulseaudio lm-sensors
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6514910Z #9 2.152   systemd-container policykit-1 mesa-utils
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6515453Z #9 2.152 Recommended packages:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6516115Z #9 2.152   chromium-sandbox upower libu2f-udev notification-daemon
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6517034Z #9 2.152   system-config-printer alsa-ucm-conf alsa-topology-conf at-spi2-core
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6517983Z #9 2.152   libgtk-3-bin mesa-vulkan-drivers | vulkan-icd systemd-timesyncd
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6518918Z #9 2.152   | time-daemon libnss-systemd libfile-mimeinfo-perl libnet-dbus-perl
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.6519893Z #9 2.152   libx11-protocol-perl x11-xserver-utils
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.8615146Z #9 2.514 The following NEW packages will be installed:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.8616209Z #9 2.514   adwaita-icon-theme chromium chromium-common dbus dbus-user-session
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.8617283Z #9 2.514   dconf-gsettings-backend dconf-service dmsetup fonts-liberation
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.8618143Z #9 2.514   glib-networking glib-networking-common glib-networking-services
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9912338Z #9 2.514   gsettings-desktop-schemas gtk-update-icon-cache libapparmor1 libargon2-1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9913632Z #9 2.514   libasound2 libasound2-data libasyncns0 libatk-bridge2.0-0 libatk1.0-0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9914776Z #9 2.514   libatk1.0-data libatspi2.0-0 libavahi-client3 libavahi-common-data
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9915749Z #9 2.514   libavahi-common3 libcap2 libcolord2 libcryptsetup12 libcups2 libdbus-1-3
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9916921Z #9 2.514   libdconf1 libdevmapper1.02.1 libdouble-conversion3 libdrm-amdgpu1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9917960Z #9 2.514   libdrm-common libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libdrm2 libepoxy0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9919134Z #9 2.514   libflac8 libfontenc1 libgbm1 libgl1 libgl1-mesa-dri libglapi-mesa libglvnd0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9920203Z #9 2.514   libglx-mesa0 libglx0 libgtk-3-0 libgtk-3-common libip4tc2 libjson-c5
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9921176Z #9 2.514   libjson-glib-1.0-0 libjson-glib-1.0-common libjsoncpp24 libkmod2 libllvm11
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9922498Z #9 2.514   libminizip1 libnspr4 libnss3 libogg0 libopus0 libpam-systemd libpciaccess0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9924915Z #9 2.514   libproxy1v5 libpulse0 librest-0.7-0 libsensors-config libsensors5
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9925509Z #9 2.514   libsnappy1v5 libsndfile1 libsoup-gnome2.4-1 libsoup2.4-1 libvorbis0a
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9926196Z #9 2.514   libvorbisenc2 libvulkan1 libwayland-client0 libwayland-cursor0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9927122Z #9 2.514   libwayland-egl1 libwayland-server0 libwoff1 libwrap0 libx11-xcb1 libxaw7
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9929727Z #9 2.514   libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-shape0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9930923Z #9 2.514   libxcb-sync1 libxcb-xfixes0 libxcomposite1 libxcursor1 libxdamage1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9932489Z #9 2.514   libxfixes3 libxft2 libxi6 libxinerama1 libxkbcommon0 libxkbfile1 libxmu6
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9933362Z #9 2.514   libxmuu1 libxnvctrl0 libxpm4 libxrandr2 libxshmfence1 libxtst6 libxv1
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9933960Z #9 2.514   libxxf86dga1 libxxf86vm1 libz3-4 systemd systemd-sysv x11-utils xdg-utils
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9934551Z #9 2.514   xkb-data
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9934987Z #9 2.542 0 upgraded, 118 newly installed, 0 to remove and 2 not upgraded.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9935387Z #9 2.542 Need to get 146 MB of archives.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9935812Z #9 2.542 After this operation, 519 MB of additional disk space will be used.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9936452Z #9 2.542 Get:1 http://deb.debian.org/debian bullseye/main amd64 libapparmor1 amd64 2.13.6-10 [99.3 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9937270Z #9 2.546 Get:2 http://deb.debian.org/debian-security bullseye-security/main amd64 libcap2 amd64 1:2.44-1+deb11u1 [24.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9938063Z #9 2.547 Get:3 http://deb.debian.org/debian bullseye/main amd64 libargon2-1 amd64 0~20171227-0.2 [19.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9939807Z #9 2.547 Get:4 http://deb.debian.org/debian bullseye/main amd64 dmsetup amd64 2:1.02.175-2.1 [92.1 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9942019Z #9 2.549 Get:5 http://deb.debian.org/debian bullseye/main amd64 libdevmapper1.02.1 amd64 2:1.02.175-2.1 [143 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9944168Z #9 2.551 Get:6 http://deb.debian.org/debian bullseye/main amd64 libjson-c5 amd64 0.15-2+deb11u1 [42.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9945846Z #9 2.552 Get:7 http://deb.debian.org/debian bullseye/main amd64 libcryptsetup12 amd64 2:2.3.7-1+deb11u1 [248 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9947574Z #9 2.554 Get:8 http://deb.debian.org/debian bullseye/main amd64 libip4tc2 amd64 1.8.7-1 [34.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9949153Z #9 2.555 Get:9 http://deb.debian.org/debian bullseye/main amd64 libkmod2 amd64 28-1 [55.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9950243Z #9 2.556 Get:10 http://deb.debian.org/debian-security bullseye-security/main amd64 systemd amd64 247.3-7+deb11u7 [4501 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9952052Z #9 2.577 Get:11 http://deb.debian.org/debian-security bullseye-security/main amd64 systemd-sysv amd64 247.3-7+deb11u7 [114 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9953592Z #9 2.578 Get:12 http://deb.debian.org/debian bullseye/main amd64 libdbus-1-3 amd64 1.12.28-0+deb11u1 [223 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9955313Z #9 2.580 Get:13 http://deb.debian.org/debian bullseye/main amd64 dbus amd64 1.12.28-0+deb11u1 [244 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9957496Z #9 2.582 Get:14 http://deb.debian.org/debian-security bullseye-security/main amd64 libpam-systemd amd64 247.3-7+deb11u7 [284 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9959141Z #9 2.583 Get:15 http://deb.debian.org/debian bullseye/main amd64 gtk-update-icon-cache amd64 3.24.24-4+deb11u4 [88.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9960445Z #9 2.584 Get:16 http://deb.debian.org/debian bullseye/main amd64 adwaita-icon-theme all 3.38.0-1 [10.9 MB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:26.9962785Z #9 2.644 Get:17 http://deb.debian.org/debian-security bullseye-security/main amd64 libasound2-data all 1.2.4-1.1+deb11u1 [38.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1003161Z #9 2.644 Get:18 http://deb.debian.org/debian-security bullseye-security/main amd64 libasound2 amd64 1.2.4-1.1+deb11u1 [357 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1004777Z #9 2.646 Get:19 http://deb.debian.org/debian bullseye/main amd64 libatk1.0-data all 2.36.0-2 [149 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1005917Z #9 2.647 Get:20 http://deb.debian.org/debian bullseye/main amd64 libatk1.0-0 amd64 2.36.0-2 [52.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1010265Z #9 2.648 Get:21 http://deb.debian.org/debian bullseye/main amd64 libatspi2.0-0 amd64 2.38.0-4+deb11u1 [72.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1012052Z #9 2.649 Get:22 http://deb.debian.org/debian bullseye/main amd64 libatk-bridge2.0-0 amd64 2.38.0-1 [64.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1013379Z #9 2.649 Get:23 http://deb.debian.org/debian-security bullseye-security/main amd64 libavahi-common-data amd64 0.8-5+deb11u3 [124 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1014784Z #9 2.650 Get:24 http://deb.debian.org/debian-security bullseye-security/main amd64 libavahi-common3 amd64 0.8-5+deb11u3 [59.0 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1015727Z #9 2.651 Get:25 http://deb.debian.org/debian-security bullseye-security/main amd64 libavahi-client3 amd64 0.8-5+deb11u3 [62.7 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1016636Z #9 2.651 Get:26 http://deb.debian.org/debian-security bullseye-security/main amd64 libcups2 amd64 2.3.3op2-3+deb11u10 [351 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1017456Z #9 2.653 Get:27 http://deb.debian.org/debian bullseye/main amd64 libdouble-conversion3 amd64 3.1.5-6.1 [41.0 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1018380Z #9 2.653 Get:28 http://deb.debian.org/debian bullseye/main amd64 libdrm-common all 2.4.104-1 [14.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1019178Z #9 2.654 Get:29 http://deb.debian.org/debian bullseye/main amd64 libdrm2 amd64 2.4.104-1 [41.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1020296Z #9 2.656 Get:30 http://deb.debian.org/debian bullseye/main amd64 libogg0 amd64 1.3.4-0.1 [27.3 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1021262Z #9 2.656 Get:31 http://deb.debian.org/debian bullseye/main amd64 libflac8 amd64 1.3.3-2+deb11u2 [112 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1022542Z #9 2.656 Get:32 http://deb.debian.org/debian bullseye/main amd64 libwayland-server0 amd64 1.18.0-2~exp1.1 [34.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1023402Z #9 2.657 Get:33 http://deb.debian.org/debian bullseye/main amd64 libgbm1 amd64 20.3.5-1 [73.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1024116Z #9 2.658 Get:34 http://deb.debian.org/debian bullseye/main amd64 libjsoncpp24 amd64 1.9.4-4 [78.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1024983Z #9 2.659 Get:35 http://deb.debian.org/debian bullseye/main amd64 libminizip1 amd64 1.1-8+deb11u1 [20.1 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1025705Z #9 2.660 Get:36 http://deb.debian.org/debian bullseye/main amd64 libnspr4 amd64 2:4.29-1 [112 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1026521Z #9 2.661 Get:37 http://deb.debian.org/debian-security bullseye-security/main amd64 libnss3 amd64 2:3.61-1+deb11u5 [1305 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1027506Z #9 2.666 Get:38 http://deb.debian.org/debian bullseye/main amd64 libopus0 amd64 1.3.1-0.1 [190 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1028279Z #9 2.668 Get:39 http://deb.debian.org/debian bullseye/main amd64 libasyncns0 amd64 0.8-6+b2 [12.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1028980Z #9 2.669 Get:40 http://deb.debian.org/debian bullseye/main amd64 libvorbis0a amd64 1.3.7-1 [93.0 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1029649Z #9 2.669 Get:41 http://deb.debian.org/debian bullseye/main amd64 libvorbisenc2 amd64 1.3.7-1 [80.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1030440Z #9 2.670 Get:42 http://deb.debian.org/debian-security bullseye-security/main amd64 libsndfile1 amd64 1.0.31-2+deb11u2 [188 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1031241Z #9 2.671 Get:43 http://deb.debian.org/debian bullseye/main amd64 libwrap0 amd64 7.6.q-31 [59.0 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1031887Z #9 2.672 Get:44 http://deb.debian.org/debian bullseye/main amd64 libpulse0 amd64 14.2-2 [285 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1032529Z #9 2.673 Get:45 http://deb.debian.org/debian bullseye/main amd64 libsnappy1v5 amd64 1.1.8-1 [17.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1033183Z #9 2.674 Get:46 http://deb.debian.org/debian bullseye/main amd64 libwoff1 amd64 1.0.2-1+b1 [42.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1033873Z #9 2.675 Get:47 http://deb.debian.org/debian bullseye/main amd64 libxcomposite1 amd64 1:0.4.5-1 [16.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1034698Z #9 2.675 Get:48 http://deb.debian.org/debian bullseye/main amd64 libxdamage1 amd64 1:1.1.5-2 [15.7 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1035553Z #9 2.676 Get:49 http://deb.debian.org/debian bullseye/main amd64 libxfixes3 amd64 1:5.0.3-2 [22.1 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1036193Z #9 2.676 Get:50 http://deb.debian.org/debian bullseye/main amd64 xkb-data all 2.29-2 [655 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1037442Z #9 2.680 Get:51 http://deb.debian.org/debian bullseye/main amd64 libxkbcommon0 amd64 1.0.3-2 [101 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1038604Z #9 2.681 Get:52 http://deb.debian.org/debian bullseye/main amd64 libxnvctrl0 amd64 470.239.06-1 [27.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1039790Z #9 2.682 Get:53 http://deb.debian.org/debian bullseye/main amd64 libxrandr2 amd64 2:1.5.1-1 [37.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1041006Z #9 2.684 Get:54 http://deb.debian.org/debian bullseye/main amd64 libcolord2 amd64 1.4.5-3 [144 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1041729Z #9 2.688 Get:55 http://deb.debian.org/debian bullseye/main amd64 libepoxy0 amd64 1.5.5-1 [193 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1042440Z #9 2.689 Get:56 http://deb.debian.org/debian bullseye/main amd64 libjson-glib-1.0-common all 1.6.2-1 [56.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1043163Z #9 2.690 Get:57 http://deb.debian.org/debian bullseye/main amd64 libjson-glib-1.0-0 amd64 1.6.2-1 [65.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1043845Z #9 2.691 Get:58 http://deb.debian.org/debian bullseye/main amd64 libproxy1v5 amd64 0.4.17-1 [59.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1044771Z #9 2.692 Get:59 http://deb.debian.org/debian bullseye/main amd64 glib-networking-common all 2.66.0-2 [68.1 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1045524Z #9 2.693 Get:60 http://deb.debian.org/debian bullseye/main amd64 glib-networking-services amd64 2.66.0-2 [17.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1046520Z #9 2.694 Get:61 http://deb.debian.org/debian bullseye/main amd64 dbus-user-session amd64 1.12.28-0+deb11u1 [100 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1047523Z #9 2.697 Get:62 http://deb.debian.org/debian bullseye/main amd64 libdconf1 amd64 0.38.0-2 [43.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1048755Z #9 2.698 Get:63 http://deb.debian.org/debian bullseye/main amd64 dconf-service amd64 0.38.0-2 [37.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1050017Z #9 2.699 Get:64 http://deb.debian.org/debian bullseye/main amd64 dconf-gsettings-backend amd64 0.38.0-2 [30.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1051025Z #9 2.700 Get:65 http://deb.debian.org/debian bullseye/main amd64 gsettings-desktop-schemas all 3.38.0-2 [588 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1051760Z #9 2.703 Get:66 http://deb.debian.org/debian bullseye/main amd64 glib-networking amd64 2.66.0-2 [67.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1052555Z #9 2.704 Get:67 http://deb.debian.org/debian-security bullseye-security/main amd64 libsoup2.4-1 amd64 2.72.0-2+deb11u3 [283 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1053655Z #9 2.706 Get:68 http://deb.debian.org/debian-security bullseye-security/main amd64 libsoup-gnome2.4-1 amd64 2.72.0-2+deb11u3 [24.1 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1054741Z #9 2.707 Get:69 http://deb.debian.org/debian bullseye/main amd64 librest-0.7-0 amd64 0.8.1-1.1 [33.8 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1055836Z #9 2.707 Get:70 http://deb.debian.org/debian bullseye/main amd64 libwayland-client0 amd64 1.18.0-2~exp1.1 [26.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1057035Z #9 2.707 Get:71 http://deb.debian.org/debian bullseye/main amd64 libwayland-cursor0 amd64 1.18.0-2~exp1.1 [14.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1058158Z #9 2.708 Get:72 http://deb.debian.org/debian bullseye/main amd64 libwayland-egl1 amd64 1.18.0-2~exp1.1 [8448 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1059387Z #9 2.708 Get:73 http://deb.debian.org/debian bullseye/main amd64 libxcursor1 amd64 1:1.2.0-2 [37.3 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1060548Z #9 2.709 Get:74 http://deb.debian.org/debian bullseye/main amd64 libxi6 amd64 2:1.7.10-1 [83.4 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1061565Z #9 2.709 Get:75 http://deb.debian.org/debian bullseye/main amd64 libxinerama1 amd64 2:1.1.4-2 [17.7 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1062609Z #9 2.710 Get:76 http://deb.debian.org/debian bullseye/main amd64 libgtk-3-common all 3.24.24-4+deb11u4 [3757 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1063351Z #9 2.736 Get:77 http://deb.debian.org/debian bullseye/main amd64 libgtk-3-0 amd64 3.24.24-4+deb11u4 [2715 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.1064034Z #9 2.753 Get:78 http://deb.debian.org/debian bullseye/main amd64 libfontenc1 amd64 1:1.1.4-1 [24.3 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2709439Z #9 2.753 Get:79 http://deb.debian.org/debian bullseye/main amd64 libglvnd0 amd64 1.3.2-1 [53.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2710864Z #9 2.754 Get:80 http://deb.debian.org/debian bullseye/main amd64 libglapi-mesa amd64 20.3.5-1 [71.7 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2712510Z #9 2.755 Get:81 http://deb.debian.org/debian bullseye/main amd64 libx11-xcb1 amd64 2:1.7.2-1+deb11u2 [204 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2713662Z #9 2.757 Get:82 http://deb.debian.org/debian bullseye/main amd64 libxcb-dri2-0 amd64 1.14-3 [103 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2714774Z #9 2.758 Get:83 http://deb.debian.org/debian bullseye/main amd64 libxcb-dri3-0 amd64 1.14-3 [102 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2715436Z #9 2.759 Get:84 http://deb.debian.org/debian bullseye/main amd64 libxcb-glx0 amd64 1.14-3 [118 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2716404Z #9 2.760 Get:85 http://deb.debian.org/debian bullseye/main amd64 libxcb-present0 amd64 1.14-3 [101 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2717595Z #9 2.761 Get:86 http://deb.debian.org/debian bullseye/main amd64 libxcb-sync1 amd64 1.14-3 [105 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2718742Z #9 2.762 Get:87 http://deb.debian.org/debian bullseye/main amd64 libxcb-xfixes0 amd64 1.14-3 [105 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2719898Z #9 2.763 Get:88 http://deb.debian.org/debian bullseye/main amd64 libxshmfence1 amd64 1.3-1 [8820 B]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2721088Z #9 2.764 Get:89 http://deb.debian.org/debian bullseye/main amd64 libxxf86vm1 amd64 1:1.1.4-1+b2 [20.8 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2721968Z #9 2.766 Get:90 http://deb.debian.org/debian bullseye/main amd64 libdrm-amdgpu1 amd64 2.4.104-1 [28.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2722678Z #9 2.766 Get:91 http://deb.debian.org/debian bullseye/main amd64 libpciaccess0 amd64 0.16-1 [53.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2723402Z #9 2.766 Get:92 http://deb.debian.org/debian bullseye/main amd64 libdrm-intel1 amd64 2.4.104-1 [71.8 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2724097Z #9 2.767 Get:93 http://deb.debian.org/debian bullseye/main amd64 libdrm-nouveau2 amd64 2.4.104-1 [26.8 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2725011Z #9 2.768 Get:94 http://deb.debian.org/debian bullseye/main amd64 libdrm-radeon1 amd64 2.4.104-1 [30.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2725688Z #9 2.768 Get:95 http://deb.debian.org/debian bullseye/main amd64 libz3-4 amd64 4.8.10-1 [6949 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2726435Z #9 2.812 Get:96 http://deb.debian.org/debian bullseye/main amd64 libllvm11 amd64 1:11.0.1-2 [17.9 MB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.2727359Z #9 2.924 Get:97 http://deb.debian.org/debian bullseye/main amd64 libsensors-config all 1:3.6.0-7 [32.3 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5206954Z #9 2.924 Get:98 http://deb.debian.org/debian bullseye/main amd64 libsensors5 amd64 1:3.6.0-7 [52.3 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5209207Z #9 2.925 Get:99 http://deb.debian.org/debian bullseye/main amd64 libvulkan1 amd64 1.2.162.0-1 [103 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5210446Z #9 2.926 Get:100 http://deb.debian.org/debian bullseye/main amd64 libgl1-mesa-dri amd64 20.3.5-1 [9633 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5211803Z #9 2.981 Get:101 http://deb.debian.org/debian bullseye/main amd64 libglx-mesa0 amd64 20.3.5-1 [186 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5212962Z #9 2.982 Get:102 http://deb.debian.org/debian bullseye/main amd64 libglx0 amd64 1.3.2-1 [35.7 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5214904Z #9 2.983 Get:103 http://deb.debian.org/debian bullseye/main amd64 libgl1 amd64 1.3.2-1 [89.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5216244Z #9 2.984 Get:104 http://deb.debian.org/debian bullseye/main amd64 libxmu6 amd64 2:1.1.2-2+b3 [60.8 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5217497Z #9 2.984 Get:105 http://deb.debian.org/debian bullseye/main amd64 libxpm4 amd64 1:3.5.12-1.1+deb11u1 [50.0 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5219019Z #9 2.985 Get:106 http://deb.debian.org/debian bullseye/main amd64 libxaw7 amd64 2:1.0.13-1.1 [202 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5220190Z #9 2.986 Get:107 http://deb.debian.org/debian bullseye/main amd64 libxcb-shape0 amd64 1.14-3 [102 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5221294Z #9 2.987 Get:108 http://deb.debian.org/debian bullseye/main amd64 libxft2 amd64 2.3.2-2 [57.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5222664Z #9 2.988 Get:109 http://deb.debian.org/debian bullseye/main amd64 libxkbfile1 amd64 1:1.1.0-1 [75.2 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5223878Z #9 2.989 Get:110 http://deb.debian.org/debian bullseye/main amd64 libxmuu1 amd64 2:1.1.2-2+b3 [23.9 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5225974Z #9 2.990 Get:111 http://deb.debian.org/debian bullseye/main amd64 libxtst6 amd64 2:1.2.3-1 [27.8 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5227600Z #9 2.990 Get:112 http://deb.debian.org/debian bullseye/main amd64 libxv1 amd64 2:1.0.11-1 [24.6 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5228797Z #9 2.990 Get:113 http://deb.debian.org/debian bullseye/main amd64 libxxf86dga1 amd64 2:1.1.4-1+b3 [22.1 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5230290Z #9 2.990 Get:114 http://deb.debian.org/debian bullseye/main amd64 x11-utils amd64 7.7+5 [202 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5231396Z #9 2.992 Get:115 http://deb.debian.org/debian bullseye/main amd64 xdg-utils all 1.1.3-4.1 [75.5 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5232951Z #9 2.993 Get:116 http://deb.debian.org/debian bullseye/main amd64 chromium-common amd64 120.0.6099.224-1~deb11u1 [5013 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.5234791Z #9 3.023 Get:117 http://deb.debian.org/debian bullseye/main amd64 chromium amd64 120.0.6099.224-1~deb11u1 [72.1 MB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.7902761Z #9 3.443 Get:118 http://deb.debian.org/debian bullseye/main amd64 fonts-liberation all 1:1.07.4-11 [828 kB]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:27.9067407Z #9 3.559 debconf: delaying package configuration, since apt-utils is not installed
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0071722Z #9 3.586 Fetched 146 MB in 1s (157 MB/s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0072536Z #9 3.600 Selecting previously unselected package libapparmor1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0073173Z #9 3.600 (Reading database ... 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0073579Z (Reading database ... 5%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0074002Z (Reading database ... 10%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0074593Z (Reading database ... 15%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0074955Z (Reading database ... 20%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0075309Z (Reading database ... 25%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0075675Z (Reading database ... 30%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0076022Z (Reading database ... 35%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0076375Z (Reading database ... 40%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0076718Z (Reading database ... 45%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0077072Z (Reading database ... 50%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0077423Z (Reading database ... 55%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0077775Z (Reading database ... 60%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0078135Z (Reading database ... 65%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0078499Z (Reading database ... 70%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0078848Z (Reading database ... 75%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0079228Z (Reading database ... 80%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0079583Z (Reading database ... 85%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0079927Z (Reading database ... 90%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0080271Z (Reading database ... 95%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0080628Z (Reading database ... 100%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0081550Z (Reading database ... 22815 files and directories currently installed.)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0082409Z #9 3.619 Preparing to unpack .../0-libapparmor1_2.13.6-10_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0082909Z #9 3.621 Unpacking libapparmor1:amd64 (2.13.6-10) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0083356Z #9 3.641 Selecting previously unselected package libcap2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0083857Z #9 3.642 Preparing to unpack .../1-libcap2_1%3a2.44-1+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0084605Z #9 3.643 Unpacking libcap2:amd64 (1:2.44-1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0085199Z #9 3.657 Selecting previously unselected package libargon2-1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0085723Z #9 3.659 Preparing to unpack .../2-libargon2-1_0~20171227-0.2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.0086197Z #9 3.660 Unpacking libargon2-1:amd64 (0~20171227-0.2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1191428Z #9 3.674 Selecting previously unselected package dmsetup.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1192005Z #9 3.675 Preparing to unpack .../3-dmsetup_2%3a1.02.175-2.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1192497Z #9 3.676 Unpacking dmsetup (2:1.02.175-2.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1192962Z #9 3.695 Selecting previously unselected package libdevmapper1.02.1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1193828Z #9 3.697 Preparing to unpack .../4-libdevmapper1.02.1_2%3a1.02.175-2.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1194722Z #9 3.698 Unpacking libdevmapper1.02.1:amd64 (2:1.02.175-2.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1195418Z #9 3.722 Selecting previously unselected package libjson-c5:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1196142Z #9 3.724 Preparing to unpack .../5-libjson-c5_0.15-2+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1197074Z #9 3.725 Unpacking libjson-c5:amd64 (0.15-2+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1197779Z #9 3.740 Selecting previously unselected package libcryptsetup12:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1198547Z #9 3.742 Preparing to unpack .../6-libcryptsetup12_2%3a2.3.7-1+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1199265Z #9 3.742 Unpacking libcryptsetup12:amd64 (2:2.3.7-1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.1199862Z #9 3.772 Selecting previously unselected package libip4tc2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.3456554Z #9 3.774 Preparing to unpack .../7-libip4tc2_1.8.7-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.3457318Z #9 3.775 Unpacking libip4tc2:amd64 (1.8.7-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.3458001Z #9 3.790 Selecting previously unselected package libkmod2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.3458722Z #9 3.792 Preparing to unpack .../8-libkmod2_28-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.3459320Z #9 3.793 Unpacking libkmod2:amd64 (28-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.3459906Z #9 3.811 Selecting previously unselected package systemd.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.3460690Z #9 3.812 Preparing to unpack .../9-systemd_247.3-7+deb11u7_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.3461346Z #9 3.848 Unpacking systemd (247.3-7+deb11u7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.6339987Z #9 4.287 Setting up libapparmor1:amd64 (2.13.6-10) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8208051Z #9 4.289 Setting up libcap2:amd64 (1:2.44-1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8209009Z #9 4.290 Setting up libargon2-1:amd64 (0~20171227-0.2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8209859Z #9 4.292 Setting up libjson-c5:amd64 (0.15-2+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8210472Z #9 4.294 Setting up libip4tc2:amd64 (1.8.7-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8210892Z #9 4.296 Setting up libkmod2:amd64 (28-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8211311Z #9 4.299 Setting up libdevmapper1.02.1:amd64 (2:1.02.175-2.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8211870Z #9 4.301 Setting up libcryptsetup12:amd64 (2:2.3.7-1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8212297Z #9 4.303 Setting up systemd (247.3-7+deb11u7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8213273Z #9 4.313 Created symlink /etc/systemd/system/getty.target.wants/getty@tty1.service → /lib/systemd/system/getty@.service.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8214567Z #9 4.315 Created symlink /etc/systemd/system/multi-user.target.wants/remote-fs.target → /lib/systemd/system/remote-fs.target.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8216183Z #9 4.318 Created symlink /etc/systemd/system/sysinit.target.wants/systemd-pstore.service → /lib/systemd/system/systemd-pstore.service.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8216880Z #9 4.323 Initializing machine ID from random generator.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.8681084Z #9 4.521 Setting up dmsetup (2:1.02.175-2.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9701964Z #9 4.545 Selecting previously unselected package systemd-sysv.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9702623Z #9 4.545 (Reading database ... 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9703027Z (Reading database ... 5%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9703399Z (Reading database ... 10%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9703819Z (Reading database ... 15%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9704179Z (Reading database ... 20%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9704693Z (Reading database ... 25%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9705042Z (Reading database ... 30%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9705433Z (Reading database ... 35%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9705786Z (Reading database ... 40%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9706138Z (Reading database ... 45%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9706480Z (Reading database ... 50%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9706830Z (Reading database ... 55%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9707212Z (Reading database ... 60%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9707583Z (Reading database ... 65%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9707954Z (Reading database ... 70%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9708315Z (Reading database ... 75%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9708705Z (Reading database ... 80%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9709072Z (Reading database ... 85%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9709423Z (Reading database ... 90%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9709765Z (Reading database ... 95%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9710108Z (Reading database ... 100%
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9710754Z (Reading database ... 23662 files and directories currently installed.)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9711677Z #9 4.559 Preparing to unpack .../000-systemd-sysv_247.3-7+deb11u7_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9712351Z #9 4.560 Unpacking systemd-sysv (247.3-7+deb11u7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9713087Z #9 4.581 Selecting previously unselected package libdbus-1-3:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9713615Z #9 4.583 Preparing to unpack .../001-libdbus-1-3_1.12.28-0+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9714079Z #9 4.584 Unpacking libdbus-1-3:amd64 (1.12.28-0+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9714750Z #9 4.614 Selecting previously unselected package dbus.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9715199Z #9 4.615 Preparing to unpack .../002-dbus_1.12.28-0+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:28.9715605Z #9 4.623 Unpacking dbus (1.12.28-0+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.0726308Z #9 4.658 Selecting previously unselected package libpam-systemd:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.0727267Z #9 4.660 Preparing to unpack .../003-libpam-systemd_247.3-7+deb11u7_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.0728048Z #9 4.660 Unpacking libpam-systemd:amd64 (247.3-7+deb11u7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.0728820Z #9 4.688 Selecting previously unselected package gtk-update-icon-cache.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.0729785Z #9 4.690 Preparing to unpack .../004-gtk-update-icon-cache_3.24.24-4+deb11u4_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.0730613Z #9 4.691 Unpacking gtk-update-icon-cache (3.24.24-4+deb11u4) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.0731349Z #9 4.725 Selecting previously unselected package adwaita-icon-theme.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.2260722Z #9 4.727 Preparing to unpack .../005-adwaita-icon-theme_3.38.0-1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:29.2261781Z #9 4.728 Unpacking adwaita-icon-theme (3.38.0-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.4130743Z #9 6.066 Selecting previously unselected package libasound2-data.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5612882Z #9 6.070 Preparing to unpack .../006-libasound2-data_1.2.4-1.1+deb11u1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5613918Z #9 6.071 Unpacking libasound2-data (1.2.4-1.1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5615280Z #9 6.094 Selecting previously unselected package libasound2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5616290Z #9 6.097 Preparing to unpack .../007-libasound2_1.2.4-1.1+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5617102Z #9 6.097 Unpacking libasound2:amd64 (1.2.4-1.1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5617788Z #9 6.134 Selecting previously unselected package libatk1.0-data.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5618415Z #9 6.137 Preparing to unpack .../008-libatk1.0-data_2.36.0-2_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5619070Z #9 6.137 Unpacking libatk1.0-data (2.36.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.5619691Z #9 6.214 Selecting previously unselected package libatk1.0-0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6734159Z #9 6.217 Preparing to unpack .../009-libatk1.0-0_2.36.0-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6800171Z #9 6.217 Unpacking libatk1.0-0:amd64 (2.36.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6800982Z #9 6.234 Selecting previously unselected package libatspi2.0-0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6801918Z #9 6.236 Preparing to unpack .../010-libatspi2.0-0_2.38.0-4+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6802759Z #9 6.237 Unpacking libatspi2.0-0:amd64 (2.38.0-4+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6803600Z #9 6.255 Selecting previously unselected package libatk-bridge2.0-0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6804704Z #9 6.258 Preparing to unpack .../011-libatk-bridge2.0-0_2.38.0-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6805466Z #9 6.258 Unpacking libatk-bridge2.0-0:amd64 (2.38.0-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6806248Z #9 6.275 Selecting previously unselected package libavahi-common-data:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6807174Z #9 6.278 Preparing to unpack .../012-libavahi-common-data_0.8-5+deb11u3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6808031Z #9 6.278 Unpacking libavahi-common-data:amd64 (0.8-5+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6808825Z #9 6.306 Selecting previously unselected package libavahi-common3:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6809705Z #9 6.309 Preparing to unpack .../013-libavahi-common3_0.8-5+deb11u3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6810494Z #9 6.309 Unpacking libavahi-common3:amd64 (0.8-5+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.6811302Z #9 6.326 Selecting previously unselected package libavahi-client3:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7879280Z #9 6.329 Preparing to unpack .../014-libavahi-client3_0.8-5+deb11u3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7880374Z #9 6.330 Unpacking libavahi-client3:amd64 (0.8-5+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7880851Z #9 6.348 Selecting previously unselected package libcups2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7881377Z #9 6.351 Preparing to unpack .../015-libcups2_2.3.3op2-3+deb11u10_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7881854Z #9 6.352 Unpacking libcups2:amd64 (2.3.3op2-3+deb11u10) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7882372Z #9 6.387 Selecting previously unselected package libdouble-conversion3:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7882943Z #9 6.389 Preparing to unpack .../016-libdouble-conversion3_3.1.5-6.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7883464Z #9 6.390 Unpacking libdouble-conversion3:amd64 (3.1.5-6.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7883913Z #9 6.405 Selecting previously unselected package libdrm-common.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7884616Z #9 6.407 Preparing to unpack .../017-libdrm-common_2.4.104-1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7885043Z #9 6.408 Unpacking libdrm-common (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7885453Z #9 6.422 Selecting previously unselected package libdrm2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7885911Z #9 6.424 Preparing to unpack .../018-libdrm2_2.4.104-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7886307Z #9 6.425 Unpacking libdrm2:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.7886692Z #9 6.441 Selecting previously unselected package libogg0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8920534Z #9 6.443 Preparing to unpack .../019-libogg0_1.3.4-0.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8921593Z #9 6.444 Unpacking libogg0:amd64 (1.3.4-0.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8922539Z #9 6.459 Selecting previously unselected package libflac8:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8923107Z #9 6.461 Preparing to unpack .../020-libflac8_1.3.3-2+deb11u2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8923566Z #9 6.462 Unpacking libflac8:amd64 (1.3.3-2+deb11u2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8924064Z #9 6.483 Selecting previously unselected package libwayland-server0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8924855Z #9 6.485 Preparing to unpack .../021-libwayland-server0_1.18.0-2~exp1.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8925380Z #9 6.486 Unpacking libwayland-server0:amd64 (1.18.0-2~exp1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8925872Z #9 6.501 Selecting previously unselected package libgbm1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8926328Z #9 6.503 Preparing to unpack .../022-libgbm1_20.3.5-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8926726Z #9 6.504 Unpacking libgbm1:amd64 (20.3.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8927147Z #9 6.522 Selecting previously unselected package libjsoncpp24:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8927911Z #9 6.525 Preparing to unpack .../023-libjsoncpp24_1.9.4-4_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8928348Z #9 6.526 Unpacking libjsoncpp24:amd64 (1.9.4-4) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:30.8928775Z #9 6.545 Selecting previously unselected package libminizip1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0498874Z #9 6.547 Preparing to unpack .../024-libminizip1_1.1-8+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0499435Z #9 6.548 Unpacking libminizip1:amd64 (1.1-8+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0499895Z #9 6.563 Selecting previously unselected package libnspr4:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0500380Z #9 6.565 Preparing to unpack .../025-libnspr4_2%3a4.29-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0500828Z #9 6.566 Unpacking libnspr4:amd64 (2:4.29-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0501256Z #9 6.586 Selecting previously unselected package libnss3:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0501744Z #9 6.589 Preparing to unpack .../026-libnss3_2%3a3.61-1+deb11u5_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0502191Z #9 6.589 Unpacking libnss3:amd64 (2:3.61-1+deb11u5) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.0502607Z #9 6.702 Selecting previously unselected package libopus0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1747253Z #9 6.705 Preparing to unpack .../027-libopus0_1.3.1-0.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1747743Z #9 6.706 Unpacking libopus0:amd64 (1.3.1-0.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1748199Z #9 6.733 Selecting previously unselected package libasyncns0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1748709Z #9 6.735 Preparing to unpack .../028-libasyncns0_0.8-6+b2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1749142Z #9 6.736 Unpacking libasyncns0:amd64 (0.8-6+b2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1749591Z #9 6.750 Selecting previously unselected package libvorbis0a:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1750370Z #9 6.753 Preparing to unpack .../029-libvorbis0a_1.3.7-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1750787Z #9 6.753 Unpacking libvorbis0a:amd64 (1.3.7-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1751234Z #9 6.774 Selecting previously unselected package libvorbisenc2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1751743Z #9 6.776 Preparing to unpack .../030-libvorbisenc2_1.3.7-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1752177Z #9 6.777 Unpacking libvorbisenc2:amd64 (1.3.7-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1752606Z #9 6.797 Selecting previously unselected package libsndfile1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1753102Z #9 6.800 Preparing to unpack .../031-libsndfile1_1.0.31-2+deb11u2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1753562Z #9 6.801 Unpacking libsndfile1:amd64 (1.0.31-2+deb11u2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.1753992Z #9 6.827 Selecting previously unselected package libwrap0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2754667Z #9 6.830 Preparing to unpack .../032-libwrap0_7.6.q-31_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2755235Z #9 6.831 Unpacking libwrap0:amd64 (7.6.q-31) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2755736Z #9 6.849 Selecting previously unselected package libpulse0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2756223Z #9 6.852 Preparing to unpack .../033-libpulse0_14.2-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2756637Z #9 6.857 Unpacking libpulse0:amd64 (14.2-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2757079Z #9 6.891 Selecting previously unselected package libsnappy1v5:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2757586Z #9 6.894 Preparing to unpack .../034-libsnappy1v5_1.1.8-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2758012Z #9 6.894 Unpacking libsnappy1v5:amd64 (1.1.8-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2758436Z #9 6.909 Selecting previously unselected package libwoff1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2758903Z #9 6.911 Preparing to unpack .../035-libwoff1_1.0.2-1+b1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2759309Z #9 6.912 Unpacking libwoff1:amd64 (1.0.2-1+b1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.2759756Z #9 6.928 Selecting previously unselected package libxcomposite1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4272622Z #9 6.930 Preparing to unpack .../036-libxcomposite1_1%3a0.4.5-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4273471Z #9 6.931 Unpacking libxcomposite1:amd64 (1:0.4.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4274178Z #9 6.946 Selecting previously unselected package libxdamage1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4275218Z #9 6.948 Preparing to unpack .../037-libxdamage1_1%3a1.1.5-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4275914Z #9 6.949 Unpacking libxdamage1:amd64 (1:1.1.5-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4276885Z #9 6.964 Selecting previously unselected package libxfixes3:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4277664Z #9 6.966 Preparing to unpack .../038-libxfixes3_1%3a5.0.3-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4278319Z #9 6.968 Unpacking libxfixes3:amd64 (1:5.0.3-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4278915Z #9 6.981 Selecting previously unselected package xkb-data.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4279589Z #9 6.984 Preparing to unpack .../039-xkb-data_2.29-2_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4280155Z #9 6.985 Unpacking xkb-data (2.29-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.4280786Z #9 7.080 Selecting previously unselected package libxkbcommon0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5479313Z #9 7.083 Preparing to unpack .../040-libxkbcommon0_1.0.3-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5480089Z #9 7.084 Unpacking libxkbcommon0:amd64 (1.0.3-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5480553Z #9 7.104 Selecting previously unselected package libxnvctrl0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5481074Z #9 7.107 Preparing to unpack .../041-libxnvctrl0_470.239.06-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5481571Z #9 7.108 Unpacking libxnvctrl0:amd64 (470.239.06-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5482018Z #9 7.123 Selecting previously unselected package libxrandr2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5482504Z #9 7.125 Preparing to unpack .../042-libxrandr2_2%3a1.5.1-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5482928Z #9 7.126 Unpacking libxrandr2:amd64 (2:1.5.1-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5483360Z #9 7.142 Selecting previously unselected package libcolord2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5483838Z #9 7.144 Preparing to unpack .../043-libcolord2_1.4.5-3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5484443Z #9 7.145 Unpacking libcolord2:amd64 (1.4.5-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5485187Z #9 7.170 Selecting previously unselected package libepoxy0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5485672Z #9 7.172 Preparing to unpack .../044-libepoxy0_1.5.5-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5486092Z #9 7.173 Unpacking libepoxy0:amd64 (1.5.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.5486538Z #9 7.201 Selecting previously unselected package libjson-glib-1.0-common.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6545375Z #9 7.203 Preparing to unpack .../045-libjson-glib-1.0-common_1.6.2-1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6546170Z #9 7.204 Unpacking libjson-glib-1.0-common (1.6.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6547184Z #9 7.233 Selecting previously unselected package libjson-glib-1.0-0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6548100Z #9 7.235 Preparing to unpack .../046-libjson-glib-1.0-0_1.6.2-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6548841Z #9 7.236 Unpacking libjson-glib-1.0-0:amd64 (1.6.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6549572Z #9 7.254 Selecting previously unselected package libproxy1v5:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6550362Z #9 7.256 Preparing to unpack .../047-libproxy1v5_0.4.17-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6551051Z #9 7.257 Unpacking libproxy1v5:amd64 (0.4.17-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6551772Z #9 7.273 Selecting previously unselected package glib-networking-common.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6552645Z #9 7.276 Preparing to unpack .../048-glib-networking-common_2.66.0-2_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6553380Z #9 7.276 Unpacking glib-networking-common (2.66.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.6554148Z #9 7.307 Selecting previously unselected package glib-networking-services.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7558130Z #9 7.310 Preparing to unpack .../049-glib-networking-services_2.66.0-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7559019Z #9 7.311 Unpacking glib-networking-services (2.66.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7559778Z #9 7.325 Selecting previously unselected package dbus-user-session.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7560701Z #9 7.327 Preparing to unpack .../050-dbus-user-session_1.12.28-0+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7561366Z #9 7.328 Unpacking dbus-user-session (1.12.28-0+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7562118Z #9 7.349 Selecting previously unselected package libdconf1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7562765Z #9 7.351 Preparing to unpack .../051-libdconf1_0.38.0-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7563181Z #9 7.352 Unpacking libdconf1:amd64 (0.38.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7563593Z #9 7.369 Selecting previously unselected package dconf-service.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7564681Z #9 7.371 Preparing to unpack .../052-dconf-service_0.38.0-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7565297Z #9 7.372 Unpacking dconf-service (0.38.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7567359Z #9 7.388 Selecting previously unselected package dconf-gsettings-backend:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7568347Z #9 7.390 Preparing to unpack .../053-dconf-gsettings-backend_0.38.0-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7569223Z #9 7.391 Unpacking dconf-gsettings-backend:amd64 (0.38.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7570087Z #9 7.406 Selecting previously unselected package gsettings-desktop-schemas.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.7571073Z #9 7.409 Preparing to unpack .../054-gsettings-desktop-schemas_3.38.0-2_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.8816446Z #9 7.410 Unpacking gsettings-desktop-schemas (3.38.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.8817285Z #9 7.476 Selecting previously unselected package glib-networking:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.8818162Z #9 7.478 Preparing to unpack .../055-glib-networking_2.66.0-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.8818887Z #9 7.479 Unpacking glib-networking:amd64 (2.66.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.8819632Z #9 7.498 Selecting previously unselected package libsoup2.4-1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.8820466Z #9 7.500 Preparing to unpack .../056-libsoup2.4-1_2.72.0-2+deb11u3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.8821205Z #9 7.501 Unpacking libsoup2.4-1:amd64 (2.72.0-2+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.8821948Z #9 7.534 Selecting previously unselected package libsoup-gnome2.4-1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9909417Z #9 7.537 Preparing to unpack .../057-libsoup-gnome2.4-1_2.72.0-2+deb11u3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9910071Z #9 7.539 Unpacking libsoup-gnome2.4-1:amd64 (2.72.0-2+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9910903Z #9 7.554 Selecting previously unselected package librest-0.7-0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9911423Z #9 7.556 Preparing to unpack .../058-librest-0.7-0_0.8.1-1.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9911857Z #9 7.557 Unpacking librest-0.7-0:amd64 (0.8.1-1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9912328Z #9 7.573 Selecting previously unselected package libwayland-client0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9912902Z #9 7.575 Preparing to unpack .../059-libwayland-client0_1.18.0-2~exp1.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9913438Z #9 7.576 Unpacking libwayland-client0:amd64 (1.18.0-2~exp1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9913933Z #9 7.591 Selecting previously unselected package libwayland-cursor0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9914726Z #9 7.593 Preparing to unpack .../060-libwayland-cursor0_1.18.0-2~exp1.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9915232Z #9 7.594 Unpacking libwayland-cursor0:amd64 (1.18.0-2~exp1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9915716Z #9 7.608 Selecting previously unselected package libwayland-egl1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9916253Z #9 7.610 Preparing to unpack .../061-libwayland-egl1_1.18.0-2~exp1.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9916757Z #9 7.611 Unpacking libwayland-egl1:amd64 (1.18.0-2~exp1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9917212Z #9 7.625 Selecting previously unselected package libxcursor1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9917696Z #9 7.627 Preparing to unpack .../062-libxcursor1_1%3a1.2.0-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9918125Z #9 7.628 Unpacking libxcursor1:amd64 (1:1.2.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:31.9918527Z #9 7.644 Selecting previously unselected package libxi6:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.1836108Z #9 7.646 Preparing to unpack .../063-libxi6_2%3a1.7.10-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.1836827Z #9 7.647 Unpacking libxi6:amd64 (2:1.7.10-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.1837286Z #9 7.665 Selecting previously unselected package libxinerama1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.1837825Z #9 7.668 Preparing to unpack .../064-libxinerama1_2%3a1.1.4-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.1838281Z #9 7.669 Unpacking libxinerama1:amd64 (2:1.1.4-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.1838752Z #9 7.683 Selecting previously unselected package libgtk-3-common.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.1839275Z #9 7.685 Preparing to unpack .../065-libgtk-3-common_3.24.24-4+deb11u4_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.1839736Z #9 7.686 Unpacking libgtk-3-common (3.24.24-4+deb11u4) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.3898539Z #9 8.042 Selecting previously unselected package libgtk-3-0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.5440336Z #9 8.045 Preparing to unpack .../066-libgtk-3-0_3.24.24-4+deb11u4_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.5440909Z #9 8.046 Unpacking libgtk-3-0:amd64 (3.24.24-4+deb11u4) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.6083333Z #9 8.261 Selecting previously unselected package libfontenc1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7256029Z #9 8.264 Preparing to unpack .../067-libfontenc1_1%3a1.1.4-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7256831Z #9 8.265 Unpacking libfontenc1:amd64 (1:1.1.4-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7257617Z #9 8.280 Selecting previously unselected package libglvnd0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7258439Z #9 8.282 Preparing to unpack .../068-libglvnd0_1.3.2-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7259087Z #9 8.283 Unpacking libglvnd0:amd64 (1.3.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7259792Z #9 8.303 Selecting previously unselected package libglapi-mesa:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7260614Z #9 8.306 Preparing to unpack .../069-libglapi-mesa_20.3.5-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7261314Z #9 8.307 Unpacking libglapi-mesa:amd64 (20.3.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7261768Z #9 8.326 Selecting previously unselected package libx11-xcb1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7262321Z #9 8.329 Preparing to unpack .../070-libx11-xcb1_2%3a1.7.2-1+deb11u2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7262805Z #9 8.330 Unpacking libx11-xcb1:amd64 (2:1.7.2-1+deb11u2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7263261Z #9 8.354 Selecting previously unselected package libxcb-dri2-0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7263779Z #9 8.356 Preparing to unpack .../071-libxcb-dri2-0_1.14-3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7264209Z #9 8.357 Unpacking libxcb-dri2-0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.7265142Z #9 8.378 Selecting previously unselected package libxcb-dri3-0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8270803Z #9 8.380 Preparing to unpack .../072-libxcb-dri3-0_1.14-3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8271407Z #9 8.381 Unpacking libxcb-dri3-0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8271879Z #9 8.403 Selecting previously unselected package libxcb-glx0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8272410Z #9 8.405 Preparing to unpack .../073-libxcb-glx0_1.14-3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8272834Z #9 8.406 Unpacking libxcb-glx0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8273284Z #9 8.428 Selecting previously unselected package libxcb-present0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8273788Z #9 8.431 Preparing to unpack .../074-libxcb-present0_1.14-3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8274214Z #9 8.432 Unpacking libxcb-present0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8275093Z #9 8.453 Selecting previously unselected package libxcb-sync1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8275667Z #9 8.455 Preparing to unpack .../075-libxcb-sync1_1.14-3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8276274Z #9 8.456 Unpacking libxcb-sync1:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8276781Z #9 8.477 Selecting previously unselected package libxcb-xfixes0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.8277263Z #9 8.480 Preparing to unpack .../076-libxcb-xfixes0_1.14-3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9278723Z #9 8.481 Unpacking libxcb-xfixes0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9279537Z #9 8.503 Selecting previously unselected package libxshmfence1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9280087Z #9 8.505 Preparing to unpack .../077-libxshmfence1_1.3-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9280515Z #9 8.506 Unpacking libxshmfence1:amd64 (1.3-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9280951Z #9 8.520 Selecting previously unselected package libxxf86vm1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9281446Z #9 8.522 Preparing to unpack .../078-libxxf86vm1_1%3a1.1.4-1+b2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9281892Z #9 8.523 Unpacking libxxf86vm1:amd64 (1:1.1.4-1+b2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9282332Z #9 8.538 Selecting previously unselected package libdrm-amdgpu1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9282827Z #9 8.541 Preparing to unpack .../079-libdrm-amdgpu1_2.4.104-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9283252Z #9 8.542 Unpacking libdrm-amdgpu1:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9283693Z #9 8.558 Selecting previously unselected package libpciaccess0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9284173Z #9 8.560 Preparing to unpack .../080-libpciaccess0_0.16-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9285139Z #9 8.561 Unpacking libpciaccess0:amd64 (0.16-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9285617Z #9 8.578 Selecting previously unselected package libdrm-intel1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:32.9286208Z #9 8.581 Preparing to unpack .../081-libdrm-intel1_2.4.104-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1521388Z #9 8.582 Unpacking libdrm-intel1:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1521950Z #9 8.601 Selecting previously unselected package libdrm-nouveau2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1522657Z #9 8.603 Preparing to unpack .../082-libdrm-nouveau2_2.4.104-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1523217Z #9 8.615 Unpacking libdrm-nouveau2:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1523729Z #9 8.632 Selecting previously unselected package libdrm-radeon1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1524460Z #9 8.634 Preparing to unpack .../083-libdrm-radeon1_2.4.104-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1525190Z #9 8.635 Unpacking libdrm-radeon1:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1525794Z #9 8.651 Selecting previously unselected package libz3-4:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1526406Z #9 8.653 Preparing to unpack .../084-libz3-4_4.8.10-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.1527027Z #9 8.654 Unpacking libz3-4:amd64 (4.8.10-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.4934563Z #9 9.146 Selecting previously unselected package libllvm11:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.6473564Z #9 9.149 Preparing to unpack .../085-libllvm11_1%3a11.0.1-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:33.6474224Z #9 9.150 Unpacking libllvm11:amd64 (1:11.0.1-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.8281470Z #9 10.48 Selecting previously unselected package libsensors-config.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9290287Z #9 10.48 Preparing to unpack .../086-libsensors-config_1%3a3.6.0-7_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9291144Z #9 10.48 Unpacking libsensors-config (1:3.6.0-7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9291878Z #9 10.50 Selecting previously unselected package libsensors5:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9292783Z #9 10.50 Preparing to unpack .../087-libsensors5_1%3a3.6.0-7_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9293489Z #9 10.53 Unpacking libsensors5:amd64 (1:3.6.0-7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9294213Z #9 10.55 Selecting previously unselected package libvulkan1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9295282Z #9 10.55 Preparing to unpack .../088-libvulkan1_1.2.162.0-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9295980Z #9 10.55 Unpacking libvulkan1:amd64 (1.2.162.0-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9296730Z #9 10.57 Selecting previously unselected package libgl1-mesa-dri:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9297589Z #9 10.58 Preparing to unpack .../089-libgl1-mesa-dri_20.3.5-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:34.9298327Z #9 10.58 Unpacking libgl1-mesa-dri:amd64 (20.3.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.5945670Z #9 11.25 Selecting previously unselected package libglx-mesa0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7108101Z #9 11.25 Preparing to unpack .../090-libglx-mesa0_20.3.5-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7125284Z #9 11.25 Unpacking libglx-mesa0:amd64 (20.3.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7125959Z #9 11.28 Selecting previously unselected package libglx0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7126687Z #9 11.28 Preparing to unpack .../091-libglx0_1.3.2-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7127262Z #9 11.28 Unpacking libglx0:amd64 (1.3.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7127848Z #9 11.30 Selecting previously unselected package libgl1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7128510Z #9 11.30 Preparing to unpack .../092-libgl1_1.3.2-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7129103Z #9 11.30 Unpacking libgl1:amd64 (1.3.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7129733Z #9 11.32 Selecting previously unselected package libxmu6:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7130485Z #9 11.33 Preparing to unpack .../093-libxmu6_2%3a1.1.2-2+b3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7131235Z #9 11.33 Unpacking libxmu6:amd64 (2:1.1.2-2+b3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7132914Z #9 11.34 Selecting previously unselected package libxpm4:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7133450Z #9 11.35 Preparing to unpack .../094-libxpm4_1%3a3.5.12-1.1+deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7134196Z #9 11.35 Unpacking libxpm4:amd64 (1:3.5.12-1.1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.7134876Z #9 11.36 Selecting previously unselected package libxaw7:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8117919Z #9 11.37 Preparing to unpack .../095-libxaw7_2%3a1.0.13-1.1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8118521Z #9 11.37 Unpacking libxaw7:amd64 (2:1.0.13-1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8118998Z #9 11.40 Selecting previously unselected package libxcb-shape0:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8119512Z #9 11.40 Preparing to unpack .../096-libxcb-shape0_1.14-3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8119930Z #9 11.40 Unpacking libxcb-shape0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8120332Z #9 11.42 Selecting previously unselected package libxft2:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8120788Z #9 11.42 Preparing to unpack .../097-libxft2_2.3.2-2_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8121167Z #9 11.42 Unpacking libxft2:amd64 (2.3.2-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8121572Z #9 11.44 Selecting previously unselected package libxkbfile1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8122050Z #9 11.44 Preparing to unpack .../098-libxkbfile1_1%3a1.1.0-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8122471Z #9 11.44 Unpacking libxkbfile1:amd64 (1:1.1.0-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8122883Z #9 11.46 Selecting previously unselected package libxmuu1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.8123354Z #9 11.46 Preparing to unpack .../099-libxmuu1_2%3a1.1.2-2+b3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9173939Z #9 11.47 Unpacking libxmuu1:amd64 (2:1.1.2-2+b3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9174860Z #9 11.48 Selecting previously unselected package libxtst6:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9175646Z #9 11.48 Preparing to unpack .../100-libxtst6_2%3a1.2.3-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9176298Z #9 11.48 Unpacking libxtst6:amd64 (2:1.2.3-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9176945Z #9 11.50 Selecting previously unselected package libxv1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9177999Z #9 11.50 Preparing to unpack .../101-libxv1_2%3a1.0.11-1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9178625Z #9 11.50 Unpacking libxv1:amd64 (2:1.0.11-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9179286Z #9 11.52 Selecting previously unselected package libxxf86dga1:amd64.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9180082Z #9 11.52 Preparing to unpack .../102-libxxf86dga1_2%3a1.1.4-1+b3_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9180793Z #9 11.52 Unpacking libxxf86dga1:amd64 (2:1.1.4-1+b3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9181441Z #9 11.54 Selecting previously unselected package x11-utils.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9182146Z #9 11.54 Preparing to unpack .../103-x11-utils_7.7+5_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9182708Z #9 11.54 Unpacking x11-utils (7.7+5) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:35.9183284Z #9 11.57 Selecting previously unselected package xdg-utils.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:36.0947449Z #9 11.57 Preparing to unpack .../104-xdg-utils_1.1.3-4.1_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:36.0947946Z #9 11.57 Unpacking xdg-utils (1.1.3-4.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:36.0948539Z #9 11.59 Selecting previously unselected package chromium-common.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:36.0949283Z #9 11.60 Preparing to unpack .../105-chromium-common_120.0.6099.224-1~deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:36.0950175Z #9 11.60 Unpacking chromium-common (120.0.6099.224-1~deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:36.3137154Z #9 11.97 Selecting previously unselected package chromium.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:36.4667856Z #9 11.97 Preparing to unpack .../106-chromium_120.0.6099.224-1~deb11u1_amd64.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:36.4668436Z #9 11.97 Unpacking chromium (120.0.6099.224-1~deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:40.8496056Z #9 16.50 Selecting previously unselected package fonts-liberation.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:40.9506855Z #9 16.51 Preparing to unpack .../107-fonts-liberation_1%3a1.07.4-11_all.deb ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:40.9507553Z #9 16.51 Unpacking fonts-liberation (1:1.07.4-11) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:40.9507965Z #9 16.60 Setting up libxcb-dri3-0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:40.9508399Z #9 16.60 Setting up libwayland-server0:amd64 (1.18.0-2~exp1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1098438Z #9 16.61 Setting up gtk-update-icon-cache (3.24.24-4+deb11u4) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1098971Z #9 16.61 Setting up libx11-xcb1:amd64 (2:1.7.2-1+deb11u2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1099504Z #9 16.61 Setting up libpciaccess0:amd64 (0.16-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1100028Z #9 16.61 Setting up systemd-sysv (247.3-7+deb11u7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1100797Z #9 16.61 Setting up libdouble-conversion3:amd64 (3.1.5-6.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1101192Z #9 16.62 Setting up libxft2:amd64 (2.3.2-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1101574Z #9 16.62 Setting up libproxy1v5:amd64 (0.4.17-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1101933Z #9 16.62 Setting up libxmu6:amd64 (2:1.1.2-2+b3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1102286Z #9 16.62 Setting up libxdamage1:amd64 (1:1.1.5-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1102668Z #9 16.63 Setting up libxcb-xfixes0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1103150Z #9 16.63 Setting up libogg0:amd64 (1.3.4-0.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1103746Z #9 16.63 Setting up libxpm4:amd64 (1:3.5.12-1.1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1104516Z #9 16.63 Setting up libxi6:amd64 (2:1.7.10-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1105009Z #9 16.64 Setting up libwoff1:amd64 (1.0.2-1+b1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1105638Z #9 16.64 Setting up libminizip1:amd64 (1.1-8+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1106012Z #9 16.64 Setting up libglvnd0:amd64 (1.3.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1106362Z #9 16.64 Setting up libxtst6:amd64 (2:1.2.3-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1106834Z #9 16.64 Setting up libxcb-glx0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1107321Z #9 16.65 Setting up libxcb-shape0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1107713Z #9 16.65 Setting up libsensors-config (1:3.6.0-7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1108087Z #9 16.65 Setting up libxxf86dga1:amd64 (2:1.1.4-1+b3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1108434Z #9 16.65 Setting up xkb-data (2.29-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1108872Z #9 16.65 Setting up libxaw7:amd64 (2:1.0.13-1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1109336Z #9 16.66 Setting up libcolord2:amd64 (1.4.5-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1109928Z #9 16.66 Setting up libxxf86vm1:amd64 (1:1.1.4-1+b2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1110298Z #9 16.66 Setting up libflac8:amd64 (1.3.3-2+deb11u2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1110777Z #9 16.66 Setting up libsnappy1v5:amd64 (1.1.8-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1111342Z #9 16.66 Setting up libxnvctrl0:amd64 (470.239.06-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1111732Z #9 16.67 Setting up libxcb-present0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1112217Z #9 16.67 Setting up libdconf1:amd64 (0.38.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1112772Z #9 16.67 Setting up libasound2-data (1.2.4-1.1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1113199Z #9 16.67 Setting up libfontenc1:amd64 (1:1.1.4-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1113545Z #9 16.67 Setting up libz3-4:amd64 (4.8.10-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1114002Z #9 16.68 Setting up libllvm11:amd64 (1:11.0.1-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1114655Z #9 16.68 Setting up adwaita-icon-theme (3.38.0-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.1115446Z #9 16.76 update-alternatives: using /usr/share/icons/Adwaita/cursor.theme to provide /usr/share/icons/default/index.theme (x-cursor-theme) in auto mode
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2120040Z #9 16.76 Setting up libwrap0:amd64 (7.6.q-31) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2121323Z #9 16.77 Setting up libepoxy0:amd64 (1.5.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2122221Z #9 16.77 Setting up libnspr4:amd64 (2:4.29-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2122866Z #9 16.77 Setting up libxfixes3:amd64 (1:5.0.3-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2123377Z #9 16.77 Setting up libxcb-sync1:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2124755Z #9 16.78 Setting up libavahi-common-data:amd64 (0.8-5+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2125404Z #9 16.78 Setting up libdbus-1-3:amd64 (1.12.28-0+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2126332Z #9 16.78 Setting up dbus (1.12.28-0+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2127129Z #9 16.85 invoke-rc.d: could not determine current runlevel
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2127625Z #9 16.86 invoke-rc.d: policy-rc.d denied execution of start.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2128014Z #9 16.86 Setting up libopus0:amd64 (1.3.1-0.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2128544Z #9 16.86 Setting up libxinerama1:amd64 (2:1.1.4-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2129132Z #9 16.86 Setting up libxv1:amd64 (2:1.0.11-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.2129600Z #9 16.86 Setting up libvorbis0a:amd64 (1.3.7-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3218323Z #9 16.87 Setting up libxrandr2:amd64 (2:1.5.1-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3218975Z #9 16.87 Setting up libsensors5:amd64 (1:3.6.0-7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3219707Z #9 16.87 Setting up libglapi-mesa:amd64 (20.3.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3220091Z #9 16.87 Setting up libvulkan1:amd64 (1.2.162.0-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3220466Z #9 16.88 Setting up libjsoncpp24:amd64 (1.9.4-4) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3220817Z #9 16.88 Setting up libxcb-dri2-0:amd64 (1.14-3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3221159Z #9 16.89 Setting up libatk1.0-data (2.36.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3221526Z #9 16.89 Setting up libasyncns0:amd64 (0.8-6+b2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3221873Z #9 16.90 Setting up libxshmfence1:amd64 (1.3-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3222267Z #9 16.90 Setting up libasound2:amd64 (1.2.4-1.1+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3222678Z #9 16.90 Setting up fonts-liberation (1:1.07.4-11) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3223084Z #9 16.90 Setting up libpam-systemd:amd64 (247.3-7+deb11u7) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3223486Z #9 16.97 debconf: unable to initialize frontend: Dialog
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3223944Z #9 16.97 debconf: (TERM is not set, so the dialog frontend is not usable.)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.3224671Z #9 16.97 debconf: falling back to frontend: Readline
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4226954Z #9 17.03 Setting up libjson-glib-1.0-common (1.6.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4227457Z #9 17.03 Setting up libatk1.0-0:amd64 (2.36.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4227878Z #9 17.03 Setting up libwayland-egl1:amd64 (1.18.0-2~exp1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4228307Z #9 17.03 Setting up libxkbfile1:amd64 (1:1.1.0-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4228719Z #9 17.04 Setting up glib-networking-common (2.66.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4229201Z #9 17.04 Setting up libdrm-common (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4229602Z #9 17.04 Setting up libxcomposite1:amd64 (1:0.4.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4230359Z #9 17.04 Setting up xdg-utils (1.1.3-4.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4231046Z #9 17.05 update-alternatives: using /usr/bin/xdg-open to provide /usr/bin/open (open) in auto mode
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4231654Z #9 17.05 Setting up libxmuu1:amd64 (2:1.1.2-2+b3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4232117Z #9 17.05 Setting up libvorbisenc2:amd64 (1.3.7-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4232503Z #9 17.05 Setting up libxkbcommon0:amd64 (1.0.3-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4232921Z #9 17.06 Setting up libwayland-client0:amd64 (1.18.0-2~exp1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4233347Z #9 17.06 Setting up glib-networking-services (2.66.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4233833Z #9 17.06 Setting up libxcursor1:amd64 (1:1.2.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4234226Z #9 17.06 Setting up libavahi-common3:amd64 (0.8-5+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4234920Z #9 17.06 Setting up libnss3:amd64 (2:3.61-1+deb11u5) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4235557Z #9 17.07 Setting up libatspi2.0-0:amd64 (2.38.0-4+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4236099Z #9 17.07 Setting up libjson-glib-1.0-0:amd64 (1.6.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4236491Z #9 17.07 Setting up libatk-bridge2.0-0:amd64 (2.38.0-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4237015Z #9 17.07 Setting up dbus-user-session (1.12.28-0+deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.4237397Z #9 17.08 Setting up libdrm2:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5320592Z #9 17.09 Setting up libwayland-cursor0:amd64 (1.18.0-2~exp1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5321446Z #9 17.09 Setting up libsndfile1:amd64 (1.0.31-2+deb11u2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5322119Z #9 17.09 Setting up libavahi-client3:amd64 (0.8-5+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5322766Z #9 17.09 Setting up libdrm-amdgpu1:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5323397Z #9 17.10 Setting up libdrm-nouveau2:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5324139Z #9 17.10 Setting up libgbm1:amd64 (20.3.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5324762Z #9 17.10 Setting up libpulse0:amd64 (14.2-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5325126Z #9 17.11 Setting up libdrm-radeon1:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5325519Z #9 17.11 Setting up libdrm-intel1:amd64 (2.4.104-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5325890Z #9 17.11 Setting up libgl1-mesa-dri:amd64 (20.3.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5326232Z #9 17.12 Setting up dconf-service (0.38.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5326604Z #9 17.12 Setting up libcups2:amd64 (2.3.3op2-3+deb11u10) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5326993Z #9 17.12 Setting up libglx-mesa0:amd64 (20.3.5-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5327620Z #9 17.12 Setting up libglx0:amd64 (1.3.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5328036Z #9 17.13 Setting up dconf-gsettings-backend:amd64 (0.38.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5328410Z #9 17.13 Setting up libgl1:amd64 (1.3.2-1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5328728Z #9 17.13 Setting up x11-utils (7.7+5) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5329114Z #9 17.14 Setting up chromium-common (120.0.6099.224-1~deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5329534Z #9 17.14 Setting up libgtk-3-common (3.24.24-4+deb11u4) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5329939Z #9 17.14 Setting up gsettings-desktop-schemas (3.38.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5330367Z #9 17.15 Processing triggers for libc-bin (2.31-13+deb11u13) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.5330767Z #9 17.18 Processing triggers for fontconfig (2.13.1-4.2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7748379Z #9 17.20 Processing triggers for hicolor-icon-theme (0.17-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7749262Z #9 17.22 Processing triggers for libglib2.0-0:amd64 (2.66.8-1+deb11u8) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7750048Z #9 17.24 Setting up glib-networking:amd64 (2.66.0-2) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7750706Z #9 17.24 Setting up libsoup2.4-1:amd64 (2.72.0-2+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7751162Z #9 17.24 Setting up libsoup-gnome2.4-1:amd64 (2.72.0-2+deb11u3) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7751578Z #9 17.25 Setting up librest-0.7-0:amd64 (0.8.1-1.1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7751971Z #9 17.25 Setting up libgtk-3-0:amd64 (3.24.24-4+deb11u4) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7752366Z #9 17.27 Setting up chromium (120.0.6099.224-1~deb11u1) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7753008Z #9 17.27 update-alternatives: using /usr/bin/chromium to provide /usr/bin/x-www-browser (x-www-browser) in auto mode
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7754888Z #9 17.27 update-alternatives: using /usr/bin/chromium to provide /usr/bin/gnome-www-browser (gnome-www-browser) in auto mode
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:41.7755948Z #9 17.28 Processing triggers for libc-bin (2.31-13+deb11u13) ...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:42.7750750Z #9 DONE 18.4s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:42.9381777Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:42.9382415Z #10 [4/6] COPY package.json yarn.lock ./
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:42.9382953Z #10 DONE 0.0s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:42.9383151Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:42.9383418Z #11 [5/6] RUN yarn install --frozen-lockfile
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:43.1081976Z #11 0.321 yarn install v1.22.22
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:43.3106283Z #11 0.371 [1/5] Validating package.json...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:43.3115450Z #11 0.373 [2/5] Resolving packages...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:43.4413307Z #11 0.654 [3/5] Fetching packages...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:51.6628247Z #11 8.875 warning log-lazy@1.0.4: The engine "bun" appears to be invalid.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:51.6628990Z #11 8.875 warning log-lazy@1.0.4: The engine "deno" appears to be invalid.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:51.8229336Z #11 8.877 warning bare-fs@4.1.5: The engine "bare" appears to be invalid.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:51.8229925Z #11 8.877 warning bare-os@3.6.1: The engine "bare" appears to be invalid.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:51.8230349Z #11 8.885 [4/5] Linking dependencies...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:55.1579223Z #11 12.37 [5/5] Building fresh packages...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:55.3166381Z #11 12.53 $ husky || true
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:55.5053873Z #11 12.56 .git can't be foundDone in 12.25s.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:55.6504110Z #11 DONE 12.9s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:55.8011341Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:29:55.8011722Z #12 [6/6] COPY . .
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:00.2830398Z #12 DONE 4.6s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:00.4346033Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:00.4346876Z #13 exporting to image
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:00.4347317Z #13 exporting layers
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.7939257Z #13 exporting layers 8.5s done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8252183Z #13 writing image sha256:7e9864cc3d2b7ed24a058365812c1cd62316a7261cadf22652eabef3e665c7c5 done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8253097Z #13 naming to docker.io/library/js-web-capture done
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8253585Z #13 DONE 8.5s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8253782Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8254032Z #14 resolving provenance for metadata file
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8255977Z #14 DONE 0.0s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8256257Z  web-capture  Built
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8326213Z ##[group]Run npm test -- tests/e2e/docker.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8326611Z [36;1mnpm test -- tests/e2e/docker.test.js[0m
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8349462Z shell: /usr/bin/bash -e {0}
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.8349715Z ##[endgroup]
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.9329305Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.9329880Z > @link-assistant/web-capture@1.3.0 test
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.9330823Z > node --experimental-vm-modules ./node_modules/.bin/jest tests/e2e/docker.test.js
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:08.9331380Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.5858444Z (node:7569) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.5859403Z (Use `node --trace-warnings ...` to show where the warning was created)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.6954121Z (node:7569) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7104586Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7105093Z     Checking if Docker service is already running...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7105605Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7105798Z       at Object.log (tests/e2e/docker.test.js:47:11)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7106011Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7240089Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7240576Z     Service not running, starting Docker container...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7240938Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7241185Z       at Object.log (tests/e2e/docker.test.js:50:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:09.7241516Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0123672Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0135839Z     Docker compose output:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0136207Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0136549Z       at Object.log (tests/e2e/docker.test.js:56:15)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0136899Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0137133Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0137744Z     Checking if service is ready at http://localhost:3000...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0138668Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0139097Z       at log (tests/e2e/docker.test.js:70:21)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0139410Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0161281Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0162231Z     Service not ready yet, error: request to http://localhost:3000/health failed, reason: read ECONNRESET
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0162972Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0163320Z       at log (tests/e2e/docker.test.js:81:21)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.0163638Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5173827Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5174259Z     Checking if service is ready at http://localhost:3000...
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5174785Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5175013Z       at Timeout.log [as _onTimeout] (tests/e2e/docker.test.js:70:21)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5175275Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5280842Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5281234Z     Service is ready!
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5281464Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5281826Z       at Timeout.log [as _onTimeout] (tests/e2e/docker.test.js:73:23)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5282298Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5286183Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5286575Z     Timing: Docker startup: 288ms
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5286868Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5287131Z       at Object.log (tests/e2e/docker.test.js:93:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5287479Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5291595Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5291991Z     Timing: Service readiness: 516ms
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5292288Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5292538Z       at Object.log (tests/e2e/docker.test.js:94:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5292888Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5296889Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5297256Z     Timing: beforeAll total: 835ms
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5297536Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5297785Z       at Object.log (tests/e2e/docker.test.js:95:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5298115Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5436716Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5437126Z     Timing: /html endpoint: 13ms
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5437414Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5437688Z       at Object.log (tests/e2e/docker.test.js:128:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5438035Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5663137Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5663559Z     Timing: /markdown endpoint: 21ms
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5663868Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5664129Z       at Object.log (tests/e2e/docker.test.js:140:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:10.5664765Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9211179Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9215170Z     Timing: /image endpoint: 9353ms
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9215494Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9215749Z       at Object.log (tests/e2e/docker.test.js:158:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9216081Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9332179Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9332782Z     Timing: /stream endpoint: 10ms
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9333176Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9333437Z       at Object.log (tests/e2e/docker.test.js:172:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9333854Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9399407Z   console.log
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9399754Z     Timing: /fetch endpoint: 6ms
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9399973Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9400178Z       at Object.log (tests/e2e/docker.test.js:185:13)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:19.9400409Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2651546Z PASS tests/e2e/docker.test.js (11.005 s)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2653413Z   E2E (Docker): Web Capture Microservice
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2655921Z     ✓ should return HTML from /html endpoint (14 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2656650Z     ✓ should return Markdown from /markdown endpoint (22 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2657238Z     ✓ should return PNG from /image endpoint (9355 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2657651Z     ✓ should stream content from /stream endpoint (12 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2658055Z     ✓ should return content from /fetch endpoint (6 ms)
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2658264Z 
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2683739Z Test Suites: 1 passed, 1 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2684185Z Tests:       5 passed, 5 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2684690Z Snapshots:   0 total
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2684994Z Time:        11.047 s
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.2685333Z Ran all test suites matching /tests\/e2e\/docker.test.js/i.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.3544053Z Post job cleanup.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.5212104Z Post job cleanup.
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6151067Z [command]/usr/bin/git version
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6186489Z git version 2.53.0
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6228379Z Temporarily overriding HOME='/home/runner/work/_temp/db8e6743-96ba-4d42-9a89-472aeca0b630' before making global git config changes
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6229796Z Adding repository directory to the temporary git global config as a safe directory
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6234912Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/web-capture/web-capture
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6270477Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6304677Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6536819Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6558725Z http.https://github.com/.extraheader
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6570839Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6601518Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6828407Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.6859023Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.7214901Z Cleaning up orphan processes
+JS - Test (Node.js on ubuntu-latest)	UNKNOWN STEP	2026-04-10T20:30:20.7548411Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/js/.changeset/fix-cicd-release-pipeline.md
+++ b/js/.changeset/fix-cicd-release-pipeline.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Fix CI/CD release pipeline: resolve git show path bug in version-and-commit.mjs where `git show origin/main:package.json` failed because git show uses repo-root-relative paths (should be `js/package.json`). Add npx-based fallback in setup-npm.mjs for Node.js 22.22.2 broken npm issue.

--- a/scripts/setup-npm.mjs
+++ b/scripts/setup-npm.mjs
@@ -48,35 +48,48 @@ try {
       'This is likely the Node.js 22.22.2 broken npm issue (actions/runner-images#13883).'
     );
 
-    // Try corepack as fallback
-    console.warn('Trying corepack as fallback...');
+    // Fallback 1: Use npx to download and install npm@11 via a fresh copy
+    // npx downloads packages to a cache and runs them, bypassing the broken
+    // global npm's rebuild/arborist code path.
+    console.warn('Trying npx-based install as fallback...');
     try {
-      await $`corepack enable`;
-      await $`corepack prepare npm@11 --activate`;
+      await $`npx --yes npm@11 install -g npm@11`;
       updated = true;
-    } catch (corepackError) {
+    } catch (npxError) {
       console.warn(
-        `Warning: corepack fallback also failed: ${corepackError.message}`
+        `Warning: npx-based install failed: ${npxError.message}`
       );
-      // Check if current npm version already supports OIDC (>= 11.5.1)
-      const majorVersion = parseInt(currentVersion.split('.')[0], 10);
-      if (majorVersion >= 11) {
-        console.log(
-          'Current npm version already supports OIDC trusted publishing'
-        );
+
+      // Fallback 2: Try corepack
+      console.warn('Trying corepack as fallback...');
+      try {
+        await $`corepack enable`;
+        await $`corepack prepare npm@11 --activate`;
         updated = true;
-      } else {
-        console.error(
-          `ERROR: Could not update npm to >= 11.5.1 for OIDC trusted publishing.`
+      } catch (corepackError) {
+        console.warn(
+          `Warning: corepack fallback also failed: ${corepackError.message}`
         );
-        console.error(
-          `Current npm version ${currentVersion} does not support OIDC.`
-        );
-        console.error(
-          'npm publish will likely fail. See: https://github.com/actions/runner-images/issues/13883'
-        );
-        // Do not exit — let the publish step fail with a clear error instead
-        // This allows the version bump to complete even if publish fails
+        // Check if current npm version already supports OIDC (>= 11.5.1)
+        const majorVersion = parseInt(currentVersion.split('.')[0], 10);
+        if (majorVersion >= 11) {
+          console.log(
+            'Current npm version already supports OIDC trusted publishing'
+          );
+          updated = true;
+        } else {
+          console.error(
+            `ERROR: Could not update npm to >= 11.5.1 for OIDC trusted publishing.`
+          );
+          console.error(
+            `Current npm version ${currentVersion} does not support OIDC.`
+          );
+          console.error(
+            'npm publish will likely fail. See: https://github.com/actions/runner-images/issues/13883'
+          );
+          // Do not exit — let the publish step fail with a clear error instead
+          // This allows the version bump to complete even if publish fails
+        }
       }
     }
   }

--- a/scripts/setup-npm.mjs
+++ b/scripts/setup-npm.mjs
@@ -12,11 +12,11 @@
 
 // Load use-m dynamically
 const { use } = eval(
-  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+  await (await fetch("https://unpkg.com/use-m/use.js")).text(),
 );
 
 // Import command-stream for shell command execution
-const { $ } = await use('command-stream');
+const { $ } = await use("command-stream");
 
 try {
   // Get current npm version
@@ -45,47 +45,45 @@ try {
   } catch (updateError) {
     console.warn(`Warning: npm install -g failed: ${updateError.message}`);
     console.warn(
-      'This is likely the Node.js 22.22.2 broken npm issue (actions/runner-images#13883).'
+      "This is likely the Node.js 22.22.2 broken npm issue (actions/runner-images#13883).",
     );
 
     // Fallback 1: Use npx to download and install npm@11 via a fresh copy
     // npx downloads packages to a cache and runs them, bypassing the broken
     // global npm's rebuild/arborist code path.
-    console.warn('Trying npx-based install as fallback...');
+    console.warn("Trying npx-based install as fallback...");
     try {
       await $`npx --yes npm@11 install -g npm@11`;
       updated = true;
     } catch (npxError) {
-      console.warn(
-        `Warning: npx-based install failed: ${npxError.message}`
-      );
+      console.warn(`Warning: npx-based install failed: ${npxError.message}`);
 
       // Fallback 2: Try corepack
-      console.warn('Trying corepack as fallback...');
+      console.warn("Trying corepack as fallback...");
       try {
         await $`corepack enable`;
         await $`corepack prepare npm@11 --activate`;
         updated = true;
       } catch (corepackError) {
         console.warn(
-          `Warning: corepack fallback also failed: ${corepackError.message}`
+          `Warning: corepack fallback also failed: ${corepackError.message}`,
         );
         // Check if current npm version already supports OIDC (>= 11.5.1)
-        const majorVersion = parseInt(currentVersion.split('.')[0], 10);
+        const majorVersion = parseInt(currentVersion.split(".")[0], 10);
         if (majorVersion >= 11) {
           console.log(
-            'Current npm version already supports OIDC trusted publishing'
+            "Current npm version already supports OIDC trusted publishing",
           );
           updated = true;
         } else {
           console.error(
-            `ERROR: Could not update npm to >= 11.5.1 for OIDC trusted publishing.`
+            `ERROR: Could not update npm to >= 11.5.1 for OIDC trusted publishing.`,
           );
           console.error(
-            `Current npm version ${currentVersion} does not support OIDC.`
+            `Current npm version ${currentVersion} does not support OIDC.`,
           );
           console.error(
-            'npm publish will likely fail. See: https://github.com/actions/runner-images/issues/13883'
+            "npm publish will likely fail. See: https://github.com/actions/runner-images/issues/13883",
           );
           // Do not exit — let the publish step fail with a clear error instead
           // This allows the version bump to complete even if publish fails
@@ -99,6 +97,6 @@ try {
   const updatedVersion = updatedResult.stdout.trim();
   console.log(`Updated npm version: ${updatedVersion}`);
 } catch (error) {
-  console.error('Error updating npm:', error.message);
+  console.error("Error updating npm:", error.message);
   process.exit(1);
 }

--- a/scripts/version-and-commit.mjs
+++ b/scripts/version-and-commit.mjs
@@ -126,7 +126,15 @@ function countChangesets() {
  */
 async function getVersion(source = 'local') {
   if (source === 'remote') {
-    const result = await $`git show origin/main:package.json`.run({
+    // git show uses repo-root-relative paths, but this script runs from
+    // a subdirectory (e.g., js/). Use git rev-parse --show-prefix to get
+    // the current directory relative to the repo root.
+    const prefixResult = await $`git rev-parse --show-prefix`.run({
+      capture: true,
+    });
+    const prefix = prefixResult.stdout.trim();
+    const gitPath = `${prefix}package.json`;
+    const result = await $`git show origin/main:${gitPath}`.run({
       capture: true,
     });
     return JSON.parse(result.stdout).version;

--- a/scripts/version-and-commit.mjs
+++ b/scripts/version-and-commit.mjs
@@ -12,85 +12,85 @@
  * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
  */
 
-import { readFileSync, appendFileSync, readdirSync } from 'fs';
+import { readFileSync, appendFileSync, readdirSync } from "fs";
 
 // Load use-m dynamically
 const { use } = eval(
-  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+  await (await fetch("https://unpkg.com/use-m/use.js")).text(),
 );
 
 // Import link-foundation libraries
-const { $ } = await use('command-stream');
-const { makeConfig } = await use('lino-arguments');
+const { $ } = await use("command-stream");
+const { makeConfig } = await use("lino-arguments");
 
 // Parse CLI arguments using lino-arguments
 const config = makeConfig({
   yargs: ({ yargs, getenv }) =>
     yargs
-      .option('mode', {
-        type: 'string',
-        default: getenv('MODE', 'changeset'),
-        describe: 'Version mode: changeset or instant',
-        choices: ['changeset', 'instant'],
+      .option("mode", {
+        type: "string",
+        default: getenv("MODE", "changeset"),
+        describe: "Version mode: changeset or instant",
+        choices: ["changeset", "instant"],
       })
-      .option('bump-type', {
-        type: 'string',
-        default: getenv('BUMP_TYPE', ''),
-        describe: 'Version bump type for instant mode: major, minor, or patch',
+      .option("bump-type", {
+        type: "string",
+        default: getenv("BUMP_TYPE", ""),
+        describe: "Version bump type for instant mode: major, minor, or patch",
       })
-      .option('description', {
-        type: 'string',
-        default: getenv('DESCRIPTION', ''),
-        describe: 'Description for instant version bump',
+      .option("description", {
+        type: "string",
+        default: getenv("DESCRIPTION", ""),
+        describe: "Description for instant version bump",
       }),
 });
 
 const { mode, bumpType, description } = config;
 
 // Debug: Log parsed configuration
-console.log('Parsed configuration:', {
+console.log("Parsed configuration:", {
   mode,
   bumpType,
-  description: description || '(none)',
+  description: description || "(none)",
 });
 
 // Detect if positional arguments were used (common mistake)
 const args = process.argv.slice(2);
-if (args.length > 0 && !args[0].startsWith('--')) {
-  console.error('Error: Positional arguments detected!');
-  console.error('Command line arguments:', args);
-  console.error('');
+if (args.length > 0 && !args[0].startsWith("--")) {
+  console.error("Error: Positional arguments detected!");
+  console.error("Command line arguments:", args);
+  console.error("");
   console.error(
-    'This script requires named arguments (--mode, --bump-type, --description).'
+    "This script requires named arguments (--mode, --bump-type, --description).",
   );
-  console.error('Usage:');
-  console.error('  Changeset mode:');
-  console.error('    node scripts/version-and-commit.mjs --mode changeset');
-  console.error('  Instant mode:');
+  console.error("Usage:");
+  console.error("  Changeset mode:");
+  console.error("    node scripts/version-and-commit.mjs --mode changeset");
+  console.error("  Instant mode:");
   console.error(
-    '    node scripts/version-and-commit.mjs --mode instant --bump-type <major|minor|patch> [--description <desc>]'
+    "    node scripts/version-and-commit.mjs --mode instant --bump-type <major|minor|patch> [--description <desc>]",
   );
-  console.error('');
-  console.error('Examples:');
+  console.error("");
+  console.error("Examples:");
   console.error(
-    '  node scripts/version-and-commit.mjs --mode instant --bump-type patch --description "Fix bug"'
+    '  node scripts/version-and-commit.mjs --mode instant --bump-type patch --description "Fix bug"',
   );
-  console.error('  node scripts/version-and-commit.mjs --mode changeset');
+  console.error("  node scripts/version-and-commit.mjs --mode changeset");
   process.exit(1);
 }
 
 // Validation: Ensure mode is set correctly
-if (mode !== 'changeset' && mode !== 'instant') {
+if (mode !== "changeset" && mode !== "instant") {
   console.error(`Invalid mode: "${mode}". Expected "changeset" or "instant".`);
-  console.error('Command line arguments:', process.argv.slice(2));
+  console.error("Command line arguments:", process.argv.slice(2));
   process.exit(1);
 }
 
 // Validation: Ensure bump type is provided for instant mode
-if (mode === 'instant' && !bumpType) {
-  console.error('Error: --bump-type is required for instant mode');
+if (mode === "instant" && !bumpType) {
+  console.error("Error: --bump-type is required for instant mode");
   console.error(
-    'Usage: node scripts/version-and-commit.mjs --mode instant --bump-type <major|minor|patch> [--description <desc>]'
+    "Usage: node scripts/version-and-commit.mjs --mode instant --bump-type <major|minor|patch> [--description <desc>]",
   );
   process.exit(1);
 }
@@ -112,9 +112,9 @@ function setOutput(key, value) {
  */
 function countChangesets() {
   try {
-    const changesetDir = '.changeset';
+    const changesetDir = ".changeset";
     const files = readdirSync(changesetDir);
-    return files.filter((f) => f.endsWith('.md') && f !== 'README.md').length;
+    return files.filter((f) => f.endsWith(".md") && f !== "README.md").length;
   } catch {
     return 0;
   }
@@ -124,8 +124,8 @@ function countChangesets() {
  * Get package version
  * @param {string} source - 'local' or 'remote'
  */
-async function getVersion(source = 'local') {
-  if (source === 'remote') {
+async function getVersion(source = "local") {
+  if (source === "remote") {
     // git show uses repo-root-relative paths, but this script runs from
     // a subdirectory (e.g., js/). Use git rev-parse --show-prefix to get
     // the current directory relative to the repo root.
@@ -139,7 +139,7 @@ async function getVersion(source = 'local') {
     });
     return JSON.parse(result.stdout).version;
   }
-  return JSON.parse(readFileSync('./package.json', 'utf8')).version;
+  return JSON.parse(readFileSync("./package.json", "utf8")).version;
 }
 
 async function main() {
@@ -149,7 +149,7 @@ async function main() {
     await $`git config user.email "github-actions[bot]@users.noreply.github.com"`;
 
     // Check if remote main has advanced (handles re-runs after partial success)
-    console.log('Checking for remote changes...');
+    console.log("Checking for remote changes...");
     await $`git fetch origin main`;
 
     const localHeadResult = await $`git rev-parse HEAD`.run({ capture: true });
@@ -162,28 +162,28 @@ async function main() {
 
     if (localHead !== remoteHead) {
       console.log(
-        `Remote main has advanced (local: ${localHead}, remote: ${remoteHead})`
+        `Remote main has advanced (local: ${localHead}, remote: ${remoteHead})`,
       );
-      console.log('This may indicate a previous attempt partially succeeded.');
+      console.log("This may indicate a previous attempt partially succeeded.");
 
       // Check if the remote version is already the expected bump
-      const remoteVersion = await getVersion('remote');
+      const remoteVersion = await getVersion("remote");
       console.log(`Remote version: ${remoteVersion}`);
 
       // Check if there are changesets to process
       const changesetCount = countChangesets();
 
       if (changesetCount === 0) {
-        console.log('No changesets to process and remote has advanced.');
+        console.log("No changesets to process and remote has advanced.");
         console.log(
-          'Assuming version bump was already completed in a previous attempt.'
+          "Assuming version bump was already completed in a previous attempt.",
         );
-        setOutput('version_committed', 'false');
-        setOutput('already_released', 'true');
-        setOutput('new_version', remoteVersion);
+        setOutput("version_committed", "false");
+        setOutput("already_released", "true");
+        setOutput("new_version", remoteVersion);
         return;
       } else {
-        console.log('Rebasing on remote main to incorporate changes...');
+        console.log("Rebasing on remote main to incorporate changes...");
         await $`git rebase origin/main`;
       }
     }
@@ -192,8 +192,8 @@ async function main() {
     const oldVersion = await getVersion();
     console.log(`Current version: ${oldVersion}`);
 
-    if (mode === 'instant') {
-      console.log('Running instant version bump...');
+    if (mode === "instant") {
+      console.log("Running instant version bump...");
       // Run instant version bump script
       // Rely on command-stream's auto-quoting for proper argument handling
       if (description) {
@@ -202,7 +202,7 @@ async function main() {
         await $`node ../scripts/instant-version-bump.mjs --bump-type ${bumpType}`;
       }
     } else {
-      console.log('Running changeset version...');
+      console.log("Running changeset version...");
       // Run changeset version to bump versions and update CHANGELOG
       await $`npm run changeset:version`;
     }
@@ -210,14 +210,14 @@ async function main() {
     // Get new version after bump
     const newVersion = await getVersion();
     console.log(`New version: ${newVersion}`);
-    setOutput('new_version', newVersion);
+    setOutput("new_version", newVersion);
 
     // Check if there are changes to commit
     const statusResult = await $`git status --porcelain`.run({ capture: true });
     const status = statusResult.stdout.trim();
 
     if (status) {
-      console.log('Changes detected, committing...');
+      console.log("Changes detected, committing...");
 
       // Stage all changes (package.json, package-lock.json, CHANGELOG.md, deleted changesets)
       await $`git add -A`;
@@ -230,14 +230,14 @@ async function main() {
       // Push directly to main
       await $`git push origin main`;
 
-      console.log('\u2705 Version bump committed and pushed to main');
-      setOutput('version_committed', 'true');
+      console.log("\u2705 Version bump committed and pushed to main");
+      setOutput("version_committed", "true");
     } else {
-      console.log('No changes to commit');
-      setOutput('version_committed', 'false');
+      console.log("No changes to commit");
+      setOutput("version_committed", "false");
     }
   } catch (error) {
-    console.error('Error:', error.message);
+    console.error("Error:", error.message);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #42 — CI/CD release pipeline failure in [run 24262572320](https://github.com/link-assistant/web-capture/actions/runs/24262572320/job/70853245788).

- **Primary fix**: `version-and-commit.mjs` used `git show origin/main:package.json` to check the remote version, but `git show` resolves paths relative to the **repo root**, not the working directory. Since the workflow runs from `js/`, the correct path is `js/package.json`. Fixed by using `git rev-parse --show-prefix` to dynamically resolve the subdirectory prefix.
- **Secondary fix**: Added `npx --yes npm@11 install -g npm@11` as a new fallback in `setup-npm.mjs` for the [Node.js 22.22.2 broken npm issue](https://github.com/actions/runner-images/issues/13883), where `npm install -g` fails with `MODULE_NOT_FOUND` for `promise-retry`.
- **Case study**: Added detailed root cause analysis and timeline in `docs/case-studies/issue-42/`.

## Root Cause

The `getVersion('remote')` function in `scripts/version-and-commit.mjs` ran:
```javascript
await $`git show origin/main:package.json`
```

But `git show <ref>:<path>` always uses **repo-root-relative** paths. The script runs from the `js/` subdirectory (via `working-directory: js` in the workflow), so the file is at `js/package.json` in git's tree. This only triggers when remote main has advanced since the CI run started (a race condition between concurrent releases).

The error from CI:
```
fatal: path 'js/package.json' exists, but not 'package.json'
Error: Unexpected end of JSON input
```

## Fix

```javascript
// Before (broken):
const result = await $`git show origin/main:package.json`.run({ capture: true });

// After (fixed):
const prefixResult = await $`git rev-parse --show-prefix`.run({ capture: true });
const prefix = prefixResult.stdout.trim();  // "js/"
const gitPath = `${prefix}package.json`;    // "js/package.json"
const result = await $`git show origin/main:${gitPath}`.run({ capture: true });
```

## Test plan

- [ ] Verify CI checks pass on this PR
- [ ] After merge, trigger a release and verify `version-and-commit.mjs` handles remote divergence correctly
- [ ] Verify `setup-npm.mjs` npm upgrade succeeds via npx fallback on Node.js 22.22.2 runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)