### PR TITLE
fix(ci): resolve npm publish E422 by adding repository field to package.json

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -32,9 +32,12 @@ on:
         required: false
         type: string
 
+# Concurrency: Only one workflow run per branch at a time
+# - For main branch (releases): cancel older runs to prevent blocking newer releases
+# - For PR branches: queue runs to avoid cancelling checks on force-pushes
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 defaults:
   run:
@@ -369,7 +372,7 @@ jobs:
           echo "Formatted changeset files"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore(js): add changeset for manual ${{ github.event.inputs.bump_type }} release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,9 +29,12 @@ on:
         required: false
         type: string
 
+# Concurrency: Only one workflow run per branch at a time
+# - For main branch (releases): cancel older runs to prevent blocking newer releases
+# - For PR branches: queue runs to avoid cancelling checks on force-pushes
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -358,7 +361,7 @@ jobs:
           node ../scripts/rust-version-bump.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore(rust): bump version (${{ github.event.inputs.bump_type }})'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-04-14T16:33:04.810Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-04-14T16:33:04.810Z

--- a/ci-logs/js-template-tree.txt
+++ b/ci-logs/js-template-tree.txt
@@ -1,0 +1,136 @@
+tree  .changeset
+blob  .changeset/README.md (510 bytes)
+blob  .changeset/config.json (271 bytes)
+tree  .github
+tree  .github/workflows
+blob  .github/workflows/links.yml (3035 bytes)
+blob  .github/workflows/release.yml (19369 bytes)
+blob  .gitignore (2178 bytes)
+blob  .gitkeep (204 bytes)
+tree  .husky
+blob  .husky/pre-commit (16 bytes)
+blob  .jscpd.json (390 bytes)
+blob  .lycheeignore (721 bytes)
+blob  .prettierignore (166 bytes)
+blob  .prettierrc (173 bytes)
+blob  .secretlintrc.json (92 bytes)
+blob  CHANGELOG.md (7475 bytes)
+blob  LICENSE (1211 bytes)
+blob  README.md (9322 bytes)
+blob  bunfig.toml (136 bytes)
+blob  deno.json (121 bytes)
+tree  docs
+blob  docs/BEST-PRACTICES.md (7560 bytes)
+blob  docs/CONTRIBUTING.md (4675 bytes)
+tree  docs/case-studies
+tree  docs/case-studies/issue-13
+blob  docs/case-studies/issue-13/README.md (7506 bytes)
+blob  docs/case-studies/issue-13/hive-mind-issue-960.json (2202 bytes)
+blob  docs/case-studies/issue-13/hive-mind-pr-961-diff.txt (27983 bytes)
+blob  docs/case-studies/issue-13/hive-mind-pr-961.json (6745 bytes)
+tree  docs/case-studies/issue-21
+blob  docs/case-studies/issue-21/README.md (14434 bytes)
+tree  docs/case-studies/issue-21/ci-logs
+blob  docs/case-studies/issue-21/ci-logs/run-20803315337.txt (133670 bytes)
+blob  docs/case-studies/issue-21/ci-logs/run-20885464993.txt (155417 bytes)
+blob  docs/case-studies/issue-21/issue-111-data.txt (700 bytes)
+blob  docs/case-studies/issue-21/issue-113-data.txt (708 bytes)
+blob  docs/case-studies/issue-21/pr-112-data.json (4967 bytes)
+blob  docs/case-studies/issue-21/pr-112-diff.patch (140742 bytes)
+blob  docs/case-studies/issue-21/pr-114-data.json (7852 bytes)
+blob  docs/case-studies/issue-21/pr-114-diff.patch (31790 bytes)
+tree  docs/case-studies/issue-23
+blob  docs/case-studies/issue-23/README.md (9202 bytes)
+tree  docs/case-studies/issue-23/data
+blob  docs/case-studies/issue-23/data/hive-mind-check-version.mjs (3689 bytes)
+blob  docs/case-studies/issue-23/data/hive-mind-ci.yml (3 bytes)
+blob  docs/case-studies/issue-23/data/hive-mind-eslint.config.mjs (2312 bytes)
+blob  docs/case-studies/issue-23/data/hive-mind-release.yml (85858 bytes)
+blob  docs/case-studies/issue-23/data/issue-1126-details.txt (485 bytes)
+blob  docs/case-studies/issue-23/data/issue-1141-comments.json (2 bytes)
+blob  docs/case-studies/issue-23/data/issue-1141-details.txt (1151 bytes)
+blob  docs/case-studies/issue-23/data/pr-1127-conversation-comments.json (17911 bytes)
+blob  docs/case-studies/issue-23/data/pr-1127-diff.txt (11091 bytes)
+blob  docs/case-studies/issue-23/data/pr-1127-review-comments.json (2 bytes)
+blob  docs/case-studies/issue-23/data/pr-1142-conversation-comments.json (8054 bytes)
+blob  docs/case-studies/issue-23/data/pr-1142-diff.txt (27946 bytes)
+blob  docs/case-studies/issue-23/data/pr-1142-review-comments.json (2 bytes)
+tree  docs/case-studies/issue-25
+blob  docs/case-studies/issue-25/DETAILED-COMPARISON.md (17912 bytes)
+blob  docs/case-studies/issue-25/README.md (10084 bytes)
+tree  docs/case-studies/issue-25/data
+blob  docs/case-studies/issue-25/data/hive-mind-file-tree.txt (84928 bytes)
+blob  docs/case-studies/issue-25/data/issue-1274-case-study.md (9175 bytes)
+blob  docs/case-studies/issue-25/data/issue-1278-case-study.md (13738 bytes)
+blob  docs/case-studies/issue-25/data/template-file-tree.txt (3372 bytes)
+tree  docs/case-studies/issue-29
+blob  docs/case-studies/issue-29/README.md (6303 bytes)
+tree  docs/case-studies/issue-3
+blob  docs/case-studies/issue-3/README.md (10928 bytes)
+blob  docs/case-studies/issue-3/created-issues.md (1274 bytes)
+blob  docs/case-studies/issue-3/issue-data.json (4625 bytes)
+blob  docs/case-studies/issue-3/original-format-release-notes.mjs (7649 bytes)
+blob  docs/case-studies/issue-3/reference-pr-59-diff.txt (23744 bytes)
+blob  docs/case-studies/issue-3/reference-pr-59.json (7914 bytes)
+blob  docs/case-studies/issue-3/release-v0.1.0.json (1008 bytes)
+blob  docs/case-studies/issue-3/repositories-with-same-script.json (771 bytes)
+blob  docs/case-studies/issue-3/research-notes.md (1394 bytes)
+tree  docs/case-studies/issue-31
+blob  docs/case-studies/issue-31/README.md (4832 bytes)
+blob  docs/case-studies/issue-31/web-capture-pr49-commits.json (2633 bytes)
+tree  docs/case-studies/issue-33
+blob  docs/case-studies/issue-33/README.md (7513 bytes)
+tree  docs/case-studies/issue-33/ci-logs
+blob  docs/case-studies/issue-33/ci-logs/release-24395209194.txt (786370 bytes)
+blob  docs/case-studies/issue-33/ci-logs/upstream-nodejs-62430.json (2053 bytes)
+blob  docs/case-studies/issue-33/ci-logs/upstream-npm-cli-9151.json (6870 bytes)
+blob  docs/case-studies/issue-33/ci-logs/upstream-runner-images-13883.json (4055 bytes)
+tree  docs/case-studies/issue-36
+blob  docs/case-studies/issue-36/README.md (5048 bytes)
+tree  docs/case-studies/issue-36/ci-logs
+blob  docs/case-studies/issue-36/ci-logs/release-24399965550.txt (845925 bytes)
+tree  docs/case-studies/issue-7
+blob  docs/case-studies/issue-7/BEST-PRACTICES-COMPARISON.md (9478 bytes)
+blob  docs/case-studies/issue-7/FORMATTER-COMPARISON.md (17660 bytes)
+blob  docs/case-studies/issue-7/current-repository-analysis.json (1988 bytes)
+blob  docs/case-studies/issue-7/effect-template-analysis.json (4644 bytes)
+blob  eslint.config.js (2850 bytes)
+tree  examples
+blob  examples/basic-usage.js (747 bytes)
+tree  experiments
+blob  experiments/test-changeset-scripts.mjs (8385 bytes)
+blob  experiments/test-check-release-needed.mjs (2751 bytes)
+blob  experiments/test-detect-changes.mjs (4045 bytes)
+blob  experiments/test-failure-detection.mjs (4472 bytes)
+blob  experiments/test-format-major-changes.mjs (1557 bytes)
+blob  experiments/test-format-minor-changes.mjs (1766 bytes)
+blob  experiments/test-format-no-hash.mjs (1284 bytes)
+blob  experiments/test-format-patch-changes.mjs (1460 bytes)
+blob  package-lock.json (144505 bytes)
+blob  package.json (1709 bytes)
+tree  scripts
+blob  scripts/changeset-version.mjs (2667 bytes)
+blob  scripts/check-changesets.mjs (1729 bytes)
+blob  scripts/check-file-line-limits.sh (1634 bytes)
+blob  scripts/check-mjs-syntax.sh (634 bytes)
+blob  scripts/check-release-needed.mjs (4050 bytes)
+blob  scripts/check-version.mjs (3737 bytes)
+blob  scripts/check-web-archive.mjs (8314 bytes)
+blob  scripts/create-github-release.mjs (2927 bytes)
+blob  scripts/create-manual-changeset.mjs (2738 bytes)
+blob  scripts/detect-code-changes.mjs (4899 bytes)
+blob  scripts/format-github-release.mjs (2871 bytes)
+blob  scripts/format-release-notes.mjs (8176 bytes)
+blob  scripts/instant-version-bump.mjs (5925 bytes)
+blob  scripts/js-paths.mjs (5686 bytes)
+blob  scripts/merge-changesets.mjs (6385 bytes)
+blob  scripts/publish-to-npm.mjs (9615 bytes)
+blob  scripts/setup-npm.mjs (3701 bytes)
+blob  scripts/simulate-fresh-merge.sh (2007 bytes)
+blob  scripts/validate-changeset.mjs (8043 bytes)
+blob  scripts/version-and-commit.mjs (9584 bytes)
+tree  src
+blob  src/index.d.ts (651 bytes)
+blob  src/index.js (694 bytes)
+tree  tests
+blob  tests/index.test.js (783 bytes)

