### PR TITLE
fix: hoist heading images before html2md to prevent silent drops (#62)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
+# Updated: 2026-04-14T15:38:45.969Z

--- a/docs/case-studies/issue-62/analysis.md
+++ b/docs/case-studies/issue-62/analysis.md
@@ -1,0 +1,69 @@
+# Case Study: Issue #62 — `<img>` inside headings dropped from markdown
+
+## Timeline
+
+1. **Issue #58** — Original archive pipeline fixes identified multiple bugs (A, B, C).
+2. **v0.3.0** — Fixed bugs A and C; bug B (heading-nested images dropped in markdown) remained.
+3. **Issue #62** — Filed as the residual of bug B from #58.
+4. **PR #63** — Fix implemented.
+
+## Root Cause Analysis
+
+### The reported bug
+
+The `html2md` crate's heading handler (`<h1>`..<h6>`) was reported to recurse only into text/inline-text children, silently dropping `<img>` elements. This created a count mismatch:
+
+- `extract_base64_images()` uses a regex over raw HTML — finds N images regardless of parent element
+- `html2md::parse_html()` converts to markdown — drops images inside headings, producing N-1 refs
+
+### Investigation findings
+
+Testing with `html2md` v0.2.15 (the version resolved by `Cargo.toml`'s `html2md = "0.2"`) showed that **the bug no longer reproduces** in the current dependency version. All heading levels (h1-h6) correctly preserve `<img>` elements, including Google Docs-style HTML with nested `<span>` wrappers.
+
+The bug was likely present in an earlier minor version of `html2md` 0.2.x and was fixed upstream. Since the `Cargo.toml` specifies `html2md = "0.2"` (allowing any 0.2.x), the fix came in automatically via a dependency update.
+
+### Why a defensive fix is still warranted
+
+1. **Semver-minor changes** — `html2md = "0.2"` allows any `0.2.x`. A future release could regress.
+2. **No upstream guarantee** — The `html2md` crate doesn't document heading-image behavior as a guarantee.
+3. **Defense in depth** — Pre-processing HTML to hoist images out of headings is a cheap, safe operation that eliminates the entire class of bugs.
+
+## Solution
+
+### Approach: Option A (pre-processing)
+
+Added `hoist_images_from_headings()` in `rust/src/markdown.rs`:
+
+- Regex-based: for each heading level (h1-h6), finds `<img>` tags inside the heading
+- Moves them to `<p>` blocks after the heading
+- Runs before `html2md::parse_html()`
+
+This approach was chosen over Option B (replacing html2md) because:
+- Minimal code change (44 lines)
+- No new dependencies
+- Preserves the existing conversion pipeline
+- html2md works correctly for all other cases
+
+### Test coverage
+
+| Test | Location | What it verifies |
+|------|----------|-----------------|
+| `img_inside_heading_is_kept_in_markdown` | `rust/tests/integration/gdocs_image_parity.rs` | Issue's exact reproduction case |
+| `img_inside_all_heading_levels_is_kept` | Same file | All h1-h6 levels |
+| `gdocs_style_heading_with_spans_keeps_img` | Same file | Google Docs HTML with span wrappers |
+| `image_count_parity_across_pipeline` | Same file | Full pipeline: extraction count == HTML count == markdown count |
+| JS heading-image tests (3) | `js/tests/unit/heading-image.test.js` | Guard rail for JS/Turndown parity |
+
+## Requirements Checklist (from issue)
+
+- [x] Rust: `img_inside_heading_is_kept_in_markdown` test added and passes
+- [x] Rust: fix via pre-processing (Option A)
+- [x] JS: parallel parity test added as guard rail
+- [x] Broader parity test: `image_count_parity_across_pipeline` asserts `md_ref_count == html_img_count == image_file_count`
+
+## References
+
+- Issue: https://github.com/link-assistant/web-capture/issues/62
+- PR: https://github.com/link-assistant/web-capture/pull/63
+- Related: #58 (original archive pipeline fixes), #53 (original archive pipeline)
+- `html2md` crate: https://crates.io/crates/html2md (v0.2.15)

--- a/experiments/heading_img_bug.rs
+++ b/experiments/heading_img_bug.rs
@@ -1,0 +1,35 @@
+// Experiment: Verify that html2md drops <img> inside headings
+// Run with: cargo test --test experiment_heading_img -- --nocapture
+// Or as a standalone script via the web-capture crate tests
+
+use web_capture::gdocs::extract_base64_images;
+use web_capture::markdown::convert_html_to_markdown;
+
+const PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+fn main() {
+    let html = format!(
+        r#"<html><body>
+<h1><img src="data:image/png;base64,{b}" alt=""> Title With Image</h1>
+<p>Body <img src="data:image/png;base64,{b}" alt=""> paragraph.</p>
+</body></html>"#,
+        b = PNG_B64
+    );
+
+    let (local_html, images) = extract_base64_images(&html);
+    println!("Extracted images: {}", images.len());
+    println!("Local HTML:\n{}", local_html);
+
+    let md = convert_html_to_markdown(&local_html, None).unwrap();
+    println!("\nMarkdown output:\n{}", md);
+
+    let md_refs = md.matches("](images/").count();
+    println!("\nImage refs in markdown: {}", md_refs);
+    println!("Images extracted: {}", images.len());
+
+    if md_refs != images.len() {
+        println!("BUG CONFIRMED: markdown refs ({}) != extracted images ({})", md_refs, images.len());
+    } else {
+        println!("OK: counts match");
+    }
+}

--- a/experiments/test_heading_img.rs
+++ b/experiments/test_heading_img.rs
@@ -1,0 +1,13 @@
+// Quick experiment to verify html2md drops <img> inside headings
+#[test]
+fn html2md_drops_img_in_heading() {
+    let html_heading = r#"<h1><img src="images/image-01.png" alt="icon"> Title</h1>"#;
+    let md = html2md::parse_html(html_heading);
+    println!("Heading img MD: {:?}", md);
+    // This will show that the image is dropped
+
+    let html_para = r#"<p>Text <img src="images/image-01.png" alt="icon"> more</p>"#;
+    let md2 = html2md::parse_html(html_para);
+    println!("Paragraph img MD: {:?}", md2);
+    // This should preserve the image
+}

--- a/js/.changeset/fix-heading-image-parity.md
+++ b/js/.changeset/fix-heading-image-parity.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Add heading-image parity guard rail tests to prevent <img> inside headings from being silently dropped during HTML-to-Markdown conversion

--- a/js/tests/unit/heading-image.test.js
+++ b/js/tests/unit/heading-image.test.js
@@ -1,0 +1,49 @@
+import { convertHtmlToMarkdown } from '../../src/lib.js';
+import { extractBase64Images } from '../../src/gdocs.js';
+
+const PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+
+const IMG_REF_PATTERN = /!\[[^\]]*\]\([^)]*images\/[^)]+\)/g;
+
+describe('heading image parity', () => {
+  it('<img> inside <h1> survives Turndown and stays in sync with extraction', () => {
+    const html = `<html><body><h1>Title <img src="data:image/png;base64,${PNG_B64}" alt="x"></h1><p>Body</p></body></html>`;
+
+    const { html: localHtml, images } = extractBase64Images(html);
+    const md = convertHtmlToMarkdown(localHtml);
+    const mdImgCount = (md.match(IMG_REF_PATTERN) || []).length;
+
+    expect(images).toHaveLength(1);
+    expect(mdImgCount).toBe(images.length);
+  });
+
+  it('<img> inside all heading levels is preserved', () => {
+    for (let level = 1; level <= 6; level++) {
+      const tag = `h${level}`;
+      const html = `<html><body><${tag}><img src="data:image/png;base64,${PNG_B64}" alt="icon"> Heading</${tag}></body></html>`;
+
+      const { html: localHtml, images } = extractBase64Images(html);
+      const md = convertHtmlToMarkdown(localHtml);
+      const refs = (md.match(IMG_REF_PATTERN) || []).length;
+
+      expect(refs).toBe(images.length);
+    }
+  });
+
+  it('image count parity across full pipeline', () => {
+    const html = `<html><body>
+<h1><img src="data:image/png;base64,${PNG_B64}" alt="h1"> Chapter</h1>
+<p>Text <img src="data:image/png;base64,${PNG_B64}" alt="p1"> here.</p>
+<h2><img src="data:image/png;base64,${PNG_B64}" alt="h2"> Section</h2>
+<p><img src="data:image/png;base64,${PNG_B64}" alt="p2"></p>
+</body></html>`;
+
+    const { html: localHtml, images } = extractBase64Images(html);
+    const md = convertHtmlToMarkdown(localHtml);
+    const mdRefCount = (md.match(IMG_REF_PATTERN) || []).length;
+
+    expect(images).toHaveLength(4);
+    expect(mdRefCount).toBe(images.length);
+  });
+});

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "web-capture"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-capture"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "CLI and microservice to render web pages as HTML, Markdown, or PNG"
 license = "Unlicense"

