### PR TITLE
Fix CI/CD pipeline and update dependencies to latest versions

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -42,7 +42,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 defaults:
   run:
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
 
       - name: Install dependencies
         run: npm install
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ on:
         default: 'instant'
         options:
           - instant
+          - changelog-pr
       bump_type:
         description: 'Manual release type'
         required: true
@@ -36,7 +37,13 @@ on:
         required: false
         type: string
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
 
 defaults:
   run:
@@ -63,6 +70,8 @@ jobs:
             ~/.cargo/git
             rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -92,9 +101,14 @@ jobs:
             ~/.cargo/git
             rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --all-features --verbose
+
+      - name: Run doc tests
+        run: cargo test --doc --verbose
 
   # Build check
   build:
@@ -115,9 +129,14 @@ jobs:
             ~/.cargo/git
             rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Build release
         run: cargo build --release
+
+      - name: Check package
+        run: cargo package --list --allow-dirty
 
       - name: Build Docker image
         run: docker build -t web-capture-rust .
@@ -134,6 +153,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -151,6 +171,8 @@ jobs:
             ~/.cargo/git
             rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Check if version changed
         id: version_check
@@ -180,6 +202,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -197,6 +220,8 @@ jobs:
             ~/.cargo/git
             rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Version and commit
         id: version
@@ -214,3 +239,50 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node ../scripts/rust-create-github-release.mjs --release-version "${{ steps.version.outputs.version }}" --repository "${{ github.repository }}" --description "${{ github.event.inputs.description }}" --commit-sha "${{ github.sha }}"
+
+  # Manual Changelog PR - creates a PR with version bump for review before release
+  changelog-pr:
+    name: Rust - Create Changelog PR
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changelog-pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Bump version in Cargo.toml and CHANGELOG.md
+        working-directory: .
+        run: |
+          cd rust
+          node ../scripts/rust-version-bump.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(rust): bump version (${{ github.event.inputs.bump_type }})'
+          branch: changelog-rust-manual-release-${{ github.run_id }}
+          delete-branch: true
+          title: 'chore(rust): manual ${{ github.event.inputs.bump_type }} release'
+          body: |
+            ## Manual Release Request (Rust)
+
+            This PR was created by a manual workflow trigger to prepare a **${{ github.event.inputs.bump_type }}** release.
+
+            ### Release Details
+            - **Type:** ${{ github.event.inputs.bump_type }}
+            - **Description:** ${{ github.event.inputs.description || 'Manual release' }}
+            - **Triggered by:** @${{ github.actor }}
+
+            ### Next Steps
+            1. Review the version bump and changelog in this PR
+            2. Merge this PR to main
+            3. The automated release workflow will publish to crates.io and create a GitHub release

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
-# Updated: 2026-04-13T06:33:10.484Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
+# Updated: 2026-04-13T06:33:10.484Z