--- a/ci-logs/rust-template-tree.txt
+++ b/ci-logs/rust-template-tree.txt
@@ -1,0 +1,113 @@
+# File Tree: link-foundation/rust-ai-driven-development-pipeline-template
+# Branch: main
+# Root SHA: 1dd6d81da270f30e5355bca43cc67bc953bec583
+
+TYPE      SIZE  PATH
+------------------------------------------------------------
+tree            .github
+tree            .github/workflows
+blob     16372  .github/workflows/release.yml
+blob       859  .gitignore
+blob       836  .pre-commit-config.yaml
+blob     47562  CHANGELOG.md
+blob      7201  CONTRIBUTING.md
+blob      8837  Cargo.lock
+blob      1242  Cargo.toml
+blob      1211  LICENSE
+blob     11715  README.md
+tree            changelog.d
+blob       608  changelog.d/20251227_224645_changeset_support.md
+blob       432  changelog.d/20251229_143823_fix_ci_workflow_dependencies.md
+blob       286  changelog.d/20251231_115800_fix_readme_script_references.md
+blob       830  changelog.d/20260107_apply_best_practices.md
+blob       857  changelog.d/20260108_171124_fix_changelog_check.md
+blob       455  changelog.d/20260108_171435_prevent_manual_version_modification.md
+blob       497  changelog.d/20260108_apply_lino_objects_codec_fixes.md
+blob       694  changelog.d/20260111_multi_language_support.md
+blob      1137  changelog.d/20260119_best_practices_from_browser_commander.md
+blob       383  changelog.d/20260311_translate_scripts_to_rust.md
+blob      1052  changelog.d/20260413-ci-cd-best-practices.md
+blob       474  changelog.d/20260413_fix_cargo_token_fallback.md
+blob       658  changelog.d/20260413_fix_crates_io_check.md
+blob       742  changelog.d/20260413_fix_lookahead_regex.md
+blob       231  changelog.d/20260414_fix_per_commit_diff.md
+blob      3235  changelog.d/README.md
+tree            docs
+tree            docs/case-studies
+tree            docs/case-studies/issue-11
+blob      8907  docs/case-studies/issue-11/README.md
+blob      6801  docs/case-studies/issue-11/analysis-crates-io.md
+blob      4331  docs/case-studies/issue-11/analysis-set-output.md
+blob      5375  docs/case-studies/issue-11/analysis-workflow-dispatch.md
+blob      6372  docs/case-studies/issue-11/online-research.md
+tree            docs/case-studies/issue-17
+blob      5870  docs/case-studies/issue-17/README.md
+tree            docs/case-studies/issue-19
+blob     10930  docs/case-studies/issue-19/README.md
+tree            docs/case-studies/issue-19/ci-logs
+blob     20042  docs/case-studies/issue-19/ci-logs/ci-run-20885464993.log.gz
+tree            docs/case-studies/issue-19/pr-114-data
+blob       708  docs/case-studies/issue-19/pr-114-data/issue-113-details.txt
+blob      3550  docs/case-studies/issue-19/pr-114-data/pr-commits.json
+blob      8310  docs/case-studies/issue-19/pr-114-data/pr-conversation-comments.json
+blob      6727  docs/case-studies/issue-19/pr-114-data/pr-details.json
+blob     31790  docs/case-studies/issue-19/pr-114-data/pr-diff.patch
+blob         2  docs/case-studies/issue-19/pr-114-data/pr-review-comments.json
+blob         2  docs/case-studies/issue-19/pr-114-data/pr-reviews.json
+blob     89348  docs/case-studies/issue-19/pr-114-data/solution-draft-log-1.txt.gz
+blob     69878  docs/case-studies/issue-19/pr-114-data/solution-draft-log-2.txt.gz
+tree            docs/case-studies/issue-21
+blob      9651  docs/case-studies/issue-21/README.md
+blob      3766  docs/case-studies/issue-21/browser-commander-issue-27.md
+blob      5448  docs/case-studies/issue-21/browser-commander-issue-29.md
+blob      4224  docs/case-studies/issue-21/browser-commander-issue-31.md
+blob      6909  docs/case-studies/issue-21/browser-commander-issue-33.md
+blob     14865  docs/case-studies/issue-21/browser-commander-rust.yml
+tree            docs/case-studies/issue-25
+blob      4724  docs/case-studies/issue-25/README.md
+tree            docs/case-studies/issue-29
+blob      6614  docs/case-studies/issue-29/README.md
+tree            docs/case-studies/issue-32
+blob      5520  docs/case-studies/issue-32/README.md
+tree            docs/case-studies/issue-34
+blob      7573  docs/case-studies/issue-34/README.md
+tree            docs/ci-cd
+blob      6373  docs/ci-cd/troubleshooting.md
+tree            examples
+blob       183  examples/basic_usage.rs
+tree            experiments
+blob      3100  experiments/test-changelog-parsing.rs
+blob      2946  experiments/test-crates-io-check.rs
+blob      3146  experiments/test-detect-code-changes.sh
+blob       812  experiments/test-version-check-dependencies.sh
+blob      1420  experiments/test-version-check.sh
+tree            scripts
+blob      5190  scripts/bump-version.rs
+blob      5230  scripts/check-changelog-fragment.rs
+blob      2764  scripts/check-file-size.rs
+blob      9444  scripts/check-release-needed.rs
+blob      4917  scripts/check-version-modification.rs
+blob      7325  scripts/collect-changelog.rs
+blob      3280  scripts/create-changelog-fragment.rs
+blob      7005  scripts/create-github-release.rs
+blob      7070  scripts/detect-code-changes.rs
+blob      5331  scripts/get-bump-type.rs
+blob      3082  scripts/get-version.rs
+blob      1953  scripts/git-config.rs
+blob      7905  scripts/publish-crate.rs
+blob      4922  scripts/rust-paths.rs
+blob     18766  scripts/version-and-commit.rs
+tree            src
+blob        32  src/lib.rs
+blob       444  src/main.rs
+blob        66  src/sum.rs
+tree            tests
+tree            tests/integration
+blob         9  tests/integration/mod.rs
+blob      1059  tests/integration/sum.rs
+tree            tests/unit
+tree            tests/unit/ci-cd
+blob      2308  tests/unit/ci-cd/changelog_parsing.rs
+blob        23  tests/unit/ci-cd/mod.rs
+blob        46  tests/unit/mod.rs
+blob       417  tests/unit/sum.rs