--- a/rust/src/markdown.rs
+++ b/rust/src/markdown.rs
@@ -4,6 +4,7 @@
 
 use crate::html::convert_relative_urls;
 use crate::Result;
+use regex::Regex;
 use scraper::{Html, Selector};
 use tracing::{debug, info};
 
@@ -36,8 +37,13 @@ pub fn convert_html_to_markdown(html: &str, base_url: Option<&str>) -> Result<St
     // Parse and clean the HTML
     let cleaned_html = clean_html(&processed_html);
 
+    // Move <img> elements out of headings so html2md always sees them.
+    // Some html2md versions only emit text children for <h1>..<h6>,
+    // silently dropping inline images.
+    let heading_safe_html = hoist_images_from_headings(&cleaned_html);
+
     // Convert to Markdown using html2md
-    let markdown = html2md::parse_html(&cleaned_html);
+    let markdown = html2md::parse_html(&heading_safe_html);
 
     // Decode HTML entities to unicode characters
     let decoded_markdown = crate::html::decode_html_entities(&markdown);
@@ -91,6 +97,50 @@ fn clean_html(html: &str) -> String {
     }
 
     cleaned
+}
+
+/// Move `<img>` tags out of `<h1>`..`<h6>` elements.
+///
+/// Rewrites `<hN>...<img ...>...text</hN>` →
+/// `<hN>...text</hN>\n<p><img ...></p>` so that any HTML→Markdown
+/// converter sees the images at block level.
+fn hoist_images_from_headings(html: &str) -> String {
+    use std::fmt::Write;
+
+    let img_re = Regex::new(r"<img\s[^>]*>").expect("valid regex");
+    let mut result = html.to_string();
+
+    for level in 1..=6 {
+        let heading_re = Regex::new(
+            &format!(r"(?si)(<h{level}\b[^>]*>)(.*?)(</h{level}>)")
+        ).expect("valid regex");
+
+        result = heading_re
+            .replace_all(&result, |caps: &regex::Captures<'_>| {
+                let open = &caps[1];
+                let inner = &caps[2];
+                let close = &caps[3];
+
+                let imgs: Vec<&str> = img_re
+                    .find_iter(inner)
+                    .map(|m| m.as_str())
+                    .collect();
+
+                if imgs.is_empty() {
+                    return caps[0].to_string();
+                }
+
+                let stripped = img_re.replace_all(inner, "").to_string();
+                let mut out = format!("{open}{stripped}{close}");
+                for img in imgs {
+                    write!(out, "\n<p>{img}</p>").expect("write to String");
+                }
+                out
+            })
+            .into_owned();
+    }
+
+    result
 }
 
 /// Clean up Markdown output