--- a/docs/case-studies/issue-44/README.md
+++ b/docs/case-studies/issue-44/README.md
@@ -1,0 +1,86 @@
+# Case Study: Issue #44 - CI/CD Package Publishing Failures
+
+## Timeline of Events
+
+1. **2026-04-11 05:42** - Push to `main` triggered the JavaScript CI/CD workflow (run [24275913722](https://github.com/link-assistant/web-capture/actions/runs/24275913722))
+2. **2026-04-11 05:48** - Lint and test jobs passed successfully
+3. **2026-04-11 05:48:13** - Release job started, version packages committed `1.4.1`
+4. **2026-04-11 05:48:37** - `setup-npm.mjs` encountered `MODULE_NOT_FOUND` for `promise-retry` (known Node.js 22.22.2 broken npm issue, [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883))
+5. **2026-04-11 05:48:43** - `publish-to-npm.mjs` started with `--should-pull`
+6. **2026-04-11 05:48:45** - Version check confirmed `1.4.1` not on npm, proceeded to publish
+7. **2026-04-11 05:48:48** - **FAILURE**: `npm publish --provenance --access public` returned `404 Not Found - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture`
+8. **2026-04-11 05:48:51** - Verification failed, retry loop started
+9. **2026-04-11 05:49:03** - Second attempt also failed with same 404
+10. **2026-04-11 05:49:18** - Third attempt failed, job exited with code 1
+
+## Root Cause Analysis
+
+### Primary Failure: npm Publish 404 Error
+
+**Root cause**: The npm OIDC trusted publishing is not properly configured for the `@link-assistant` scope on npmjs.org.
+
+**Evidence**:
+- The package `@link-assistant/web-capture@1.1.2` was previously published using token-based authentication by user `konard`
+- The workflow uses `npm publish --provenance --access public` which requires OIDC trusted publishing
+- The npm registry returns `404 Not Found` on the PUT request, which is the standard npm error when OIDC provenance-based publishing is not authorized for the package
+- The provenance statement was successfully signed (`Signed provenance statement with source and build information from GitHub Actions`) but the registry rejected the publish
+
+**npm OIDC trusted publishing requirements**:
+1. The package must be linked to a GitHub repository on npmjs.org
+2. The npm organization/user must enable "Require two-factor authentication or an automation or granular access token for publishing" or configure trusted publishing
+3. The GitHub Actions workflow must have `id-token: write` permission (present in workflow)
+4. The package must be configured on npmjs.org to trust the specific GitHub repository and workflow
+
+### Secondary Issue: Broken npm on GitHub Actions Runner
+
+**Root cause**: Node.js 22.22.2 on ubuntu-latest runners ships with npm 10.9.7 that is missing the `promise-retry` module.
+
+**Evidence**:
+```
+npm error code MODULE_NOT_FOUND
+npm error Cannot find module 'promise-retry'
+```
+
+**Mitigation**: The `setup-npm.mjs` script already has fallback logic (npx-based install, corepack) that partially handles this. However, if the npm upgrade itself fails, the subsequent publish will use the broken npm version.
+
+### Tertiary Issues: Dependency and Workflow Gaps
+
+1. **JavaScript `lino-arguments`**: Currently `^0.2.5`, latest is `0.3.0` - should update to `^0.3.0`
+2. **JavaScript `browser-commander`**: Currently `^0.8.0`, latest is `0.8.0` - already up to date
+3. **Rust `browser-commander`**: Commented out in Cargo.toml, not being used
+4. **Rust CI/CD workflow**: Missing several best practices from reference repos (detect-changes, changelog-pr mode, cancel-in-progress, verbose tests, etc.)
+
+## Requirements from Issue
+
+1. Update all dependencies (browser-commander, lino-arguments) to latest versions for both JS and Rust
+2. Compare CI/CD workflows with reference repos and adopt best practices
+3. Fix CI/CD pipeline to properly publish packages
+4. Create case study documentation (this document)
+5. Report issues to template repo if applicable
+
+## Solutions
+
+### 1. Fix npm Publishing (Critical)
+
+The `publish-to-npm.mjs` script needs a fallback to token-based authentication when OIDC publishing fails with 404. This is the approach used by the reference repos.
+
+**Fix**: Add `NODE_AUTH_TOKEN`-based fallback when OIDC publish returns 404, and improve error messaging to distinguish between OIDC configuration issues and actual publish failures.
+
+### 2. Update Dependencies
+
+- Update `lino-arguments` from `^0.2.5` to `^0.3.0` in `js/package.json`
+- Enable `browser-commander` in `rust/Cargo.toml` (uncomment and set to latest version)
+- Add `lino-arguments` to `rust/Cargo.toml` dependencies
+
+### 3. Align CI/CD Workflows
+
+Key improvements from reference repos (browser-commander, lino-arguments):
+- Add `cancel-in-progress: true` to concurrency settings
+- Add global env variables (`CARGO_TERM_COLOR`, `RUSTFLAGS`)
+- Add cache `restore-keys` for partial cache hits
+- Add `--verbose` flags to test commands
+- Add `changelog-pr` manual release mode for Rust workflow
+
+## CI Log Files
+
+- [ci-run-24275913722-failed.txt](./ci-run-24275913722-failed.txt) - Failed job logs from the release workflow

--- a/docs/case-studies/issue-44/ci-run-24275913722-failed.txt
+++ b/docs/case-studies/issue-44/ci-run-24275913722-failed.txt
@@ -1,0 +1,640 @@
+JS - Release	UNKNOWN STEP	﻿2026-04-11T05:48:11.9339486Z Current runner version: '2.333.1'
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9363710Z ##[group]Runner Image Provisioner
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9364465Z Hosted Compute Agent
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9365095Z Version: 20260213.493
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9365715Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9366415Z Build Date: 2026-02-13T00:28:41Z
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9367466Z Worker ID: {5393c39f-bdb8-49c7-be96-db044f9c80f5}
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9368165Z Azure Region: westcentralus
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9368741Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9370073Z ##[group]Operating System
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9371057Z Ubuntu
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9371499Z 24.04.4
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9371941Z LTS
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9372432Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9372926Z ##[group]Runner Image
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9373459Z Image: ubuntu-24.04
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9374077Z Version: 20260406.80.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9375230Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260406.80/images/ubuntu/Ubuntu2404-Readme.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9376726Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260406.80
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9377596Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9378750Z ##[group]GITHUB_TOKEN Permissions
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9380949Z Contents: write
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9381533Z Metadata: read
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9382075Z PullRequests: write
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9382619Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9384536Z Secret source: Actions
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9385320Z Prepare workflow directory
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9844469Z Prepare all required actions
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:11.9881360Z Getting action download info
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.4016518Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.5427642Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8201715Z Complete job name: JS - Release
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8902878Z ##[group]Run actions/checkout@v4
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8903711Z with:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8904088Z   fetch-depth: 0
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8904512Z   repository: link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8905210Z   token: ***
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8905589Z   ssh-strict: true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8905981Z   ssh-user: git
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8906386Z   persist-credentials: true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8906832Z   clean: true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8907223Z   sparse-checkout-cone-mode: true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8907689Z   fetch-tags: false
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8908082Z   show-progress: true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8908467Z   lfs: false
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8908852Z   submodules: false
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8909245Z   set-safe-directory: true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.8909960Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:12.9997550Z Syncing repository: link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0000303Z ##[group]Getting Git version info
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0001869Z Working directory is '/home/runner/work/web-capture/web-capture'
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0003541Z [command]/usr/bin/git version
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0038557Z git version 2.53.0
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0065752Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0090725Z Temporarily overriding HOME='/home/runner/work/_temp/69b274c4-ef78-4527-b1ae-83dd58670371' before making global git config changes
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0093080Z Adding repository directory to the temporary git global config as a safe directory
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0097155Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/web-capture/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0131314Z Deleting the contents of '/home/runner/work/web-capture/web-capture'
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0136353Z ##[group]Initializing the repository
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0141415Z [command]/usr/bin/git init /home/runner/work/web-capture/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0227233Z hint: Using 'master' as the name for the initial branch. This default branch name
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0229212Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0231290Z hint: to use in all of your new repositories, which will suppress this warning,
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0233080Z hint: call:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0233858Z hint:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0234843Z hint: 	git config --global init.defaultBranch <name>
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0236233Z hint:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0237459Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0239404Z hint: 'development'. The just-created branch can be renamed via this command:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0241231Z hint:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0242228Z hint: 	git branch -m <name>
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0243301Z hint:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0244955Z hint: Disable this message with "git config set advice.defaultBranchName false"
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0247071Z Initialized empty Git repository in /home/runner/work/web-capture/web-capture/.git/
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0250982Z [command]/usr/bin/git remote add origin https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0271110Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0272391Z ##[group]Disabling automatic garbage collection
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0276033Z [command]/usr/bin/git config --local gc.auto 0
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0315246Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0316767Z ##[group]Setting up auth
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0318260Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0353008Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0636435Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0665799Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0888572Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.0917608Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.1135797Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.1167952Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.1168801Z ##[group]Fetching the repository
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:13.1177369Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2105965Z From https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2131824Z  * [new branch]      issue-1-5017a66c05a8  -> origin/issue-1-5017a66c05a8
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2142005Z  * [new branch]      issue-11-2861fe92     -> origin/issue-11-2861fe92
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2143468Z  * [new branch]      issue-13-a8f3466f6d79 -> origin/issue-13-a8f3466f6d79
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2144975Z  * [new branch]      issue-15-ba41292e60dd -> origin/issue-15-ba41292e60dd
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2146291Z  * [new branch]      issue-17-d61fd69fb1d0 -> origin/issue-17-d61fd69fb1d0
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2147158Z  * [new branch]      issue-19-7350892c64e0 -> origin/issue-19-7350892c64e0
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2148036Z  * [new branch]      issue-21-ae540dd05ccf -> origin/issue-21-ae540dd05ccf
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2148904Z  * [new branch]      issue-24-000cedc18c0c -> origin/issue-24-000cedc18c0c
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2149889Z  * [new branch]      issue-26-f5bc08d1c062 -> origin/issue-26-f5bc08d1c062
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2151247Z  * [new branch]      issue-28-9ae2d8528d6f -> origin/issue-28-9ae2d8528d6f
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2152311Z  * [new branch]      issue-29-1750ff5496be -> origin/issue-29-1750ff5496be
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2153348Z  * [new branch]      issue-3-e1f5cfd3      -> origin/issue-3-e1f5cfd3
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2154458Z  * [new branch]      issue-31-e38e38b91777 -> origin/issue-31-e38e38b91777
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2155566Z  * [new branch]      issue-33-597c234012bd -> origin/issue-33-597c234012bd
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2157749Z  * [new branch]      issue-36-4868dc6a6cd1 -> origin/issue-36-4868dc6a6cd1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2159415Z  * [new branch]      issue-38-1c6b407f9682 -> origin/issue-38-1c6b407f9682
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2161482Z  * [new branch]      issue-40-aea0c7bbe29d -> origin/issue-40-aea0c7bbe29d
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2163188Z  * [new branch]      issue-42-51e981719f34 -> origin/issue-42-51e981719f34
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2164797Z  * [new branch]      issue-5-37ef445c      -> origin/issue-5-37ef445c
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2166340Z  * [new branch]      issue-7-c22ac3d5      -> origin/issue-7-c22ac3d5
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2167948Z  * [new branch]      issue-8-2bf69acf      -> origin/issue-8-2bf69acf
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2169400Z  * [new branch]      main                  -> origin/main
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2170870Z  * [new tag]         v1.1.1                -> v1.1.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2172116Z  * [new tag]         v1.1.2                -> v1.1.2
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2173288Z  * [new tag]         v1.1.3                -> v1.1.3
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2174412Z  * [new tag]         v1.2.0                -> v1.2.0
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2175531Z  * [new tag]         v1.3.0                -> v1.3.0
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2193149Z [command]/usr/bin/git branch --list --remote origin/main
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2218814Z   origin/main
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2229452Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2250323Z 4c80b8eda211decb14e0f484015545a3c2b9c7fc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2262887Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2264035Z ##[group]Determining the checkout info
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2265287Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2265843Z [command]/usr/bin/git sparse-checkout disable
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2301427Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2328372Z ##[group]Checking out the ref
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2333262Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2493293Z Switched to a new branch 'main'
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2496287Z branch 'main' set up to track 'origin/main'.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2503996Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2538477Z [command]/usr/bin/git log -1 --format=%H
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2560948Z 4c80b8eda211decb14e0f484015545a3c2b9c7fc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2835047Z ##[group]Run actions/setup-node@v4
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2835754Z with:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2836184Z   node-version: 22.x
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2836796Z   registry-url: https://registry.npmjs.org
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2837589Z   always-auth: false
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2838113Z   check-latest: false
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2838896Z   token: ***
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.2839355Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.4592761Z Found in cache @ /opt/hostedtoolcache/node/22.22.2/x64
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:14.4599040Z ##[group]Environment details
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4776264Z node: v22.22.2
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4776903Z npm: 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4777301Z yarn: 1.22.22
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4780138Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4901717Z ##[group]Run npm install
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4902060Z [36;1mnpm install[0m
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4965621Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4965905Z env:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4966178Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4966545Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:17.4966843Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:20.3451095Z npm warn deprecated supertest@6.3.4: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:21.4260558Z npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:21.5205642Z npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:22.2642987Z npm warn deprecated superagent@8.1.2: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:23.8580119Z npm warn deprecated puppeteer@24.8.2: < 24.15.0 is no longer supported
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:24.3943724Z npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3056476Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3057688Z > @link-assistant/web-capture@1.4.0 prepare
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3058368Z > husky || true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3058714Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3526360Z .git can't be found
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3527019Z added 857 packages, and audited 858 packages in 15s
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3527407Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3529307Z 136 packages are looking for funding
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3529875Z   run `npm fund` for details
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3660828Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3661661Z 14 vulnerabilities (1 low, 5 moderate, 6 high, 2 critical)
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3662229Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3662544Z To address all issues, run:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3663090Z   npm audit fix
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3663379Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.3663648Z Run `npm audit` for details.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.4238088Z ##[group]Run node ../scripts/setup-npm.mjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.4238437Z [36;1mnode ../scripts/setup-npm.mjs[0m
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.4260006Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.4260238Z env:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.4260749Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.4261068Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:32.4261312Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:34.2077842Z 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:34.2121649Z Current npm version: 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0035510Z npm error code MODULE_NOT_FOUND
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0036831Z npm error Cannot find module 'promise-retry'
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0037335Z npm error Require stack:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0038467Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0040581Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/index.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0042507Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/index.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0044197Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/libnpmfund/lib/index.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0045746Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-output.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0047200Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-finish.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0049653Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/commands/install.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0051115Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/npm.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0052255Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli/entry.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0053466Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0054599Z npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/bin/npm-cli.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.0056149Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T05_48_34_265Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1031205Z 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1087695Z Updated npm version: 10.9.7
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1189692Z ##[group]Run # Count changeset files (excluding README.md and config.json)
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1190226Z [36;1m# Count changeset files (excluding README.md and config.json)[0m
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1191157Z [36;1mCHANGESET_COUNT=$(find .changeset -name "*.md" ! -name "README.md" | wc -l)[0m
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1191787Z [36;1mecho "Found $CHANGESET_COUNT changeset file(s)"[0m
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1192273Z [36;1mecho "has_changesets=$([[ $CHANGESET_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT[0m
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1213955Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1214176Z env:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1214396Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1214716Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1214960Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1278384Z Found 1 changeset file(s)
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1325330Z ##[group]Run node ../scripts/version-and-commit.mjs --mode changeset
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1325781Z [36;1mnode ../scripts/version-and-commit.mjs --mode changeset[0m
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1344993Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1345198Z env:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1345417Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1345719Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:37.1345972Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.5492045Z 📝 Loaded 2 variables from .lenv
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.5589408Z Parsed configuration: { mode: 'changeset', bumpType: '', description: '(none)' }
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.5759721Z Checking for remote changes...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.9083323Z From https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.9084089Z  * branch            main       -> FETCH_HEAD
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.9200926Z 4c80b8eda211decb14e0f484015545a3c2b9c7fc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.9271922Z 4c80b8eda211decb14e0f484015545a3c2b9c7fc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.9279259Z Current version: 1.4.0
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:39.9279680Z Running changeset version...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:40.0237420Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:40.0238063Z > @link-assistant/web-capture@1.4.0 changeset:version
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:40.0238741Z > node ../scripts/changeset-version.mjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:40.0239052Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:40.7130897Z Running changeset version...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:41.3831289Z 🦋  All files have been updated. Review them and commit at your leisure
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:41.4002001Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:41.4002407Z Synchronizing package-lock.json...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.5783868Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.5784602Z > @link-assistant/web-capture@1.4.1 prepare
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.5785065Z > husky || true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.5785234Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6173143Z .git can't be found
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6174016Z up to date, audited 860 packages in 1s
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6174502Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6174772Z 136 packages are looking for funding
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6175232Z   run `npm fund` for details
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6375438Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6376030Z 14 vulnerabilities (1 low, 5 moderate, 6 high, 2 critical)
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6376505Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6376721Z To address all issues, run:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6377139Z   npm audit fix
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6377345Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6377543Z Run `npm audit` for details.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6502337Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6503125Z ✅ Version bump complete with synchronized package-lock.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6626166Z New version: 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6769462Z  D js/.changeset/fix-cicd-release-pipeline.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6770043Z  M js/CHANGELOG.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6770591Z  M js/package-lock.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6771011Z  M js/package.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.6776212Z Changes detected, committing...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.7091810Z [main 69f5461] 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.7092524Z  4 files changed, 9 insertions(+), 8 deletions(-)
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:42.7093399Z  delete mode 100644 js/.changeset/fix-cicd-release-pipeline.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6096207Z To https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6096815Z    4c80b8e..69f5461  main -> main
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6143497Z ✅ Version bump committed and pushed to main
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6249203Z ##[group]Run node ../scripts/publish-to-npm.mjs --should-pull
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6249629Z [36;1mnode ../scripts/publish-to-npm.mjs --should-pull[0m
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6271184Z shell: /usr/bin/bash -e {0}
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6271557Z env:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6271783Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6272089Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:43.6272329Z ##[endgroup]
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:44.7695067Z 📝 Loaded 2 variables from .lenv
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.1002735Z From https://github.com/link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.1003418Z  * branch            main       -> FETCH_HEAD
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.1063238Z Already up to date.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.1079594Z Current version to publish: 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.1080610Z Checking if version 1.4.1 is already published...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7726870Z npm error code E404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7727983Z npm error 404 No match found for version 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7728544Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7729186Z npm error 404  '@link-assistant/web-capture@1.4.1' is not in this registry.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7729789Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7730256Z npm error 404 Note that you can also install from a
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7731165Z npm error 404 tarball, folder, http url, or git url.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7739150Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T05_48_45_159Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7796749Z Version 1.4.1 not found on npm, proceeding with publish...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:45.7797350Z Publish attempt 1 of 3...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.0590595Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.0591603Z > @link-assistant/web-capture@1.4.1 prepare
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.0592056Z > husky || true
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.0592183Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7944026Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7945208Z npm warn publish errors corrected:
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7945860Z npm warn publish "bin[web-capture]" script name was cleaned
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7983441Z npm notice
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7985503Z npm notice 📦  @link-assistant/web-capture@1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7986345Z npm notice Tarball Contents
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7989271Z npm notice 271B .changeset/config.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7989836Z npm notice 510B .changeset/README.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7990517Z npm notice 390B .jscpd.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7990921Z npm notice 184B .lenv
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7991311Z npm notice 77B .prettierignore
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7991570Z npm notice 173B .prettierrc
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7991806Z npm notice 1.1kB CHANGELOG.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7992036Z npm notice 1.1kB Dockerfile
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7992254Z npm notice 13.4kB README.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7992505Z npm notice 178B babel.config.cjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7992781Z npm notice 23.9kB bin/web-capture.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7993071Z npm notice 148B docker-compose.yml
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7993444Z npm notice 3.4kB eslint.config.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7994026Z npm notice 1.5kB examples/js/engine_comparison.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7994649Z npm notice 675B examples/js/html_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7995283Z npm notice 1.1kB examples/js/image_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7995912Z npm notice 681B examples/js/markdown_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7996434Z npm notice 884B examples/js/playwright_example.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7997092Z npm notice 410B examples/python/html_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7997770Z npm notice 690B examples/python/image_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7998437Z npm notice 416B examples/python/markdown_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7999049Z npm notice 838B examples/python/playwright_example.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7999543Z npm notice 481B jest.config.mjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.7999964Z npm notice 3.1kB package.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8000544Z npm notice 9.0kB src/animation.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8000826Z npm notice 6.5kB src/archive.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8001334Z npm notice 5.2kB src/batch.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8001609Z npm notice 8.5kB src/browser.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8001844Z npm notice 5.4kB src/docx.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8002078Z npm notice 1.1kB src/fetch.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8002475Z npm notice 5.9kB src/figures.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8002723Z npm notice 10.1kB src/gdocs.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8002958Z npm notice 2.5kB src/html.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8003186Z npm notice 3.6kB src/image.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8003432Z npm notice 2.4kB src/index.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8003666Z npm notice 3.6kB src/latex.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8003890Z npm notice 17.0kB src/lib.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8004170Z npm notice 5.2kB src/localize-images.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8004465Z npm notice 543B src/markdown.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8004722Z npm notice 9.0kB src/metadata.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8005215Z npm notice 2.5kB src/pdf.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8005647Z npm notice 5.2kB src/popups.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8006111Z npm notice 7.5kB src/postprocess.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8006381Z npm notice 1.3kB src/retry.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8006623Z npm notice 1.3kB src/stream.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8006882Z npm notice 4.9kB src/themed-image.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8007153Z npm notice 9.3kB src/verify.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8007438Z npm notice 6.5kB tests/e2e/docker.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8007755Z npm notice 4.1kB tests/e2e/process.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8008086Z npm notice 1.2kB tests/fixtures/habr-articles.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8008476Z npm notice 6.9kB tests/integration/api-endpoints.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8008894Z npm notice 4.1kB tests/integration/browser-engines.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8009305Z npm notice 10.9kB tests/integration/habr-article.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8009643Z npm notice 190B tests/jest.setup.mjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8009934Z npm notice 6.7kB tests/mock/index.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8010256Z npm notice 1.1kB tests/unit/animation.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8010744Z npm notice 3.4kB tests/unit/batch.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8011062Z npm notice 6.2kB tests/unit/browser.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8011373Z npm notice 5.0kB tests/unit/cli.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8011749Z npm notice 1.6kB tests/unit/convertRelativeUrls.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8012201Z npm notice 2.3kB tests/unit/figures.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8012515Z npm notice 6.3kB tests/unit/gdocs.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8012828Z npm notice 19.6kB tests/unit/html2md.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8013133Z npm notice 4.1kB tests/unit/latex.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8013472Z npm notice 2.5kB tests/unit/localize-images.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8013818Z npm notice 4.5kB tests/unit/metadata.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8014169Z npm notice 3.4kB tests/unit/postprocess.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8014494Z npm notice 2.9kB tests/unit/retry.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8014796Z npm notice 5.3kB tests/unit/verify.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8015067Z npm notice Tarball Details
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8015365Z npm notice name: @link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8015651Z npm notice version: 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8015997Z npm notice filename: link-assistant-web-capture-1.4.1.tgz
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8016361Z npm notice package size: 69.5 kB
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8016967Z npm notice unpacked size: 292.1 kB
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8017558Z npm notice shasum: 201981c6e86af9fd94e8a23360cc3f426ada3fbe
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8018296Z npm notice integrity: sha512-QuVRT5vLSwKeb[...]8o1gUpRPZs/eQ==
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8018870Z npm notice total files: 69
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8019210Z npm notice
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:46.8019905Z npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.0347741Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.0349335Z npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1277242346
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2683400Z npm error code E404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2684782Z npm error 404 Not Found - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Not found
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2685697Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2686420Z npm error 404  '@link-assistant/web-capture@1.4.1' is not in this registry.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2687119Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2687996Z npm error 404 Note that you can also install from a
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2688747Z npm error 404 tarball, folder, http url, or git url.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2693558Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T05_48_45_831Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:48.2818782Z .git can't be foundVerifying publish...
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6292550Z npm error code E404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6293286Z npm error 404 No match found for version 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6293863Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6294349Z npm error 404  '@link-assistant/web-capture@1.4.1' is not in this registry.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6294806Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6295149Z npm error 404 Note that you can also install from a
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6295643Z npm error 404 tarball, folder, http url, or git url.
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6304873Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T05_48_51_338Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-11T05:48:51.6365701Z Publish failed: Publish verification failed: version 1.4.1 not found on npm after publish, waiting 10s before retry...
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:01.6464697Z Publish attempt 2 of 3...
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:01.9054297Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:01.9054863Z > @link-assistant/web-capture@1.4.1 prepare
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:01.9055378Z > husky || true
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:01.9055518Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6308701Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6309436Z npm warn publish errors corrected:
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6310046Z npm warn publish "bin[web-capture]" script name was cleaned
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6345157Z npm notice
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6346054Z npm notice 📦  @link-assistant/web-capture@1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6346685Z npm notice Tarball Contents
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6349726Z npm notice 271B .changeset/config.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6350317Z npm notice 510B .changeset/README.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6351156Z npm notice 390B .jscpd.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6351581Z npm notice 184B .lenv
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6352048Z npm notice 77B .prettierignore
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6352523Z npm notice 173B .prettierrc
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6352979Z npm notice 1.1kB CHANGELOG.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6353439Z npm notice 1.1kB Dockerfile
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6353882Z npm notice 13.4kB README.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6354376Z npm notice 178B babel.config.cjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6354922Z npm notice 23.9kB bin/web-capture.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6355490Z npm notice 148B docker-compose.yml
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6356032Z npm notice 3.4kB eslint.config.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6356642Z npm notice 1.5kB examples/js/engine_comparison.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6357256Z npm notice 675B examples/js/html_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6357906Z npm notice 1.1kB examples/js/image_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6358559Z npm notice 681B examples/js/markdown_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6359259Z npm notice 884B examples/js/playwright_example.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6359978Z npm notice 410B examples/python/html_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6360936Z npm notice 690B examples/python/image_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6361633Z npm notice 416B examples/python/markdown_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6362418Z npm notice 838B examples/python/playwright_example.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6363086Z npm notice 481B jest.config.mjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6363568Z npm notice 3.1kB package.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6364080Z npm notice 9.0kB src/animation.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6364579Z npm notice 6.5kB src/archive.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6365050Z npm notice 5.2kB src/batch.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6365545Z npm notice 8.5kB src/browser.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6365973Z npm notice 5.4kB src/docx.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6366380Z npm notice 1.1kB src/fetch.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6367146Z npm notice 5.9kB src/figures.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6367704Z npm notice 10.1kB src/gdocs.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6368168Z npm notice 2.5kB src/html.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6368610Z npm notice 3.6kB src/image.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6369442Z npm notice 2.4kB src/index.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6369832Z npm notice 3.6kB src/latex.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6370289Z npm notice 17.0kB src/lib.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6371061Z npm notice 5.2kB src/localize-images.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6371613Z npm notice 543B src/markdown.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6372341Z npm notice 9.0kB src/metadata.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6372727Z npm notice 2.5kB src/pdf.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6373201Z npm notice 5.2kB src/popups.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6373660Z npm notice 7.5kB src/postprocess.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6374089Z npm notice 1.3kB src/retry.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6374505Z npm notice 1.3kB src/stream.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6375005Z npm notice 4.9kB src/themed-image.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6375534Z npm notice 9.3kB src/verify.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6376101Z npm notice 6.5kB tests/e2e/docker.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6376733Z npm notice 4.1kB tests/e2e/process.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6377375Z npm notice 1.2kB tests/fixtures/habr-articles.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6378132Z npm notice 6.9kB tests/integration/api-endpoints.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6378895Z npm notice 4.1kB tests/integration/browser-engines.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6379688Z npm notice 10.9kB tests/integration/habr-article.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6380291Z npm notice 190B tests/jest.setup.mjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6381123Z npm notice 6.7kB tests/mock/index.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6381744Z npm notice 1.1kB tests/unit/animation.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6382432Z npm notice 3.4kB tests/unit/batch.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6383028Z npm notice 6.2kB tests/unit/browser.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6383635Z npm notice 5.0kB tests/unit/cli.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6384329Z npm notice 1.6kB tests/unit/convertRelativeUrls.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6385054Z npm notice 2.3kB tests/unit/figures.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6385694Z npm notice 6.3kB tests/unit/gdocs.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6386305Z npm notice 19.6kB tests/unit/html2md.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6386920Z npm notice 4.1kB tests/unit/latex.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6387563Z npm notice 2.5kB tests/unit/localize-images.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6388232Z npm notice 4.5kB tests/unit/metadata.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6388895Z npm notice 3.4kB tests/unit/postprocess.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6389480Z npm notice 2.9kB tests/unit/retry.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6390019Z npm notice 5.3kB tests/unit/verify.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6390766Z npm notice Tarball Details
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6391322Z npm notice name: @link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6391870Z npm notice version: 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6392542Z npm notice filename: link-assistant-web-capture-1.4.1.tgz
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6393239Z npm notice package size: 69.5 kB
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6393779Z npm notice unpacked size: 292.1 kB
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6394479Z npm notice shasum: 201981c6e86af9fd94e8a23360cc3f426ada3fbe
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6395351Z npm notice integrity: sha512-QuVRT5vLSwKeb[...]8o1gUpRPZs/eQ==
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6396015Z npm notice total files: 69
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6396417Z npm notice
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:02.6397258Z npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.4444609Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.4446175Z npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1277245255
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.6926569Z npm error code E404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.6927697Z npm error 404 Not Found - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Not found
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.6928573Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.6929278Z npm error 404  '@link-assistant/web-capture@1.4.1' is not in this registry.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.6930315Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.6931193Z npm error 404 Note that you can also install from a
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.6932028Z npm error 404 tarball, folder, http url, or git url.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.6935931Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T05_49_01_701Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:03.7047300Z .git can't be foundVerifying publish...
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0522416Z npm error code E404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0523049Z npm error 404 No match found for version 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0523593Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0524300Z npm error 404  '@link-assistant/web-capture@1.4.1' is not in this registry.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0524979Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0525494Z npm error 404 Note that you can also install from a
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0526193Z npm error 404 tarball, folder, http url, or git url.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0535243Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T05_49_06_763Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:07.0598199Z Publish failed: Publish verification failed: version 1.4.1 not found on npm after publish, waiting 10s before retry...
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:17.0702930Z Publish attempt 3 of 3...
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:17.3254566Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:17.3255293Z > @link-assistant/web-capture@1.4.1 prepare
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:17.3255664Z > husky || true
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:17.3255794Z 
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0524493Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0525560Z npm warn publish errors corrected:
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0526275Z npm warn publish "bin[web-capture]" script name was cleaned
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0566806Z npm notice
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0567855Z npm notice 📦  @link-assistant/web-capture@1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0568425Z npm notice Tarball Contents
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0571039Z npm notice 271B .changeset/config.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0571562Z npm notice 510B .changeset/README.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0571866Z npm notice 390B .jscpd.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0572183Z npm notice 184B .lenv
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0572639Z npm notice 77B .prettierignore
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0573103Z npm notice 173B .prettierrc
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0573575Z npm notice 1.1kB CHANGELOG.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0574033Z npm notice 1.1kB Dockerfile
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0574456Z npm notice 13.4kB README.md
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0574944Z npm notice 178B babel.config.cjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0575478Z npm notice 23.9kB bin/web-capture.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0576053Z npm notice 148B docker-compose.yml
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0576589Z npm notice 3.4kB eslint.config.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0576922Z npm notice 1.5kB examples/js/engine_comparison.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0577277Z npm notice 675B examples/js/html_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0577613Z npm notice 1.1kB examples/js/image_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0577950Z npm notice 681B examples/js/markdown_download.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0578305Z npm notice 884B examples/js/playwright_example.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0578671Z npm notice 410B examples/python/html_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0598698Z npm notice 690B examples/python/image_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0599224Z npm notice 416B examples/python/markdown_download.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0599662Z npm notice 838B examples/python/playwright_example.py
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0600238Z npm notice 481B jest.config.mjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0601622Z npm notice 3.1kB package.json
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0602083Z npm notice 9.0kB src/animation.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0602371Z npm notice 6.5kB src/archive.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0602629Z npm notice 5.2kB src/batch.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0603104Z npm notice 8.5kB src/browser.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0603508Z npm notice 5.4kB src/docx.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0603904Z npm notice 1.1kB src/fetch.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0604323Z npm notice 5.9kB src/figures.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0604752Z npm notice 10.1kB src/gdocs.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0605141Z npm notice 2.5kB src/html.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0605754Z npm notice 3.6kB src/image.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0606167Z npm notice 2.4kB src/index.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0606543Z npm notice 3.6kB src/latex.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0606769Z npm notice 17.0kB src/lib.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0607048Z npm notice 5.2kB src/localize-images.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0607524Z npm notice 543B src/markdown.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0607783Z npm notice 9.0kB src/metadata.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0608038Z npm notice 2.5kB src/pdf.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0608282Z npm notice 5.2kB src/popups.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0608555Z npm notice 7.5kB src/postprocess.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0608811Z npm notice 1.3kB src/retry.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0609241Z npm notice 1.3kB src/stream.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0609627Z npm notice 4.9kB src/themed-image.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0610020Z npm notice 9.3kB src/verify.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0610625Z npm notice 6.5kB tests/e2e/docker.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0611098Z npm notice 4.1kB tests/e2e/process.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0611595Z npm notice 1.2kB tests/fixtures/habr-articles.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0612297Z npm notice 6.9kB tests/integration/api-endpoints.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0613042Z npm notice 4.1kB tests/integration/browser-engines.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0613766Z npm notice 10.9kB tests/integration/habr-article.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0614371Z npm notice 190B tests/jest.setup.mjs
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0614887Z npm notice 6.7kB tests/mock/index.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0615457Z npm notice 1.1kB tests/unit/animation.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0616025Z npm notice 3.4kB tests/unit/batch.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0616420Z npm notice 6.2kB tests/unit/browser.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0616726Z npm notice 5.0kB tests/unit/cli.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0617078Z npm notice 1.6kB tests/unit/convertRelativeUrls.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0617422Z npm notice 2.3kB tests/unit/figures.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0617731Z npm notice 6.3kB tests/unit/gdocs.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0618037Z npm notice 19.6kB tests/unit/html2md.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0618349Z npm notice 4.1kB tests/unit/latex.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0618698Z npm notice 2.5kB tests/unit/localize-images.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0619034Z npm notice 4.5kB tests/unit/metadata.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0619363Z npm notice 3.4kB tests/unit/postprocess.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0619685Z npm notice 2.9kB tests/unit/retry.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0619977Z npm notice 5.3kB tests/unit/verify.test.js
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0620242Z npm notice Tarball Details
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0620904Z npm notice name: @link-assistant/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0621383Z npm notice version: 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0621803Z npm notice filename: link-assistant-web-capture-1.4.1.tgz
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0622152Z npm notice package size: 69.5 kB
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0622428Z npm notice unpacked size: 292.1 kB
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0622775Z npm notice shasum: 201981c6e86af9fd94e8a23360cc3f426ada3fbe
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0623212Z npm notice integrity: sha512-QuVRT5vLSwKeb[...]8o1gUpRPZs/eQ==
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0623547Z npm notice total files: 69
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0623832Z npm notice
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.0624575Z npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.8592774Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:18.8594391Z npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1277248091
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1325985Z npm error code E404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1328568Z npm error 404 Not Found - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Not found
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1329441Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1330164Z npm error 404  '@link-assistant/web-capture@1.4.1' is not in this registry.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1331170Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1331699Z npm error 404 Note that you can also install from a
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1332541Z npm error 404 tarball, folder, http url, or git url.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1336255Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T05_49_17_122Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:19.1452807Z .git can't be foundVerifying publish...
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5132987Z npm error code E404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5134029Z npm error 404 No match found for version 1.4.1
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5134617Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5135219Z npm error 404  '@link-assistant/web-capture@1.4.1' is not in this registry.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5135645Z npm error 404
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5135977Z npm error 404 Note that you can also install from a
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5136450Z npm error 404 tarball, folder, http url, or git url.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5145834Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-11T05_49_22_203Z-debug-0.log
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5209742Z ❌ Failed to publish after 3 attempts
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5278523Z ##[error]Process completed with exit code 1.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.5402145Z Post job cleanup.
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6337878Z [command]/usr/bin/git version
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6374566Z git version 2.53.0
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6418700Z Temporarily overriding HOME='/home/runner/work/_temp/0de5a55b-6f38-4759-a763-9afa9e175f03' before making global git config changes
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6419680Z Adding repository directory to the temporary git global config as a safe directory
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6431531Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/web-capture/web-capture
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6465079Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6497703Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6716016Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6735851Z http.https://github.com/.extraheader
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6748285Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6778093Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.6994857Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.7024720Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.7360025Z Cleaning up orphan processes
+JS - Release	UNKNOWN STEP	2026-04-11T05:49:22.7769637Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/js/.changeset/update-deps-and-cicd.md
+++ b/js/.changeset/update-deps-and-cicd.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Update lino-arguments to ^0.3.0, fix npm publish OIDC fallback, and align CI/CD workflows with reference repo best practices

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -16,7 +16,7 @@
         "express": "^4.18.2",
         "he": "^1.2.0",
         "iconv-lite": "^0.6.3",
-        "lino-arguments": "^0.2.5",
+        "lino-arguments": "^0.3.0",
         "node-fetch": "^2.7.0",
         "playwright": "^1.49.0",
         "puppeteer": "^24.8.2",
@@ -7926,9 +7926,9 @@
       "license": "Unlicense"
     },
     "node_modules/lino-arguments": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/lino-arguments/-/lino-arguments-0.2.5.tgz",
-      "integrity": "sha512-NyFNcE9EwuXmQ6DVnVA8GFoL5Dtm0gv9j99Tg8n8Z3HR0gkxuIprchItD8UGKiLsskxlcgk7LIbIao2V0vWeiQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/lino-arguments/-/lino-arguments-0.3.0.tgz",
+      "integrity": "sha512-46RbNaq0kpDxjyzBqhiCjPypHy9tuL0ITC9LgEolFH65PKtwl0/kRxryleG+5HnqS1JLnUUypZ2GoHWhLWH/PQ==",
       "license": "Unlicense",
       "dependencies": {
         "getenv": "^2.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -39,7 +39,7 @@
     "express": "^4.18.2",
     "he": "^1.2.0",
     "iconv-lite": "^0.6.3",
-    "lino-arguments": "^0.2.5",
+    "lino-arguments": "^0.3.0",
     "node-fetch": "^2.7.0",
     "playwright": "^1.49.0",
     "puppeteer": "^24.8.2",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -3249,16 +3249,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
-fsevents@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -4303,10 +4293,10 @@ links-notation@^0.11.2:
   resolved "https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz"
   integrity sha512-VPyELWBXpaCCiNPVeZhMbG7RuvOQR51nhqELK+s/rbSzKYhSs+tyiSOdQ7z8I7Kh3PLABF3bZETtWSFwx3vFfg==
 
-lino-arguments@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.npmjs.org/lino-arguments/-/lino-arguments-0.2.5.tgz"
-  integrity sha512-NyFNcE9EwuXmQ6DVnVA8GFoL5Dtm0gv9j99Tg8n8Z3HR0gkxuIprchItD8UGKiLsskxlcgk7LIbIao2V0vWeiQ==
+lino-arguments@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/lino-arguments/-/lino-arguments-0.3.0.tgz"
+  integrity sha512-46RbNaq0kpDxjyzBqhiCjPypHy9tuL0ITC9LgEolFH65PKtwl0/kRxryleG+5HnqS1JLnUUypZ2GoHWhLWH/PQ==
   dependencies:
     getenv "^2.0.0"
     links-notation "^0.11.2"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -62,15 +62,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.37"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -197,7 +197,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -228,7 +228,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -243,7 +243,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -291,7 +291,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -387,9 +387,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -471,18 +471,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -592,27 +592,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "brotli",
  "compression-core",
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie 0.18.1",
  "document-features",
@@ -695,6 +695,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -760,7 +770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -787,9 +797,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -802,7 +812,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -813,7 +823,7 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -855,7 +865,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -999,21 +1009,21 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1025,6 +1035,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1062,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1077,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1087,15 +1103,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1123,26 +1139,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -1152,9 +1168,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1164,7 +1180,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1215,8 +1230,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1252,9 +1280,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1317,7 +1354,7 @@ dependencies = [
  "markup5ever 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1390,9 +1427,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1405,7 +1442,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1413,15 +1449,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1445,14 +1480,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body",
@@ -1471,12 +1505,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1484,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1497,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1511,15 +1546,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1531,15 +1566,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1549,6 +1584,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -1573,25 +1614,27 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1605,9 +1648,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1617,7 +1660,7 @@ checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
 dependencies = [
  "cesu8",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1625,16 +1668,40 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1655,10 +1722,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
@@ -1697,15 +1770,15 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1785,7 +1858,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1805,9 +1878,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1827,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1838,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1870,15 +1943,15 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1888,9 +1961,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1909,20 +1982,20 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -2011,7 +2084,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2025,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2048,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -2062,15 +2135,15 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2095,6 +2168,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -2123,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2135,6 +2218,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2188,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2200,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2211,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2281,27 +2370,27 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2321,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2338,9 +2427,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2353,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2384,12 +2473,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2397,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2423,6 +2512,12 @@ dependencies = [
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2451,7 +2546,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2537,21 +2632,21 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2561,12 +2656,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2625,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2651,17 +2746,17 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2677,14 +2772,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2725,7 +2820,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2736,7 +2831,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2750,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2765,15 +2860,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2781,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2791,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -2808,13 +2903,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2944,7 +3039,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2970,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3018,9 +3113,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3033,6 +3128,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3135,10 +3236,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3149,23 +3259,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3173,24 +3279,58 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -3224,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3328,11 +3468,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3368,28 +3508,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3405,12 +3528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,12 +3538,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3441,22 +3552,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3471,12 +3570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3487,12 +3580,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3507,12 +3594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,12 +3604,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winreg"
@@ -3551,12 +3626,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xml5ever"
@@ -3571,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3582,54 +3739,54 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3641,9 +3798,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3652,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3663,13 +3820,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3688,15 +3845,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,6 +111,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,10 +156,170 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.3",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.3",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.3",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5359381fd414fbdb272c48f2111c16cb0bb3447bfacd59311ff3736da9f6664"
+dependencies = [
+ "async-std",
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -138,7 +331,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -169,7 +362,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -182,6 +375,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -191,6 +390,28 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "brotli"
@@ -214,6 +435,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "browser-commander"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5894b91b0917ec089bfc52157fdb67f5a3f58261ec8fe2137f0d3173a3b8ed"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chromiumoxide",
+ "dirs",
+ "fantoccini",
+ "futures",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +474,9 @@ name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -252,6 +499,74 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chromiumoxide"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380ce7721cc895fe8a184c49d615fe755b0c9a3d7986355cee847439fff907f"
+dependencies = [
+ "async-std",
+ "async-tungstenite",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chromiumoxide_cdp",
+ "chromiumoxide_types",
+ "dunce",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+ "which",
+ "winreg",
+]
+
+[[package]]
+name = "chromiumoxide_cdp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadbfb52fa0aeca43626f6c42ca04184b108b786f8e45198dc41a42aedcf2e50"
+dependencies = [
+ "chromiumoxide_pdl",
+ "chromiumoxide_types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_pdl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c197aeb42872c5d4c923e7d8ad46d99a58fd0fec37f6491554ff677a6791d3c9"
+dependencies = [
+ "chromiumoxide_types",
+ "either",
+ "heck 0.4.1",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923486888790528d55ac37ec2f7483ed19eb8ccbb44701878e5856d1ceadf5d8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "clap"
@@ -281,10 +596,10 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -328,6 +643,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,7 +678,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
 dependencies = [
- "cookie",
+ "cookie 0.18.1",
  "document-features",
  "idna",
  "log",
@@ -373,12 +707,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -401,8 +760,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
@@ -421,7 +802,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -432,7 +813,38 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -443,7 +855,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -454,6 +866,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -471,10 +889,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ego-tree"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -499,6 +944,57 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fantoccini"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a6a7a9a454c24453f9807c7f12b37e31ae43f3eb41888ae1f79a9a3e3be3f5"
+dependencies = [
+ "base64 0.22.1",
+ "cookie 0.18.1",
+ "futures-util",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "mime",
+ "openssl",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "url",
+ "webdriver",
 ]
 
 [[package]]
@@ -565,12 +1061,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -578,6 +1090,47 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "futures-sink"
@@ -592,13 +1145,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -611,6 +1175,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -646,6 +1220,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,7 +1242,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -672,9 +1258,30 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html-escape"
@@ -710,7 +1317,7 @@ dependencies = [
  "markup5ever 0.12.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -723,6 +1330,17 @@ dependencies = [
  "mac",
  "markup5ever 0.14.1",
  "match_token",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -742,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -753,7 +1371,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -781,7 +1399,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -799,7 +1417,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -831,12 +1449,12 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -1022,6 +1640,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1659,41 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lino-arguments"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be512a5c5eacea6ef5ec015fb0c7e1725c8e4cda1befd31606e203f281069968"
+dependencies = [
+ "clap",
+ "ctor",
+ "dotenvy",
+ "lino-env",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "lino-env"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f453c53827aabe91a3d3856d61d14ae3867ab1a4344db22f9fa5396664c8d0e"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1065,6 +1727,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "mac"
@@ -1120,7 +1785,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1244,7 +1909,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1264,6 +1929,18 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1334,7 +2011,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1359,10 +2036,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1378,6 +2080,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -1431,6 +2142,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -1439,6 +2162,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1447,6 +2173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1484,14 +2221,14 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
- "cookie",
+ "cookie 0.18.1",
  "cookie_store",
  "encoding_rs",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -1536,6 +2273,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -1543,7 +2293,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1701,7 +2451,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1747,6 +2497,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1853,6 +2614,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
@@ -1879,7 +2651,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1912,7 +2684,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1953,7 +2725,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1964,7 +2736,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2042,7 +2814,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2127,7 +2899,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "iri-string",
@@ -2172,7 +2944,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2221,10 +2993,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -2279,6 +3081,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -2372,7 +3180,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -2391,11 +3199,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "base64",
+ "base64 0.22.1",
+ "browser-commander",
  "clap",
  "encoding_rs",
  "html-escape",
  "html2md",
+ "lino-arguments",
  "regex",
  "reqwest",
  "scraper",
@@ -2420,6 +3230,38 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webdriver"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144ab979b12d36d65065635e646549925de229954de2eb3b47459b432a42db71"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "cookie 0.16.2",
+ "http 0.2.12",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "unicode-segmentation",
+ "url",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
 ]
 
 [[package]]
@@ -2468,6 +3310,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2491,6 +3342,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2528,6 +3394,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2540,6 +3412,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2549,6 +3427,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2576,6 +3460,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2585,6 +3475,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2600,6 +3496,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2612,6 +3514,12 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -2621,6 +3529,22 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -2664,7 +3588,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2685,7 +3609,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2705,7 +3629,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -2745,7 +3669,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/web-capture"
 readme = "README.md"
 keywords = ["web", "capture", "screenshot", "markdown", "html"]
 categories = ["command-line-utilities", "web-programming"]
-rust-version = "1.75"
+rust-version = "1.88"
 
 [lib]
 path = "src/lib.rs"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Browser automation using browser-commander from link-foundation
-browser-commander = { version = "0.9", optional = true }
+browser-commander = "0.9"
 
 # Unified configuration from CLI args, env vars, and .lenv files
 lino-arguments = "0.3"
@@ -74,10 +74,6 @@ html-escape = "0.2"
 
 # ZIP archive creation
 zip = { version = "4.0", default-features = false, features = ["deflate"] }
-
-[features]
-default = []
-browser = ["browser-commander"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,8 +20,10 @@ path = "src/main.rs"
 
 [dependencies]
 # Browser automation using browser-commander from link-foundation
-# Note: browser-commander is available but optional, as it requires Chrome to be installed
-# browser-commander = "0.4"
+browser-commander = { version = "0.9", optional = true }
+
+# Unified configuration from CLI args, env vars, and .lenv files
+lino-arguments = "0.3"
 
 # Async runtime
 tokio = { version = "1.0", features = ["full"] }
@@ -72,6 +74,10 @@ html-escape = "0.2"
 
 # ZIP archive creation
 zip = { version = "4.0", default-features = false, features = ["deflate"] }
+
+[features]
+default = []
+browser = ["browser-commander"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.83-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 
 WORKDIR /app
 

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -100,24 +100,29 @@ async function main() {
     // Strategy:
     // 1. Try OIDC trusted publishing (npm publish --provenance --access public)
     // 2. If OIDC fails with 404 (not configured on npmjs.org), fall back to token-based auth
-    // 3. If token-based auth also fails, try changeset publish as last resort
     for (let i = 1; i <= MAX_RETRIES; i++) {
       console.log(`Publish attempt ${i} of ${MAX_RETRIES}...`);
       try {
         // Try OIDC trusted publishing first
         console.log('Trying OIDC trusted publishing...');
-        const publishResult = await $`npm publish --provenance --access public`.run({ capture: true });
-
-        if (publishResult.code !== 0) {
-          const stderr = publishResult.stderr || '';
+        let oidcFailed = false;
+        try {
+          await $`npm publish --provenance --access public`;
+        } catch (oidcError) {
+          const errorMsg = oidcError.message || '';
           // 404 on PUT means OIDC trusted publishing is not configured for this package
-          if (stderr.includes('404') || stderr.includes('Not Found')) {
-            console.log('OIDC trusted publishing not configured for this package, trying token-based publish...');
-            // Fall back to token-based auth (uses NODE_AUTH_TOKEN from environment)
-            await $`npm publish --access public`;
+          if (errorMsg.includes('404') || errorMsg.includes('Not Found') || errorMsg.includes('E404')) {
+            console.log('OIDC trusted publishing returned 404 (not configured for this package scope)');
+            oidcFailed = true;
           } else {
-            throw new Error(`npm publish failed: ${stderr}`);
+            throw oidcError;
           }
+        }
+
+        if (oidcFailed) {
+          // Fall back to token-based auth (uses NODE_AUTH_TOKEN from environment)
+          console.log('Falling back to token-based publish...');
+          await $`npm publish --access public`;
         }
 
         // Verify the version was actually published

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -96,18 +96,33 @@ async function main() {
       );
     }
 
-    // Publish to npm using direct npm publish with retry logic
-    // Note: We use `npm publish` directly instead of `changeset publish` because
-    // `changeset publish` does not properly support OIDC trusted publishing for
-    // scoped packages and does not propagate publish failures (exits 0 on error).
+    // Publish to npm with retry logic
+    // Strategy:
+    // 1. Try OIDC trusted publishing (npm publish --provenance --access public)
+    // 2. If OIDC fails with 404 (not configured on npmjs.org), fall back to token-based auth
+    // 3. If token-based auth also fails, try changeset publish as last resort
     for (let i = 1; i <= MAX_RETRIES; i++) {
       console.log(`Publish attempt ${i} of ${MAX_RETRIES}...`);
       try {
-        await $`npm publish --provenance --access public`;
+        // Try OIDC trusted publishing first
+        console.log('Trying OIDC trusted publishing...');
+        const publishResult = await $`npm publish --provenance --access public`.run({ capture: true });
+
+        if (publishResult.code !== 0) {
+          const stderr = publishResult.stderr || '';
+          // 404 on PUT means OIDC trusted publishing is not configured for this package
+          if (stderr.includes('404') || stderr.includes('Not Found')) {
+            console.log('OIDC trusted publishing not configured for this package, trying token-based publish...');
+            // Fall back to token-based auth (uses NODE_AUTH_TOKEN from environment)
+            await $`npm publish --access public`;
+          } else {
+            throw new Error(`npm publish failed: ${stderr}`);
+          }
+        }
 
         // Verify the version was actually published
         console.log('Verifying publish...');
-        await sleep(3000); // Wait for npm registry to propagate
+        await sleep(5000);
         const verifyResult =
           await $`npm view "${PACKAGE_NAME}@${currentVersion}" version`.run({
             capture: true,

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -96,33 +96,35 @@ async function main() {
       );
     }
 
-    // Publish to npm with retry logic
-    // Strategy:
-    // 1. Try OIDC trusted publishing (npm publish --provenance --access public)
-    // 2. If OIDC fails with 404 (not configured on npmjs.org), fall back to token-based auth
+    // Publish to npm with retry logic using OIDC trusted publishing
     for (let i = 1; i <= MAX_RETRIES; i++) {
       console.log(`Publish attempt ${i} of ${MAX_RETRIES}...`);
       try {
-        // Try OIDC trusted publishing first
-        console.log('Trying OIDC trusted publishing...');
-        let oidcFailed = false;
+        console.log('Publishing with OIDC trusted publishing...');
         try {
           await $`npm publish --provenance --access public`;
-        } catch (oidcError) {
-          const errorMsg = oidcError.message || '';
-          // 404 on PUT means OIDC trusted publishing is not configured for this package
+        } catch (publishError) {
+          const errorMsg = publishError.message || String(publishError);
           if (errorMsg.includes('404') || errorMsg.includes('Not Found') || errorMsg.includes('E404')) {
-            console.log('OIDC trusted publishing returned 404 (not configured for this package scope)');
-            oidcFailed = true;
-          } else {
-            throw oidcError;
+            console.error(`\n\u274C OIDC trusted publishing is not configured for ${PACKAGE_NAME} on npmjs.org.`);
+            console.error(`\nThe first version of a package must be published manually to establish the package on the registry.`);
+            console.error(`After manual publish, configure OIDC trusted publishing on npmjs.org for automated CI/CD releases.\n`);
+            console.error(`To publish manually, run these commands locally:\n`);
+            console.error(`  1. Log in to npm:`);
+            console.error(`     npm login`);
+            console.error(`  2. Navigate to the JS package directory:`);
+            console.error(`     cd js`);
+            console.error(`  3. Publish the package:`);
+            console.error(`     npm publish --access public`);
+            console.error(`  4. Configure OIDC trusted publishing on npmjs.org:`);
+            console.error(`     - Go to https://www.npmjs.com/package/${PACKAGE_NAME}/access`);
+            console.error(`     - Under "Publishing access", add a trusted publisher`);
+            console.error(`     - Set repository to: ${process.env.GITHUB_REPOSITORY || 'link-assistant/web-capture'}`);
+            console.error(`     - Set workflow to: js.yml`);
+            console.error(`     - Set environment to: (leave empty or set to your environment name)\n`);
+            process.exit(1);
           }
-        }
-
-        if (oidcFailed) {
-          // Fall back to token-based auth (uses NODE_AUTH_TOKEN from environment)
-          console.log('Falling back to token-based publish...');
-          await $`npm publish --access public`;
+          throw publishError;
         }
 
         // Verify the version was actually published


### PR DESCRIPTION
## Summary

Fixes #44

- **Fix npm publish OIDC error handling**: The `publish-to-npm.mjs` script now fails with a clear error message and detailed manual publish instructions when OIDC trusted publishing returns 404 (not configured on npmjs.org for the `@link-assistant` scope). No token-based fallback — tokens are not used.
- **Update JS dependencies**: `lino-arguments` from `^0.2.5` to `^0.3.0` (latest)
- **Make browser-commander required in Rust**: `browser-commander` `0.9` is now a required dependency (not optional/feature-gated), matching the issue requirement to use it by default in both JavaScript and Rust
- **Enable Rust dependencies**: `lino-arguments` `0.3` added to `Cargo.toml`
- **Align CI/CD workflows with reference repo best practices**:
  - Add `cancel-in-progress: true` to concurrency settings
  - Add `CARGO_TERM_COLOR` and `RUSTFLAGS` environment variables
  - Add cache `restore-keys` for partial cache hits
  - Add `--verbose` flag to Rust test commands
  - Add `cargo package --list --allow-dirty` build verification
  - Add `changelog-pr` manual release mode to Rust workflow
  - Align all Node.js versions to 22.x (matching `engines` field)
  - Add explicit `token` parameter in checkout for release jobs

## Root Cause Analysis

The CI failure in [run 24275913722](https://github.com/link-assistant/web-capture/actions/runs/24275913722) was caused by:

1. **Primary**: npm OIDC trusted publishing not configured for `@link-assistant` scope on npmjs.org. The `npm publish --provenance --access public` command signed provenance successfully but the registry returned `404 Not Found` on the PUT request.
2. **Secondary**: Node.js 22.22.2 on GitHub Actions runners has a broken npm 10.9.7 missing `promise-retry` module ([actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883)). The existing fallback logic in `setup-npm.mjs` handles this.

Full analysis in [docs/case-studies/issue-44/README.md](https://github.com/link-assistant/web-capture/blob/issue-44-5fc8fd3303bb/docs/case-studies/issue-44/README.md).

## Feedback Addressed

- **Removed token-based publish fallback** (per [reviewer feedback](https://github.com/link-assistant/web-capture/pull/45#issuecomment-4234567277)): When OIDC 404 occurs, the script now fails immediately with clear instructions for manual first-time publish and OIDC configuration
- **Made browser-commander non-optional in Rust** (per reviewer feedback): Removed the `browser` feature gate — `browser-commander` is now a required dependency, used by default in both JS and Rust

## Related Issues

- Reported [link-foundation/rust-ai-driven-development-pipeline-template#26](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/26) for missing cache restore-keys and checkout token in the template

## Test Plan

- [x] Rust `cargo check` passes with browser-commander as required dependency
- [x] Rust `cargo test` passes (8 tests + 2 doc tests)
- [x] `npm install --package-lock-only` succeeds with updated lino-arguments
- [x] CI workflow syntax validated (YAML structure correct)
- [ ] CI pipeline runs on this PR to verify workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)