--- a/docs/case-studies/issue-64/README.md
+++ b/docs/case-studies/issue-64/README.md
@@ -25,7 +25,7 @@ npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assist
 
 The `js/package.json` had no `repository` field at all. When npm reads a package without this field, it treats `repository.url` as an empty string `""`, which fails sigstore's provenance validation against the expected GitHub repository URL.
 
-**Evidence**: Line 3241 of `ci-logs/js-release-24407389441.log` shows the exact npm error. The `Cargo.toml` for the Rust package already had `repository = "https://github.com/link-assistant/web-capture"` set correctly (line 7), confirming this was a JS-specific oversight.
+**Evidence**: Line 3241 of `ci-logs/js-release-errors.log` shows the exact npm error. The `Cargo.toml` for the Rust package already had `repository = "https://github.com/link-assistant/web-capture"` set correctly (line 7), confirming this was a JS-specific oversight.
 
 ### Secondary Root Cause: Divergence from template best practices
 

--- a/docs/case-studies/issue-64/README.md
+++ b/docs/case-studies/issue-64/README.md
@@ -1,0 +1,116 @@
+# Case Study: Issue #64 — JavaScript CI/CD Failed
+
+## Timeline of Events
+
+1. **2026-04-14T15:19:43Z**: CI run [#24407389441](https://github.com/link-assistant/web-capture/actions/runs/24407389441) triggered on push to `main` branch.
+2. **2026-04-14T15:19:45Z**: `JS - Detect Changes` job completed successfully. Change detection found only `.gitkeep` was modified, so `js-code-changed=false`.
+3. **2026-04-14T15:26:05Z**: `JS - Release` job started on `ubuntu-latest` (Ubuntu 24.04).
+4. **2026-04-14T15:26:47Z**: `npm publish --provenance --access public --verbose` failed with HTTP 422 error.
+5. **2026-04-14T15:27:00Z**: After 3 retry attempts, the release job failed with exit code 1.
+
+## Root Cause Analysis
+
+### Primary Root Cause: Missing `repository` field in `js/package.json`
+
+The npm registry's sigstore provenance verification requires the `repository.url` field in `package.json` to match the GitHub repository from which the publish action originates.
+
+**Error message** (from CI logs line 3241):
+
+```
+npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture
+  - Error verifying sigstore provenance bundle: Failed to validate repository information:
+    package.json: "repository.url" is "", expected to match
+    "https://github.com/link-assistant/web-capture" from provenance
+```
+
+The `js/package.json` had no `repository` field at all. When npm reads a package without this field, it treats `repository.url` as an empty string `""`, which fails sigstore's provenance validation against the expected GitHub repository URL.
+
+**Evidence**: Line 3241 of `ci-logs/js-release-24407389441.log` shows the exact npm error. The `Cargo.toml` for the Rust package already had `repository = "https://github.com/link-assistant/web-capture"` set correctly (line 7), confirming this was a JS-specific oversight.
+
+### Secondary Root Cause: Divergence from template best practices
+
+The repository's CI/CD scripts had diverged from the upstream templates in several ways:
+
+1. **No `js-paths.mjs` utility** — The JS template (`js-ai-driven-development-pipeline-template`) includes a `scripts/js-paths.mjs` module for auto-detecting single-language vs multi-language repository layouts. This repo's scripts used hardcoded relative paths.
+
+2. **Outdated concurrency settings** — Both `js.yml` and `rust.yml` used `cancel-in-progress: true` unconditionally, which cancels PR check runs on force-pushes. The template uses `cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}` to only cancel on main.
+
+3. **Outdated action versions** — `peter-evans/create-pull-request@v7` instead of `@v8`.
+
+4. **Missing failure detection patterns** — The `publish-to-npm.mjs` script lacked the template's `FAILURE_PATTERNS` array for detecting and reporting specific npm publish failures.
+
+## Requirements from Issue
+
+1. Fix the CI/CD failure
+2. Compare all CI/CD files with template repositories
+3. Apply best practices from templates
+4. Download logs and create case study analysis
+5. Report issues in template repos if found
+
+## Solutions Applied
+
+### Fix 1: Add `repository` field to `js/package.json`
+
+```json
+"repository": {
+  "type": "git",
+  "url": "https://github.com/link-assistant/web-capture"
+}
+```
+
+### Fix 2: Add `scripts/js-paths.mjs` utility
+
+Ported from the JS template to auto-detect JavaScript root directory in multi-language repos.
+
+### Fix 3: Update scripts to use `js-paths.mjs`
+
+Updated `publish-to-npm.mjs`, `check-release-needed.mjs`, `validate-changeset.mjs`, and `instant-version-bump.mjs` to use the path detection utility instead of hardcoded paths.
+
+### Fix 4: Add failure detection patterns to `publish-to-npm.mjs`
+
+Added `FAILURE_PATTERNS` array and `detectPublishFailure()` helper for better error reporting.
+
+### Fix 5: Update workflow concurrency settings
+
+Changed `cancel-in-progress` from `true` to `${{ github.ref == 'refs/heads/main' }}` in both `js.yml` and `rust.yml`.
+
+### Fix 6: Update `peter-evans/create-pull-request` to v8
+
+Updated from v7 to v8 in both workflow files.
+
+## Template Comparison Summary
+
+### Compared against:
+- [js-ai-driven-development-pipeline-template](https://github.com/link-foundation/js-ai-driven-development-pipeline-template) (JS template)
+- [rust-ai-driven-development-pipeline-template](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template) (Rust template)
+
+### Key differences found and addressed:
+
+| Feature | This Repo (Before) | JS Template | Action |
+|---------|-------------------|-------------|--------|
+| `repository` in package.json | Missing | Present | **Fixed** |
+| `js-paths.mjs` utility | Missing | Present | **Added** |
+| Concurrency cancel-in-progress | Always `true` | Only on `main` | **Fixed** |
+| `create-pull-request` version | v7 | v8 | **Updated** |
+| Failure detection in publish | Missing | Present | **Added** |
+
+### Features in templates not yet ported (future work):
+
+| Feature | JS Template | Rust Template |
+|---------|-------------|---------------|
+| `check-file-line-limits.sh` | Yes | Yes (as .rs) |
+| `check-mjs-syntax.sh` | Yes | N/A |
+| `simulate-fresh-merge.sh` | Yes | N/A |
+| `version-check` job | Yes | Yes |
+| `validate-docs` job | Yes | N/A |
+| `secretlint` | Yes | N/A |
+| `links.yml` workflow | Yes | N/A |
+| Multi-runtime test matrix | Node/Bun/Deno | N/A |
+
+## References
+
+- Failed CI run: https://github.com/link-assistant/web-capture/actions/runs/24407389441
+- npm sigstore provenance docs: https://docs.npmjs.com/generating-provenance-statements
+- npm trusted publishers: https://docs.npmjs.com/trusted-publishers
+- JS template: https://github.com/link-foundation/js-ai-driven-development-pipeline-template
+- Rust template: https://github.com/link-foundation/rust-ai-driven-development-pipeline-template

--- a/docs/case-studies/issue-64/ci-logs/js-release-errors.log
+++ b/docs/case-studies/issue-64/ci-logs/js-release-errors.log
@@ -1,0 +1,83 @@
+2434:JS - Release	UNKNOWN STEP	2026-04-14T15:26:28.5188045Z npm error code E404
+2435:JS - Release	UNKNOWN STEP	2026-04-14T15:26:28.5191190Z npm error 404 No match found for version 1.7.0
+2436:JS - Release	UNKNOWN STEP	2026-04-14T15:26:28.5192119Z npm error 404
+2437:JS - Release	UNKNOWN STEP	2026-04-14T15:26:28.5193731Z npm error 404  The requested resource '@link-assistant/web-capture@1.7.0' could not be found or you do not have permission to access it.
+2438:JS - Release	UNKNOWN STEP	2026-04-14T15:26:28.5194817Z npm error 404
+2439:JS - Release	UNKNOWN STEP	2026-04-14T15:26:28.5195339Z npm error 404 Note that you can also install from a
+2440:JS - Release	UNKNOWN STEP	2026-04-14T15:26:28.5196109Z npm error 404 tarball, folder, http url, or git url.
+2441:JS - Release	UNKNOWN STEP	2026-04-14T15:26:28.5206487Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_27_909Z-debug-0.log
+2459:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.0939672Z npm error code E404
+2460:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.0940569Z npm error 404 No match found for version 1.7.0
+2461:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.0941111Z npm error 404
+2462:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.0946205Z npm error 404  The requested resource '@link-assistant/web-capture@1.7.0' could not be found or you do not have permission to access it.
+2463:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.0947532Z npm error 404
+2464:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.0948762Z npm error 404 Note that you can also install from a
+2465:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.0951614Z npm error 404 tarball, folder, http url, or git url.
+2466:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.0965621Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_30_856Z-debug-0.log
+2477:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.2779440Z npm verbose argv "publish" "--provenance" "--access" "public" "--loglevel" "verbose"
+2486:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.8514145Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+2487:JS - Release	UNKNOWN STEP	2026-04-14T15:26:31.8515346Z npm warn publish errors corrected:
+2578:JS - Release	UNKNOWN STEP	2026-04-14T15:26:33.8688805Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+2581:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3092277Z npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+2592:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3109269Z npm error code E422
+2593:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3111759Z npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+2600:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3123974Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_31_245Z-debug-0.log
+2614:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3244663Z npm verbose argv "publish" "--provenance" "--access" "public" "--loglevel" "verbose"
+2619:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3249200Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+2620:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3249819Z npm warn publish errors corrected:
+2711:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3282332Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+2714:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3285587Z npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+2725:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3295076Z npm error code E422
+2726:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3296433Z npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+2733:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3300130Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_31_245Z-debug-0.log
+2735:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3300807Z .git can't be foundPublish failed: npm publish failed with exit code 1: 
+2744:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3303516Z npm verbose argv "publish" "--provenance" "--access" "public" "--loglevel" "verbose"
+2749:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3307378Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+2750:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3307996Z npm warn publish errors corrected:
+2841:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3357927Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+2844:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3361165Z npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+2855:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3370770Z npm error code E422
+2856:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3372141Z npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+2863:JS - Release	UNKNOWN STEP	2026-04-14T15:26:34.3375116Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_31_245Z-debug-0.log
+2874:JS - Release	UNKNOWN STEP	2026-04-14T15:26:44.4950887Z npm verbose argv "publish" "--provenance" "--access" "public" "--loglevel" "verbose"
+2883:JS - Release	UNKNOWN STEP	2026-04-14T15:26:45.0007258Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+2884:JS - Release	UNKNOWN STEP	2026-04-14T15:26:45.0008448Z npm warn publish errors corrected:
+2975:JS - Release	UNKNOWN STEP	2026-04-14T15:26:46.7261362Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+2978:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.3989816Z npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+2989:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4008534Z npm error code E422
+2990:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4011409Z npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+2997:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4018898Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_44_467Z-debug-0.log
+3011:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4128856Z npm verbose argv "publish" "--provenance" "--access" "public" "--loglevel" "verbose"
+3016:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4132281Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+3017:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4132883Z npm warn publish errors corrected:
+3108:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4167681Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+3111:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4170899Z npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+3122:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4180448Z npm error code E422
+3123:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4181812Z npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+3130:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4184817Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_44_467Z-debug-0.log
+3132:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4185468Z .git can't be foundPublish failed: npm publish failed with exit code 1: 
+3141:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4188533Z npm verbose argv "publish" "--provenance" "--access" "public" "--loglevel" "verbose"
+3146:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4191882Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+3147:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4192478Z npm warn publish errors corrected:
+3238:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4225013Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+3241:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4228651Z npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+3252:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4241714Z npm error code E422
+3253:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4243078Z npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+3260:JS - Release	UNKNOWN STEP	2026-04-14T15:26:47.4246072Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_44_467Z-debug-0.log
+3271:JS - Release	UNKNOWN STEP	2026-04-14T15:26:57.5859233Z npm verbose argv "publish" "--provenance" "--access" "public" "--loglevel" "verbose"
+3280:JS - Release	UNKNOWN STEP	2026-04-14T15:26:58.1098625Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+3281:JS - Release	UNKNOWN STEP	2026-04-14T15:26:58.1099809Z npm warn publish errors corrected:
+3372:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.3011449Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+3375:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8162773Z npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+3386:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8176461Z npm error code E422
+3387:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8178135Z npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+3394:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8197661Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_57_558Z-debug-0.log
+3408:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8297865Z npm verbose argv "publish" "--provenance" "--access" "public" "--loglevel" "verbose"
+3413:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8301367Z npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
+3414:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8302242Z npm warn publish errors corrected:
+3505:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8335777Z npm notice publish Signed provenance statement with source and build information from GitHub Actions
+3508:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8339774Z npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+3519:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8400052Z npm error code E422
+3520:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8401422Z npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@link-assistant%2fweb-capture - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance
+3527:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8404420Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-14T15_26_57_558Z-debug-0.log
+3531:JS - Release	UNKNOWN STEP	2026-04-14T15:27:00.8415086Z ##[error]Process completed with exit code 1.

--- a/docs/case-studies/issue-64/js-template-tree.txt
+++ b/docs/case-studies/issue-64/js-template-tree.txt
@@ -1,0 +1,136 @@
+tree  .changeset
+blob  .changeset/README.md (510 bytes)
+blob  .changeset/config.json (271 bytes)
+tree  .github
+tree  .github/workflows
+blob  .github/workflows/links.yml (3035 bytes)
+blob  .github/workflows/release.yml (19369 bytes)
+blob  .gitignore (2178 bytes)
+blob  .gitkeep (204 bytes)
+tree  .husky
+blob  .husky/pre-commit (16 bytes)
+blob  .jscpd.json (390 bytes)
+blob  .lycheeignore (721 bytes)
+blob  .prettierignore (166 bytes)
+blob  .prettierrc (173 bytes)
+blob  .secretlintrc.json (92 bytes)
+blob  CHANGELOG.md (7475 bytes)
+blob  LICENSE (1211 bytes)
+blob  README.md (9322 bytes)
+blob  bunfig.toml (136 bytes)
+blob  deno.json (121 bytes)
+tree  docs
+blob  docs/BEST-PRACTICES.md (7560 bytes)
+blob  docs/CONTRIBUTING.md (4675 bytes)
+tree  docs/case-studies
+tree  docs/case-studies/issue-13
+blob  docs/case-studies/issue-13/README.md (7506 bytes)
+blob  docs/case-studies/issue-13/hive-mind-issue-960.json (2202 bytes)
+blob  docs/case-studies/issue-13/hive-mind-pr-961-diff.txt (27983 bytes)
+blob  docs/case-studies/issue-13/hive-mind-pr-961.json (6745 bytes)
+tree  docs/case-studies/issue-21
+blob  docs/case-studies/issue-21/README.md (14434 bytes)
+tree  docs/case-studies/issue-21/ci-logs
+blob  docs/case-studies/issue-21/ci-logs/run-20803315337.txt (133670 bytes)
+blob  docs/case-studies/issue-21/ci-logs/run-20885464993.txt (155417 bytes)
+blob  docs/case-studies/issue-21/issue-111-data.txt (700 bytes)
+blob  docs/case-studies/issue-21/issue-113-data.txt (708 bytes)
+blob  docs/case-studies/issue-21/pr-112-data.json (4967 bytes)
+blob  docs/case-studies/issue-21/pr-112-diff.patch (140742 bytes)
+blob  docs/case-studies/issue-21/pr-114-data.json (7852 bytes)
+blob  docs/case-studies/issue-21/pr-114-diff.patch (31790 bytes)
+tree  docs/case-studies/issue-23
+blob  docs/case-studies/issue-23/README.md (9202 bytes)
+tree  docs/case-studies/issue-23/data
+blob  docs/case-studies/issue-23/data/hive-mind-check-version.mjs (3689 bytes)
+blob  docs/case-studies/issue-23/data/hive-mind-ci.yml (3 bytes)
+blob  docs/case-studies/issue-23/data/hive-mind-eslint.config.mjs (2312 bytes)
+blob  docs/case-studies/issue-23/data/hive-mind-release.yml (85858 bytes)
+blob  docs/case-studies/issue-23/data/issue-1126-details.txt (485 bytes)
+blob  docs/case-studies/issue-23/data/issue-1141-comments.json (2 bytes)
+blob  docs/case-studies/issue-23/data/issue-1141-details.txt (1151 bytes)
+blob  docs/case-studies/issue-23/data/pr-1127-conversation-comments.json (17911 bytes)
+blob  docs/case-studies/issue-23/data/pr-1127-diff.txt (11091 bytes)
+blob  docs/case-studies/issue-23/data/pr-1127-review-comments.json (2 bytes)
+blob  docs/case-studies/issue-23/data/pr-1142-conversation-comments.json (8054 bytes)
+blob  docs/case-studies/issue-23/data/pr-1142-diff.txt (27946 bytes)
+blob  docs/case-studies/issue-23/data/pr-1142-review-comments.json (2 bytes)
+tree  docs/case-studies/issue-25
+blob  docs/case-studies/issue-25/DETAILED-COMPARISON.md (17912 bytes)
+blob  docs/case-studies/issue-25/README.md (10084 bytes)
+tree  docs/case-studies/issue-25/data
+blob  docs/case-studies/issue-25/data/hive-mind-file-tree.txt (84928 bytes)
+blob  docs/case-studies/issue-25/data/issue-1274-case-study.md (9175 bytes)
+blob  docs/case-studies/issue-25/data/issue-1278-case-study.md (13738 bytes)
+blob  docs/case-studies/issue-25/data/template-file-tree.txt (3372 bytes)
+tree  docs/case-studies/issue-29
+blob  docs/case-studies/issue-29/README.md (6303 bytes)
+tree  docs/case-studies/issue-3
+blob  docs/case-studies/issue-3/README.md (10928 bytes)
+blob  docs/case-studies/issue-3/created-issues.md (1274 bytes)
+blob  docs/case-studies/issue-3/issue-data.json (4625 bytes)
+blob  docs/case-studies/issue-3/original-format-release-notes.mjs (7649 bytes)
+blob  docs/case-studies/issue-3/reference-pr-59-diff.txt (23744 bytes)
+blob  docs/case-studies/issue-3/reference-pr-59.json (7914 bytes)
+blob  docs/case-studies/issue-3/release-v0.1.0.json (1008 bytes)
+blob  docs/case-studies/issue-3/repositories-with-same-script.json (771 bytes)
+blob  docs/case-studies/issue-3/research-notes.md (1394 bytes)
+tree  docs/case-studies/issue-31
+blob  docs/case-studies/issue-31/README.md (4832 bytes)
+blob  docs/case-studies/issue-31/web-capture-pr49-commits.json (2633 bytes)
+tree  docs/case-studies/issue-33
+blob  docs/case-studies/issue-33/README.md (7513 bytes)
+tree  docs/case-studies/issue-33/ci-logs
+blob  docs/case-studies/issue-33/ci-logs/release-24395209194.txt (786370 bytes)
+blob  docs/case-studies/issue-33/ci-logs/upstream-nodejs-62430.json (2053 bytes)
+blob  docs/case-studies/issue-33/ci-logs/upstream-npm-cli-9151.json (6870 bytes)
+blob  docs/case-studies/issue-33/ci-logs/upstream-runner-images-13883.json (4055 bytes)
+tree  docs/case-studies/issue-36
+blob  docs/case-studies/issue-36/README.md (5048 bytes)
+tree  docs/case-studies/issue-36/ci-logs
+blob  docs/case-studies/issue-36/ci-logs/release-24399965550.txt (845925 bytes)
+tree  docs/case-studies/issue-7
+blob  docs/case-studies/issue-7/BEST-PRACTICES-COMPARISON.md (9478 bytes)
+blob  docs/case-studies/issue-7/FORMATTER-COMPARISON.md (17660 bytes)
+blob  docs/case-studies/issue-7/current-repository-analysis.json (1988 bytes)
+blob  docs/case-studies/issue-7/effect-template-analysis.json (4644 bytes)
+blob  eslint.config.js (2850 bytes)
+tree  examples
+blob  examples/basic-usage.js (747 bytes)
+tree  experiments
+blob  experiments/test-changeset-scripts.mjs (8385 bytes)
+blob  experiments/test-check-release-needed.mjs (2751 bytes)
+blob  experiments/test-detect-changes.mjs (4045 bytes)
+blob  experiments/test-failure-detection.mjs (4472 bytes)
+blob  experiments/test-format-major-changes.mjs (1557 bytes)
+blob  experiments/test-format-minor-changes.mjs (1766 bytes)
+blob  experiments/test-format-no-hash.mjs (1284 bytes)
+blob  experiments/test-format-patch-changes.mjs (1460 bytes)
+blob  package-lock.json (144505 bytes)
+blob  package.json (1709 bytes)
+tree  scripts
+blob  scripts/changeset-version.mjs (2667 bytes)
+blob  scripts/check-changesets.mjs (1729 bytes)
+blob  scripts/check-file-line-limits.sh (1634 bytes)
+blob  scripts/check-mjs-syntax.sh (634 bytes)
+blob  scripts/check-release-needed.mjs (4050 bytes)
+blob  scripts/check-version.mjs (3737 bytes)
+blob  scripts/check-web-archive.mjs (8314 bytes)
+blob  scripts/create-github-release.mjs (2927 bytes)
+blob  scripts/create-manual-changeset.mjs (2738 bytes)
+blob  scripts/detect-code-changes.mjs (4899 bytes)
+blob  scripts/format-github-release.mjs (2871 bytes)
+blob  scripts/format-release-notes.mjs (8176 bytes)
+blob  scripts/instant-version-bump.mjs (5925 bytes)
+blob  scripts/js-paths.mjs (5686 bytes)
+blob  scripts/merge-changesets.mjs (6385 bytes)
+blob  scripts/publish-to-npm.mjs (9615 bytes)
+blob  scripts/setup-npm.mjs (3701 bytes)
+blob  scripts/simulate-fresh-merge.sh (2007 bytes)
+blob  scripts/validate-changeset.mjs (8043 bytes)
+blob  scripts/version-and-commit.mjs (9584 bytes)
+tree  src
+blob  src/index.d.ts (651 bytes)
+blob  src/index.js (694 bytes)
+tree  tests
+blob  tests/index.test.js (783 bytes)

--- a/docs/case-studies/issue-64/rust-template-tree.txt
+++ b/docs/case-studies/issue-64/rust-template-tree.txt
@@ -1,0 +1,113 @@
+# File Tree: link-foundation/rust-ai-driven-development-pipeline-template
+# Branch: main
+# Root SHA: 1dd6d81da270f30e5355bca43cc67bc953bec583
+
+TYPE      SIZE  PATH
+------------------------------------------------------------
+tree            .github
+tree            .github/workflows
+blob     16372  .github/workflows/release.yml
+blob       859  .gitignore
+blob       836  .pre-commit-config.yaml
+blob     47562  CHANGELOG.md
+blob      7201  CONTRIBUTING.md
+blob      8837  Cargo.lock
+blob      1242  Cargo.toml
+blob      1211  LICENSE
+blob     11715  README.md
+tree            changelog.d
+blob       608  changelog.d/20251227_224645_changeset_support.md
+blob       432  changelog.d/20251229_143823_fix_ci_workflow_dependencies.md
+blob       286  changelog.d/20251231_115800_fix_readme_script_references.md
+blob       830  changelog.d/20260107_apply_best_practices.md
+blob       857  changelog.d/20260108_171124_fix_changelog_check.md
+blob       455  changelog.d/20260108_171435_prevent_manual_version_modification.md
+blob       497  changelog.d/20260108_apply_lino_objects_codec_fixes.md
+blob       694  changelog.d/20260111_multi_language_support.md
+blob      1137  changelog.d/20260119_best_practices_from_browser_commander.md
+blob       383  changelog.d/20260311_translate_scripts_to_rust.md
+blob      1052  changelog.d/20260413-ci-cd-best-practices.md
+blob       474  changelog.d/20260413_fix_cargo_token_fallback.md
+blob       658  changelog.d/20260413_fix_crates_io_check.md
+blob       742  changelog.d/20260413_fix_lookahead_regex.md
+blob       231  changelog.d/20260414_fix_per_commit_diff.md
+blob      3235  changelog.d/README.md
+tree            docs
+tree            docs/case-studies
+tree            docs/case-studies/issue-11
+blob      8907  docs/case-studies/issue-11/README.md
+blob      6801  docs/case-studies/issue-11/analysis-crates-io.md
+blob      4331  docs/case-studies/issue-11/analysis-set-output.md
+blob      5375  docs/case-studies/issue-11/analysis-workflow-dispatch.md
+blob      6372  docs/case-studies/issue-11/online-research.md
+tree            docs/case-studies/issue-17
+blob      5870  docs/case-studies/issue-17/README.md
+tree            docs/case-studies/issue-19
+blob     10930  docs/case-studies/issue-19/README.md
+tree            docs/case-studies/issue-19/ci-logs
+blob     20042  docs/case-studies/issue-19/ci-logs/ci-run-20885464993.log.gz
+tree            docs/case-studies/issue-19/pr-114-data
+blob       708  docs/case-studies/issue-19/pr-114-data/issue-113-details.txt
+blob      3550  docs/case-studies/issue-19/pr-114-data/pr-commits.json
+blob      8310  docs/case-studies/issue-19/pr-114-data/pr-conversation-comments.json
+blob      6727  docs/case-studies/issue-19/pr-114-data/pr-details.json
+blob     31790  docs/case-studies/issue-19/pr-114-data/pr-diff.patch
+blob         2  docs/case-studies/issue-19/pr-114-data/pr-review-comments.json
+blob         2  docs/case-studies/issue-19/pr-114-data/pr-reviews.json
+blob     89348  docs/case-studies/issue-19/pr-114-data/solution-draft-log-1.txt.gz
+blob     69878  docs/case-studies/issue-19/pr-114-data/solution-draft-log-2.txt.gz
+tree            docs/case-studies/issue-21
+blob      9651  docs/case-studies/issue-21/README.md
+blob      3766  docs/case-studies/issue-21/browser-commander-issue-27.md
+blob      5448  docs/case-studies/issue-21/browser-commander-issue-29.md
+blob      4224  docs/case-studies/issue-21/browser-commander-issue-31.md
+blob      6909  docs/case-studies/issue-21/browser-commander-issue-33.md
+blob     14865  docs/case-studies/issue-21/browser-commander-rust.yml
+tree            docs/case-studies/issue-25
+blob      4724  docs/case-studies/issue-25/README.md
+tree            docs/case-studies/issue-29
+blob      6614  docs/case-studies/issue-29/README.md
+tree            docs/case-studies/issue-32
+blob      5520  docs/case-studies/issue-32/README.md
+tree            docs/case-studies/issue-34
+blob      7573  docs/case-studies/issue-34/README.md
+tree            docs/ci-cd
+blob      6373  docs/ci-cd/troubleshooting.md
+tree            examples
+blob       183  examples/basic_usage.rs
+tree            experiments
+blob      3100  experiments/test-changelog-parsing.rs
+blob      2946  experiments/test-crates-io-check.rs
+blob      3146  experiments/test-detect-code-changes.sh
+blob       812  experiments/test-version-check-dependencies.sh
+blob      1420  experiments/test-version-check.sh
+tree            scripts
+blob      5190  scripts/bump-version.rs
+blob      5230  scripts/check-changelog-fragment.rs
+blob      2764  scripts/check-file-size.rs
+blob      9444  scripts/check-release-needed.rs
+blob      4917  scripts/check-version-modification.rs
+blob      7325  scripts/collect-changelog.rs
+blob      3280  scripts/create-changelog-fragment.rs
+blob      7005  scripts/create-github-release.rs
+blob      7070  scripts/detect-code-changes.rs
+blob      5331  scripts/get-bump-type.rs
+blob      3082  scripts/get-version.rs
+blob      1953  scripts/git-config.rs
+blob      7905  scripts/publish-crate.rs
+blob      4922  scripts/rust-paths.rs
+blob     18766  scripts/version-and-commit.rs
+tree            src
+blob        32  src/lib.rs
+blob       444  src/main.rs
+blob        66  src/sum.rs
+tree            tests
+tree            tests/integration
+blob         9  tests/integration/mod.rs
+blob      1059  tests/integration/sum.rs
+tree            tests/unit
+tree            tests/unit/ci-cd
+blob      2308  tests/unit/ci-cd/changelog_parsing.rs
+blob        23  tests/unit/ci-cd/mod.rs
+blob        46  tests/unit/mod.rs
+blob       417  tests/unit/sum.rs

--- a/js/package.json
+++ b/js/package.json
@@ -73,6 +73,10 @@
     "microservice"
   ],
   "license": "Unlicense",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/link-assistant/web-capture"
+  },
   "engines": {
     "node": ">=22.0.0 <23.0.0"
   },