--- a/rust/src/markdown.rs
+++ b/rust/src/markdown.rs
@@ -111,9 +111,8 @@ fn hoist_images_from_headings(html: &str) -> String {
     let mut result = html.to_string();
 
     for level in 1..=6 {
-        let heading_re = Regex::new(
-            &format!(r"(?si)(<h{level}\b[^>]*>)(.*?)(</h{level}>)")
-        ).expect("valid regex");
+        let heading_re = Regex::new(&format!(r"(?si)(<h{level}\b[^>]*>)(.*?)(</h{level}>)"))
+            .expect("valid regex");
 
         result = heading_re
             .replace_all(&result, |caps: &regex::Captures<'_>| {
@@ -121,10 +120,7 @@ fn hoist_images_from_headings(html: &str) -> String {
                 let inner = &caps[2];
                 let close = &caps[3];
 
-                let imgs: Vec<&str> = img_re
-                    .find_iter(inner)
-                    .map(|m| m.as_str())
-                    .collect();
+                let imgs: Vec<&str> = img_re.find_iter(inner).map(|m| m.as_str()).collect();
 
                 if imgs.is_empty() {
                     return caps[0].to_string();

--- a/rust/tests/integration/gdocs_image_parity.rs
+++ b/rust/tests/integration/gdocs_image_parity.rs
@@ -1,0 +1,101 @@
+use web_capture::gdocs::extract_base64_images;
+use web_capture::markdown::convert_html_to_markdown;
+
+const PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+#[test]
+fn img_inside_heading_is_kept_in_markdown() {
+    let html = format!(
+        r#"<html><body>
+<h1><img src="data:image/png;base64,{PNG_B64}" alt=""> Title With Image</h1>
+<p>Body <img src="data:image/png;base64,{PNG_B64}" alt=""> paragraph.</p>
+</body></html>"#
+    );
+
+    let (local_html, images) = extract_base64_images(&html);
+    assert_eq!(images.len(), 2, "two images should be extracted to files");
+
+    let md = convert_html_to_markdown(&local_html, None).unwrap();
+    let md_refs = md.matches("](images/").count();
+
+    assert_eq!(
+        md_refs,
+        images.len(),
+        "markdown image refs ({md_refs}) must match extracted image files ({}). MD:\n{md}",
+        images.len(),
+    );
+}
+
+#[test]
+fn img_inside_all_heading_levels_is_kept() {
+    for level in 1..=6 {
+        let open = format!("<h{level}>");
+        let close = format!("</h{level}>");
+        let html = format!(
+            r#"<html><body>{open}<img src="data:image/png;base64,{PNG_B64}" alt="icon"> Heading {level}{close}</body></html>"#
+        );
+
+        let (local_html, images) = extract_base64_images(&html);
+        assert_eq!(images.len(), 1, "h{level}: one image extracted");
+
+        let md = convert_html_to_markdown(&local_html, None).unwrap();
+        let refs = md.matches("](images/").count();
+        assert_eq!(
+            refs, 1,
+            "h{level}: image ref missing from markdown. MD:\n{md}"
+        );
+    }
+}
+
+#[test]
+fn gdocs_style_heading_with_spans_keeps_img() {
+    let html = format!(
+        r#"<html><head><style>body{{margin:0}}</style></head><body>
+<h1 id="h.abc" class="c12"><span class="c4"><img src="data:image/png;base64,{PNG_B64}" alt="" style="width:32px"></span><span class="c4"> Title</span></h1>
+<p class="c5"><span><img src="data:image/png;base64,{PNG_B64}" alt=""></span><span> Body.</span></p>
+</body></html>"#
+    );
+
+    let (local_html, images) = extract_base64_images(&html);
+    assert_eq!(images.len(), 2);
+
+    let md = convert_html_to_markdown(&local_html, None).unwrap();
+    let refs = md.matches("](images/").count();
+    assert_eq!(
+        refs,
+        images.len(),
+        "GDocs-style heading lost image. MD:\n{md}"
+    );
+}
+
+#[test]
+fn image_count_parity_across_pipeline() {
+    let html = format!(
+        r#"<html><body>
+<h1><img src="data:image/png;base64,{PNG_B64}" alt="h1"> Chapter</h1>
+<p>Text <img src="data:image/png;base64,{PNG_B64}" alt="p1"> here.</p>
+<h2><img src="data:image/png;base64,{PNG_B64}" alt="h2"> Section</h2>
+<p><img src="data:image/png;base64,{PNG_B64}" alt="p2"></p>
+<h3>No image heading</h3>
+<p>Final <img src="data:image/png;base64,{PNG_B64}" alt="p3"> paragraph.</p>
+</body></html>"#
+    );
+
+    let (local_html, images) = extract_base64_images(&html);
+    let html_img_count = local_html.matches("<img ").count();
+    let md = convert_html_to_markdown(&local_html, None).unwrap();
+    let md_ref_count = md.matches("](images/").count();
+
+    assert_eq!(
+        html_img_count,
+        images.len(),
+        "HTML img tags ({html_img_count}) != extracted files ({})",
+        images.len()
+    );
+    assert_eq!(
+        md_ref_count,
+        images.len(),
+        "MD refs ({md_ref_count}) != extracted files ({}). MD:\n{md}",
+        images.len()
+    );
+}

--- a/rust/tests/integration/gdocs_image_parity.rs
+++ b/rust/tests/integration/gdocs_image_parity.rs
@@ -1,7 +1,8 @@
 use web_capture::gdocs::extract_base64_images;
 use web_capture::markdown::convert_html_to_markdown;
 
-const PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+const PNG_B64: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 
 #[test]
 fn img_inside_heading_is_kept_in_markdown() {

--- a/rust/tests/integration/mod.rs
+++ b/rust/tests/integration/mod.rs
@@ -3,4 +3,5 @@ mod batch;
 mod browser;
 mod figures;
 mod gdocs;
+mod gdocs_image_parity;
 mod themed_image;


### PR DESCRIPTION
## Summary

- **Defensive pre-processing**: Added `hoist_images_from_headings()` in `rust/src/markdown.rs` that moves `<img>` elements out of `<h1>..<h6>` into adjacent `<p>` blocks before calling `html2md::parse_html()`. This prevents silent image drops regardless of which html2md version is used.
- **Rust regression tests**: 4 integration tests in `rust/tests/integration/gdocs_image_parity.rs` covering all heading levels (h1-h6), Google Docs-style HTML with spans, and full pipeline image-count parity.
- **JS parity tests**: 3 unit tests in `js/tests/unit/heading-image.test.js` confirming Turndown preserves heading images (guard rail against future library changes).
- **Version bump**: Rust crate `0.3.0` → `0.3.1`.

## Investigation findings

Testing with `html2md` v0.2.15 (currently resolved by `Cargo.toml`'s `html2md = "0.2"`) showed that the library **already preserves** `<img>` inside headings. The bug likely manifested with an earlier html2md version. The defensive pre-processing ensures this class of bug cannot recur even if html2md behavior changes in a future update.

## Test plan

- [x] `cargo test` — all 88 tests + 2 doc-tests pass (no regressions)
- [x] `cargo clippy --all-targets` — no new warnings
- [x] JS `jest tests/unit/heading-image.test.js` — all 3 tests pass
- [x] Verified image refs in markdown match extracted image count for h1-h6, Google Docs-style HTML, and multi-image documents

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)