### PR TITLE
fix: fallback to CARGO_TOKEN and fail instead of skip when publishing to crates.io

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
+  CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
 
 defaults:
   run:
@@ -182,7 +184,8 @@ jobs:
         if: steps.version_check.outputs.should_release == 'true'
         id: publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
         run: node ../scripts/rust-publish-crate.mjs
 
       - name: Create GitHub Release
@@ -231,7 +234,8 @@ jobs:
         if: steps.version.outputs.version_committed == 'true'
         id: publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
         run: node ../scripts/rust-publish-crate.mjs
 
       - name: Create GitHub Release

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
+# Updated: 2026-04-13T08:16:46.192Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
-# Updated: 2026-04-13T08:16:46.192Z

--- a/docs/case-studies/issue-46/README.md
+++ b/docs/case-studies/issue-46/README.md
@@ -75,7 +75,7 @@ Priority 3: No token → exit(1) with clear error message
 
 ## Template Repo Issue
 
-The `rust-ai-driven-development-pipeline-template` has a minor inconsistency: the workflow-level env uses `secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN` fallback, but publish steps hardcode only `secrets.CARGO_TOKEN`. This means if only `CARGO_REGISTRY_TOKEN` is configured, the per-step env would be empty (though the script compensates). This was reported as an issue.
+The `rust-ai-driven-development-pipeline-template` has a minor inconsistency: the workflow-level env uses `secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN` fallback, but publish steps hardcode only `secrets.CARGO_TOKEN`. This means if only `CARGO_REGISTRY_TOKEN` is configured, the per-step env would be empty (though the script compensates). Reported as [link-foundation/rust-ai-driven-development-pipeline-template#32](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/32).
 
 ## Verification
 

--- a/docs/case-studies/issue-46/README.md
+++ b/docs/case-studies/issue-46/README.md
@@ -1,0 +1,88 @@
+# Case Study: Issue #46 — CARGO_TOKEN Fallback and Fail-on-Missing-Token
+
+## Problem Statement
+
+The Rust CI/CD release pipeline silently skipped publishing to crates.io when `CARGO_REGISTRY_TOKEN` was not configured, instead of either:
+1. Falling back to `CARGO_TOKEN` (which may be configured at the organization level)
+2. Failing with a clear error message
+
+## Timeline
+
+- **2026-04-13T08:00:46Z**: Rust CI run [24332395778](https://github.com/link-assistant/web-capture/actions/runs/24332395778) triggered on push to `main` (commit `63157e6`)
+- **2026-04-13T08:13:25Z**: Release job runs `rust-version-check.mjs`, determines `should_release=true` for version `0.1.0`
+- **2026-04-13T08:13:28Z**: Publish step starts, `CARGO_REGISTRY_TOKEN` is empty
+- **2026-04-13T08:13:29Z**: Script outputs `CARGO_REGISTRY_TOKEN not set, skipping publish` and exits with code 0 (success)
+- **Result**: No crate published, no error surfaced, no GitHub release created (since `published=false`)
+
+## Root Cause Analysis
+
+### Root Cause 1: Missing CARGO_TOKEN Fallback
+
+The `rust-publish-crate.mjs` script only checked `process.env.CARGO_REGISTRY_TOKEN` (line 71). The organization may use `CARGO_TOKEN` as the secret name (this is the convention used in `browser-commander`, `lino-arguments`, and `Numbers` repos within the same organization).
+
+**Evidence from CI log** (`ci-logs/rust-24332395778.log`):
+```
+Rust - Release  Publish to crates.io  CARGO_REGISTRY_TOKEN: 
+Rust - Release  Publish to crates.io  Current version to publish: 0.1.0
+Rust - Release  Publish to crates.io  CARGO_REGISTRY_TOKEN not set, skipping publish
+Rust - Release  Publish to crates.io  Output: published=false
+Rust - Release  Publish to crates.io  Output: skipped=true
+```
+
+### Root Cause 2: Silent Skip Instead of Failure
+
+When no token was available, the script exited with code 0 and `published=false`. This made the overall CI run appear successful while no crate was actually published. The issue states: "we should not skip publish, but always fail if we cannot publish."
+
+### Root Cause 3: Inconsistent Token Handling Across Reference Repos
+
+All four reference repos (`browser-commander`, `lino-arguments`, `Numbers`, `rust-ai-driven-development-pipeline-template`) use a dual-token fallback pattern, but `web-capture` did not follow this convention.
+
+## Reference Repository Comparison
+
+| Feature | web-capture (before) | browser-commander | lino-arguments | Numbers | template |
+|---------|---------------------|-------------------|----------------|---------|----------|
+| CARGO_REGISTRY_TOKEN support | ✅ | ✅ | ✅ | ✅ | ✅ |
+| CARGO_TOKEN fallback | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Fail on missing token | ❌ (skip) | ⚠️ (warn) | ⚠️ (warn) | ⚠️ (warn) | ⚠️ (warn) |
+| crates.io pre-check | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Explicit --token flag | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Auth failure diagnostics | ❌ | ✅ | ❌ | ✅ | ✅ |
+| Workflow-level token env | ❌ | ✅ | ✅ | ✅ | ✅ |
+
+## Solution
+
+### Changes Made
+
+1. **`scripts/rust-publish-crate.mjs`**:
+   - Token resolution: `CARGO_REGISTRY_TOKEN || CARGO_TOKEN` with priority chain
+   - Fail with `exit(1)` and `::error::` annotation when no token is available
+   - Pre-check crates.io API before attempting publish (avoids unnecessary attempts)
+   - Pass token explicitly via `cargo publish --token` flag
+   - Add authentication failure diagnostics with remediation guidance
+   - Read crate name dynamically from `Cargo.toml`
+
+2. **`.github/workflows/rust.yml`**:
+   - Add workflow-level `CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}`
+   - Update both `release` and `instant-release` publish steps to pass both token env vars
+
+### Token Resolution Chain
+
+```
+Priority 1: CARGO_REGISTRY_TOKEN (cargo's native env var, preferred)
+Priority 2: CARGO_TOKEN (backwards compatible, used by org-level secrets)
+Priority 3: No token → exit(1) with clear error message
+```
+
+## Template Repo Issue
+
+The `rust-ai-driven-development-pipeline-template` has a minor inconsistency: the workflow-level env uses `secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN` fallback, but publish steps hardcode only `secrets.CARGO_TOKEN`. This means if only `CARGO_REGISTRY_TOKEN` is configured, the per-step env would be empty (though the script compensates). This was reported as an issue.
+
+## Verification
+
+- Token resolution logic tested via `experiments/test-token-resolution.mjs` (5 test cases, all passing)
+- CI pipeline runs on PR to verify workflow syntax and test pass
+
+## Files
+
+- `rust-ci-run-24332395778.log` — Full Rust CI log showing the failed publish
+- `js-ci-run-24332395802.log` — JS CI log from the same commit (for reference)

--- a/experiments/test-token-resolution.mjs
+++ b/experiments/test-token-resolution.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+/**
+ * Test token resolution logic from rust-publish-crate.mjs
+ * Verifies the fallback chain: CARGO_REGISTRY_TOKEN > CARGO_TOKEN > error
+ *
+ * Usage: node experiments/test-token-resolution.mjs
+ */
+
+function resolveToken(env) {
+  return env.CARGO_REGISTRY_TOKEN || env.CARGO_TOKEN || '';
+}
+
+function getTokenSource(env) {
+  if (env.CARGO_REGISTRY_TOKEN) return 'CARGO_REGISTRY_TOKEN';
+  if (env.CARGO_TOKEN) return 'CARGO_TOKEN';
+  return 'none';
+}
+
+const tests = [
+  {
+    name: 'Both tokens set — prefers CARGO_REGISTRY_TOKEN',
+    env: { CARGO_REGISTRY_TOKEN: 'registry-tok', CARGO_TOKEN: 'cargo-tok' },
+    expectedToken: 'registry-tok',
+    expectedSource: 'CARGO_REGISTRY_TOKEN',
+  },
+  {
+    name: 'Only CARGO_REGISTRY_TOKEN set',
+    env: { CARGO_REGISTRY_TOKEN: 'registry-tok', CARGO_TOKEN: '' },
+    expectedToken: 'registry-tok',
+    expectedSource: 'CARGO_REGISTRY_TOKEN',
+  },
+  {
+    name: 'Only CARGO_TOKEN set — fallback works',
+    env: { CARGO_REGISTRY_TOKEN: '', CARGO_TOKEN: 'cargo-tok' },
+    expectedToken: 'cargo-tok',
+    expectedSource: 'CARGO_TOKEN',
+  },
+  {
+    name: 'Neither token set — should fail',
+    env: { CARGO_REGISTRY_TOKEN: '', CARGO_TOKEN: '' },
+    expectedToken: '',
+    expectedSource: 'none',
+  },
+  {
+    name: 'CARGO_REGISTRY_TOKEN undefined, CARGO_TOKEN set',
+    env: { CARGO_TOKEN: 'cargo-tok' },
+    expectedToken: 'cargo-tok',
+    expectedSource: 'CARGO_TOKEN',
+  },
+];
+
+let passed = 0;
+let failed = 0;
+
+for (const test of tests) {
+  const token = resolveToken(test.env);
+  const source = getTokenSource(test.env);
+  const tokenOk = token === test.expectedToken;
+  const sourceOk = source === test.expectedSource;
+
+  if (tokenOk && sourceOk) {
+    console.log(`✅ PASS: ${test.name}`);
+    passed++;
+  } else {
+    console.log(`❌ FAIL: ${test.name}`);
+    if (!tokenOk)
+      console.log(`   token: got "${token}", expected "${test.expectedToken}"`);
+    if (!sourceOk)
+      console.log(
+        `   source: got "${source}", expected "${test.expectedSource}"`
+      );
+    failed++;
+  }
+}
+
+console.log(`\n${passed} passed, ${failed} failed, ${tests.length} total`);
+process.exit(failed > 0 ? 1 : 0);

--- a/js/.changeset/fix-cargo-token-fallback.md
+++ b/js/.changeset/fix-cargo-token-fallback.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Fix cargo publish token resolution: fallback to CARGO_TOKEN when CARGO_REGISTRY_TOKEN is not set, and fail instead of silently skipping publish

--- a/scripts/rust-publish-crate.mjs
+++ b/scripts/rust-publish-crate.mjs
@@ -5,11 +5,13 @@
  * Usage: node scripts/rust-publish-crate.mjs
  *
  * Environment variables:
- *   CARGO_REGISTRY_TOKEN: Token for crates.io authentication
+ *   CARGO_REGISTRY_TOKEN: Token for crates.io authentication (preferred)
+ *   CARGO_TOKEN: Fallback token for backwards compatibility
  *
  * Outputs:
  *   published: true if publish succeeded
  *   published_version: The published version
+ *   publish_result: success, already_exists, or failed
  *
  * Uses link-foundation libraries:
  * - use-m: Dynamic package loading without package.json dependencies
@@ -29,19 +31,10 @@ const { $ } = await use('command-stream');
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 10000; // 10 seconds
 
-/**
- * Sleep for specified milliseconds
- * @param {number} ms
- */
 function sleep(ms) {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
-/**
- * Append to GitHub Actions output file
- * @param {string} key
- * @param {string} value
- */
 function setOutput(key, value) {
   const outputFile = process.env.GITHUB_OUTPUT;
   if (outputFile) {
@@ -50,9 +43,6 @@ function setOutput(key, value) {
   console.log(`Output: ${key}=${value}`);
 }
 
-/**
- * Extract version from Cargo.toml
- */
 function getCargoVersion() {
   const cargoToml = readFileSync('./Cargo.toml', 'utf8');
   const match = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
@@ -62,44 +52,121 @@ function getCargoVersion() {
   return match[1];
 }
 
+function getCrateName() {
+  const cargoToml = readFileSync('./Cargo.toml', 'utf8');
+  const match = cargoToml.match(/^name\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error('Could not find name in Cargo.toml');
+  }
+  return match[1];
+}
+
+async function checkCratesIo(crateName, version) {
+  try {
+    const response = await fetch(
+      `https://crates.io/api/v1/crates/${crateName}/${version}`
+    );
+    if (response.ok) {
+      return { exists: true };
+    }
+    return { exists: false };
+  } catch {
+    return { exists: false };
+  }
+}
+
 try {
-  // Get current version
+  const crateName = getCrateName();
   const currentVersion = getCargoVersion();
+  console.log(`Crate: ${crateName}`);
   console.log(`Current version to publish: ${currentVersion}`);
 
-  // Check if CARGO_REGISTRY_TOKEN is set
-  if (!process.env.CARGO_REGISTRY_TOKEN) {
-    console.log('CARGO_REGISTRY_TOKEN not set, skipping publish');
+  // Resolve token: CARGO_REGISTRY_TOKEN (cargo's native env var) > CARGO_TOKEN (backwards compat)
+  const token =
+    process.env.CARGO_REGISTRY_TOKEN || process.env.CARGO_TOKEN || '';
+
+  if (!token) {
+    console.error(
+      '::error::Neither CARGO_REGISTRY_TOKEN nor CARGO_TOKEN is set.'
+    );
+    console.error(
+      'Publishing requires a crates.io API token. Configure one of these secrets:'
+    );
+    console.error(
+      '  - CARGO_REGISTRY_TOKEN (preferred, cargo\'s native env var)'
+    );
+    console.error('  - CARGO_TOKEN (backwards compatibility)');
     setOutput('published', 'false');
-    setOutput('skipped', 'true');
+    setOutput('publish_result', 'failed');
+    process.exit(1);
+  }
+
+  console.log(
+    `Token source: ${process.env.CARGO_REGISTRY_TOKEN ? 'CARGO_REGISTRY_TOKEN' : 'CARGO_TOKEN'}`
+  );
+
+  // Pre-check crates.io to see if this version is already published
+  console.log(`Checking crates.io for ${crateName}@${currentVersion}...`);
+  const cratesCheck = await checkCratesIo(crateName, currentVersion);
+  if (cratesCheck.exists) {
+    console.log(
+      `Version ${currentVersion} is already published on crates.io`
+    );
+    setOutput('published', 'true');
+    setOutput('published_version', currentVersion);
+    setOutput('publish_result', 'already_exists');
+    setOutput('already_published', 'true');
     process.exit(0);
   }
 
-  // Publish to crates.io with retry logic
+  // Publish to crates.io with retry logic, passing token explicitly via --token
   for (let i = 1; i <= MAX_RETRIES; i++) {
     console.log(`Publish attempt ${i} of ${MAX_RETRIES}...`);
     try {
-      await $`cargo publish --allow-dirty`;
+      await $`cargo publish --allow-dirty --token ${token}`;
       setOutput('published', 'true');
       setOutput('published_version', currentVersion);
-      console.log(`Published web-capture@${currentVersion} to crates.io`);
+      setOutput('publish_result', 'success');
+      console.log(`Published ${crateName}@${currentVersion} to crates.io`);
       process.exit(0);
     } catch (error) {
-      // Check if the error is because it's already published
-      if (
-        error.message &&
-        error.message.includes('already uploaded')
-      ) {
+      const msg = error.message || '';
+
+      if (msg.includes('already uploaded') || msg.includes('already exists')) {
         console.log(`Version ${currentVersion} is already published`);
         setOutput('published', 'true');
         setOutput('published_version', currentVersion);
+        setOutput('publish_result', 'already_exists');
         setOutput('already_published', 'true');
         process.exit(0);
       }
 
+      if (
+        msg.includes('non-empty token') ||
+        msg.includes('unauthorized') ||
+        msg.includes('authentication')
+      ) {
+        console.error('::error::AUTHENTICATION FAILURE');
+        console.error(
+          'The provided token was rejected by crates.io. Verify:'
+        );
+        console.error(
+          '  1. The token is valid and not expired'
+        );
+        console.error(
+          '  2. The token has publish scope for this crate'
+        );
+        console.error(
+          '  3. The correct secret (CARGO_REGISTRY_TOKEN or CARGO_TOKEN) is configured'
+        );
+        setOutput('published', 'false');
+        setOutput('publish_result', 'failed');
+        process.exit(1);
+      }
+
       if (i < MAX_RETRIES) {
         console.log(
-          `Publish failed: ${error.message}, waiting ${RETRY_DELAY / 1000}s before retry...`
+          `Publish failed: ${msg}, waiting ${RETRY_DELAY / 1000}s before retry...`
         );
         await sleep(RETRY_DELAY);
       }
@@ -107,6 +174,8 @@ try {
   }
 
   console.error(`Failed to publish after ${MAX_RETRIES} attempts`);
+  setOutput('published', 'false');
+  setOutput('publish_result', 'failed');
   process.exit(1);
 } catch (error) {
   console.error('Error:', error.message);


### PR DESCRIPTION
## Summary

Fixes #46

- **Fix token fallback**: `rust-publish-crate.mjs` now resolves the crates.io token from `CARGO_REGISTRY_TOKEN` (preferred) or `CARGO_TOKEN` (backwards compatibility), matching the convention used across `browser-commander`, `lino-arguments`, `Numbers`, and the `rust-ai-driven-development-pipeline-template`
- **Fail instead of skip**: When neither token is configured, the script now fails with `exit(1)` and a clear `::error::` annotation, instead of silently exiting with code 0 and `published=false`
- **Pre-check crates.io API**: Before attempting `cargo publish`, checks the crates.io API to detect already-published versions (avoids unnecessary publish attempts)
- **Explicit --token flag**: Token is passed explicitly via `cargo publish --token` rather than relying solely on env var detection
- **Auth failure diagnostics**: Detects authentication errors and provides remediation guidance
- **Workflow token fallback**: Both `release` and `instant-release` jobs now pass `CARGO_REGISTRY_TOKEN` and `CARGO_TOKEN` with the `||` fallback chain

## Root Cause

The CI log from [run 24332395778](https://github.com/link-assistant/web-capture/actions/runs/24332395778) shows:

```
CARGO_REGISTRY_TOKEN: 
Current version to publish: 0.1.0
CARGO_REGISTRY_TOKEN not set, skipping publish
Output: published=false
Output: skipped=true
```

The `CARGO_REGISTRY_TOKEN` secret was empty, and the script had no fallback to `CARGO_TOKEN`. It also exited with code 0 (success) instead of failing.

Full analysis in [docs/case-studies/issue-46/README.md](https://github.com/link-assistant/web-capture/blob/issue-46-74be9b28b867/docs/case-studies/issue-46/README.md).

## Related Issues

- Reported [link-foundation/rust-ai-driven-development-pipeline-template#32](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/32) — publish steps in the template override the workflow-level token fallback chain, affecting all downstream repos

## Test Plan

- [x] Token resolution logic tested via `experiments/test-token-resolution.mjs` (5 test cases, all passing)
- [x] CI lint checks pass (cargo fmt, clippy)
- [x] CI tests pass on all platforms (ubuntu, macos, windows)
- [ ] After merge: verify publish step uses the correct token and publishes to crates.io (requires `CARGO_REGISTRY_TOKEN` or `CARGO_TOKEN` secret to be configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)