--- a/scripts/check-release-needed.mjs
+++ b/scripts/check-release-needed.mjs
@@ -30,6 +30,12 @@
  */
 
 import { readFileSync, readdirSync, existsSync, appendFileSync } from 'fs';
+import {
+  getJsRoot,
+  getPackageJsonPath,
+  getChangesetDir,
+  parseJsRootConfig,
+} from './js-paths.mjs';
 
 // Load use-m dynamically
 const { use } = eval(
@@ -37,6 +43,9 @@ const { use } = eval(
 );
 
 const { $ } = await use('command-stream');
+
+const jsRootConfig = parseJsRootConfig();
+const jsRoot = getJsRoot({ jsRoot: jsRootConfig, verbose: true });
 
 const JS_PUBLISHABLE_PATHS = [
   'js/src/',
@@ -54,17 +63,19 @@ function setOutput(key, value) {
 }
 
 function getPackageVersion() {
-  const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
+  const packageJsonPath = getPackageJsonPath({ jsRoot });
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
   return pkg.version;
 }
 
 function getPackageName() {
-  const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
+  const packageJsonPath = getPackageJsonPath({ jsRoot });
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
   return pkg.name;
 }
 
 function countChangesets() {
-  const changesetDir = '.changeset';
+  const changesetDir = getChangesetDir({ jsRoot });
   if (!existsSync(changesetDir)) return 0;
 
   const files = readdirSync(changesetDir);

--- a/scripts/instant-version-bump.mjs
+++ b/scripts/instant-version-bump.mjs
@@ -13,6 +13,11 @@
  */
 
 import { readFileSync, writeFileSync } from 'fs';
+import {
+  getJsRoot,
+  getPackageJsonPath,
+  parseJsRootConfig,
+} from './js-paths.mjs';
 
 // Load use-m dynamically
 const { use } = eval(
@@ -43,6 +48,9 @@ const config = makeConfig({
 try {
   const { bumpType, description } = config;
   const finalDescription = description || `Manual ${bumpType} release`;
+  const jsRootConfig = parseJsRootConfig();
+  const jsRoot = getJsRoot({ jsRoot: jsRootConfig, verbose: true });
+  const packageJsonPath = getPackageJsonPath({ jsRoot });
 
   if (!bumpType || !['major', 'minor', 'patch'].includes(bumpType)) {
     console.error(
@@ -54,7 +62,7 @@ try {
   console.log(`\nBumping version (${bumpType})...`);
 
   // Get current version
-  const packageJson = JSON.parse(readFileSync('package.json', 'utf-8'));
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   const oldVersion = packageJson.version;
   console.log(`Current version: ${oldVersion}`);
 
@@ -62,7 +70,7 @@ try {
   await $`npm version ${bumpType} --no-git-tag-version`;
 
   // Get new version
-  const updatedPackageJson = JSON.parse(readFileSync('package.json', 'utf-8'));
+  const updatedPackageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   const newVersion = updatedPackageJson.version;
   console.log(`New version: ${newVersion}`);
 

--- a/scripts/js-paths.mjs
+++ b/scripts/js-paths.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+/**
+ * JavaScript package path detection utility.
+ * Auto-detects JS root for single-language repos (package.json in root)
+ * and multi-language repos (package.json in js/ subfolder).
+ *
+ * Exported functions:
+ *   getJsRoot(options)          → '.' or 'js'
+ *   getPackageJsonPath(options) → './package.json' or 'js/package.json'
+ *   getPackageLockPath(options) → './package-lock.json' or 'js/package-lock.json'
+ *   getChangesetDir(options)    → './.changeset' or 'js/.changeset'
+ *   getCdPrefix(options)        → '' or 'cd js && '
+ *   needsCd(options)            → boolean
+ *   resetCache()                → void (for testing)
+ *   parseJsRootConfig()         → string|undefined
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+let cachedJsRoot = null;
+
+export function getJsRoot(options = {}) {
+  const { jsRoot: explicitRoot, verbose = false } = options;
+  if (explicitRoot !== undefined && explicitRoot !== '') {
+    if (verbose)
+      console.log(
+        `Using explicitly configured JavaScript root: ${explicitRoot}`
+      );
+    return explicitRoot;
+  }
+  if (cachedJsRoot !== null) return cachedJsRoot;
+  if (existsSync('./package.json')) {
+    if (verbose)
+      console.log(
+        'Detected single-language repository (package.json in root)'
+      );
+    cachedJsRoot = '.';
+    return cachedJsRoot;
+  }
+  if (existsSync('./js/package.json')) {
+    if (verbose)
+      console.log(
+        'Detected multi-language repository (package.json in js/)'
+      );
+    cachedJsRoot = 'js';
+    return cachedJsRoot;
+  }
+  throw new Error(
+    'Could not find package.json in expected locations.\n' +
+      'Searched in: ./package.json, ./js/package.json\n' +
+      'Fix: run from repo root, use --js-root, or set JS_ROOT env var'
+  );
+}
+
+export function getPackageJsonPath(options = {}) {
+  const jsRoot =
+    options.jsRoot !== undefined ? options.jsRoot : getJsRoot(options);
+  return jsRoot === '.' ? './package.json' : join(jsRoot, 'package.json');
+}
+
+export function getPackageLockPath(options = {}) {
+  const jsRoot =
+    options.jsRoot !== undefined ? options.jsRoot : getJsRoot(options);
+  return jsRoot === '.'
+    ? './package-lock.json'
+    : join(jsRoot, 'package-lock.json');
+}
+
+export function getChangesetDir(options = {}) {
+  const jsRoot =
+    options.jsRoot !== undefined ? options.jsRoot : getJsRoot(options);
+  return jsRoot === '.' ? './.changeset' : join(jsRoot, '.changeset');
+}
+
+export function getCdPrefix(options = {}) {
+  const jsRoot =
+    options.jsRoot !== undefined ? options.jsRoot : getJsRoot(options);
+  return jsRoot === '.' ? '' : `cd ${jsRoot} && `;
+}
+
+export function needsCd(options = {}) {
+  const jsRoot =
+    options.jsRoot !== undefined ? options.jsRoot : getJsRoot(options);
+  return jsRoot !== '.';
+}
+
+export function resetCache() {
+  cachedJsRoot = null;
+}
+
+export function parseJsRootConfig() {
+  const args = process.argv.slice(2);
+  const idx = args.indexOf('--js-root');
+  if (idx >= 0 && args[idx + 1]) return args[idx + 1];
+  if (process.env.JS_ROOT) return process.env.JS_ROOT;
+  return undefined;
+}

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -2,8 +2,12 @@
 
 /**
  * Publish to npm using OIDC trusted publishing
- * Usage: node scripts/publish-to-npm.mjs [--should-pull]
+ * Usage: node scripts/publish-to-npm.mjs [--should-pull] [--js-root <path>]
  *   should_pull: Optional flag to pull latest changes before publishing (for release job)
+ *
+ * Configuration:
+ * - CLI: --js-root <path> to explicitly set JavaScript root
+ * - Environment: JS_ROOT=<path>
  *
  * IMPORTANT: Update the PACKAGE_NAME constant below to match your package.json
  *
@@ -14,6 +18,12 @@
  */
 
 import { readFileSync, appendFileSync } from 'fs';
+import {
+  getJsRoot,
+  getPackageJsonPath,
+  needsCd,
+  parseJsRootConfig,
+} from './js-paths.mjs';
 
 const PACKAGE_NAME = '@link-assistant/web-capture';
 
@@ -29,16 +39,37 @@ const { makeConfig } = await use('lino-arguments');
 // Parse CLI arguments using lino-arguments
 const config = makeConfig({
   yargs: ({ yargs, getenv }) =>
-    yargs.option('should-pull', {
-      type: 'boolean',
-      default: getenv('SHOULD_PULL', false),
-      describe: 'Pull latest changes before publishing',
-    }),
+    yargs
+      .option('should-pull', {
+        type: 'boolean',
+        default: getenv('SHOULD_PULL', false),
+        describe: 'Pull latest changes before publishing',
+      })
+      .option('js-root', {
+        type: 'string',
+        default: getenv('JS_ROOT', ''),
+        describe: 'JavaScript package root directory',
+      }),
 });
 
-const { shouldPull } = config;
+const { shouldPull, jsRoot: jsRootArg } = config;
+const jsRootConfig = jsRootArg || parseJsRootConfig();
+const jsRoot = getJsRoot({ jsRoot: jsRootConfig, verbose: true });
+
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 10000; // 10 seconds
+const originalCwd = process.cwd();
+
+const FAILURE_PATTERNS = [
+  'packages failed to publish',
+  'error occurred while publishing',
+  'npm error code E',
+  'npm error 404',
+  'npm error 401',
+  'npm error 403',
+  'Access token expired',
+  'ENEEDAUTH',
+];
 
 /**
  * Sleep for specified milliseconds
@@ -46,6 +77,13 @@ const RETRY_DELAY = 10000; // 10 seconds
  */
 function sleep(ms) {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+}
+
+function detectPublishFailure(output) {
+  const lower = output.toLowerCase();
+  for (const p of FAILURE_PATTERNS)
+    if (lower.includes(p.toLowerCase())) return p;
+  return null;
 }
 
 /**
@@ -68,7 +106,8 @@ async function main() {
     }
 
     // Get current version
-    const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
+    const packageJsonPath = getPackageJsonPath({ jsRoot });
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
     const currentVersion = packageJson.version;
     console.log(`Current version to publish: ${currentVersion}`);
 
@@ -165,6 +204,13 @@ async function main() {
           console.error(`     - Set workflow to: js.yml`);
           console.error(`     - Set environment to: (leave empty or set to your environment name)\n`);
           process.exit(1);
+        }
+
+        const failurePattern = detectPublishFailure(combinedOutput);
+        if (failurePattern) {
+          console.error(
+            `Detected publish failure pattern: "${failurePattern}"`
+          );
         }
 
         if (publishResult.code !== 0) {

--- a/scripts/validate-changeset.mjs
+++ b/scripts/validate-changeset.mjs
@@ -8,12 +8,16 @@
 
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { getChangesetDir, parseJsRootConfig, getJsRoot } from './js-paths.mjs';
 
 const PACKAGE_NAME = '@link-assistant/web-capture';
 
+const jsRootConfig = parseJsRootConfig();
+const jsRoot = getJsRoot({ jsRoot: jsRootConfig });
+
 try {
   // Count changeset files (excluding README.md and config.json)
-  const changesetDir = '.changeset';
+  const changesetDir = getChangesetDir({ jsRoot });
   const changesetFiles = readdirSync(changesetDir).filter(
     (file) => file.endsWith('.md') && file !== 'README.md'
   );


### PR DESCRIPTION
## Summary

Fixes #64

The JavaScript CI/CD release job was failing with npm `E422 Unprocessable Entity` because `js/package.json` was missing the `repository` field required by npm's sigstore provenance verification.

**Root cause**: When publishing with `--provenance`, npm validates that `repository.url` in `package.json` matches the GitHub repository URL. Without this field, npm treats it as an empty string and rejects the publish request.

**Error**: `package.json: "repository.url" is "", expected to match "https://github.com/link-assistant/web-capture" from provenance`

## Changes

### Critical fix
- `js/package.json`: Added `repository` with `type: "git"` and `url: "https://github.com/link-assistant/web-capture"`

### Template best practices
- Added `scripts/js-paths.mjs` to support single-language and multi-language repo layouts
- Updated `scripts/publish-to-npm.mjs`, `scripts/check-release-needed.mjs`, `scripts/validate-changeset.mjs`, and `scripts/instant-version-bump.mjs` to use `js-paths.mjs`
- Added npm publish failure-pattern detection to `scripts/publish-to-npm.mjs`
- Updated `.github/workflows/js.yml` and `.github/workflows/rust.yml` to only cancel in-progress runs on `main`
- Updated `peter-evans/create-pull-request` from `v7` to `v8` in both workflows

### Documentation
- Added `docs/case-studies/issue-64/` with timeline, root cause analysis, template comparison, and saved CI error logs
- Corrected the case-study log reference to match the checked-in artifact path

## Validation

- [x] Verified `repository` is present in `js/package.json` and matches `https://github.com/link-assistant/web-capture`
- [x] Verified `js-paths.mjs` detects this repo layout as `js`
- [x] Ran `node experiments/test-release-check-logic.mjs`
- [x] Ran `cd js && npm run lint` (warnings only, no errors)
- [x] Ran `cd js && npm test -- --runInBand tests/unit/cli.test.js tests/unit/verify.test.js`
- [x] Ran `cd rust && cargo test --all-features --quiet`
- [x] Confirmed saved CI log `docs/case-studies/issue-64/ci-logs/js-release-errors.log` contains the original `E422` provenance failure at line 3241
- [x] Confirmed latest branch workflow runs after the fix commit completed successfully
- [ ] Confirm npm publish succeeds on the next release from `main`
