### PR TITLE
fix: handle npm registry lag after successful publish

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-04-15T07:05:02.332Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-04-15T07:05:02.332Z

--- a/docs/case-studies/issue-66/README.md
+++ b/docs/case-studies/issue-66/README.md
@@ -1,0 +1,64 @@
+# Case Study: Issue #66 — JavaScript CI/CD Fails
+
+## Timeline
+
+1. **2026-04-15T06:27:41Z**: GitHub Actions run [#24439870541](https://github.com/link-assistant/web-capture/actions/runs/24439870541) starts on `main`.
+2. **2026-04-15T06:34:26Z**: `JS - Release` decides version `1.7.1` is not on npm because `npm view @link-assistant/web-capture@1.7.1 version` returns `E404`.
+3. **2026-04-15T06:34:28Z**: First `npm publish --provenance --access public --verbose` succeeds and OIDC token exchange succeeds.
+4. **2026-04-15T06:34:32Z**: The script begins post-publish verification.
+5. **2026-04-15T06:34:38Z**: Verification still sees `E404`, so the script treats the publish as failed.
+6. **2026-04-15T06:34:48Z**: Second publish attempt fails with `You cannot publish over the previously published versions: 1.7.1.`
+7. **2026-04-15T06:35:01Z**: Third publish attempt fails the same way and the job exits with code 1.
+
+## Requirements From The Issue
+
+1. Fix the JavaScript CI/CD failure.
+2. Download logs and preserve them in the repository.
+3. Produce a case-study analysis under `docs/case-studies/issue-66/`.
+4. Compare behavior with the CI/CD template direction and reuse best practices where relevant.
+
+## Root Cause
+
+The publish itself succeeded. The failure was in the verification logic immediately after publish.
+
+`scripts/publish-to-npm.mjs` waited 5 seconds and then ran one verification request:
+
+```text
+npm view "@link-assistant/web-capture@1.7.1" version
+```
+
+In run [#24439870541](https://github.com/link-assistant/web-capture/actions/runs/24439870541), npm returned a transient `E404` even though the preceding publish already succeeded:
+
+- `docs/case-studies/issue-66/ci-run-24439870541.log:2609` shows the successful OIDC token exchange.
+- `docs/case-studies/issue-66/ci-run-24439870541.log:2613` shows provenance publication.
+- `docs/case-studies/issue-66/ci-run-24439870541.log:2624` shows the transient verification `E404`.
+- `docs/case-studies/issue-66/ci-run-24439870541.log:2749` shows the duplicate publish failure.
+
+This means the registry package metadata was not yet visible through `npm view` when the script verified the publish. The script then retried the entire publish operation instead of retrying only the verification step.
+
+## Fix
+
+Updated `scripts/publish-to-npm.mjs` to:
+
+1. Separate publish retries from verification retries.
+2. Poll `npm view` multiple times before declaring verification failure.
+3. Avoid re-publishing the same version while npm registry metadata is still propagating.
+
+The new behavior matches the actual failure mode from the logs: a successful publish followed by delayed metadata visibility.
+
+## Validation
+
+- Saved CI logs to [ci-run-24439870541.log](/tmp/gh-issue-solver-1776236700447/docs/case-studies/issue-66/ci-run-24439870541.log)
+- Added regression experiment: [test-publish-verification.mjs](/tmp/gh-issue-solver-1776236700447/experiments/test-publish-verification.mjs)
+- Syntax check: `node --check scripts/publish-to-npm.mjs`
+- Targeted unit test: `cd js && npm test -- --runTestsByPath tests/unit/cli.test.js`
+
+## Template Comparison Notes
+
+The repository already had the broader release structure from prior CI template sync work, including:
+
+- npm OIDC trusted publishing
+- release-needed detection against npm registry
+- release case-study documentation pattern
+
+The missing best practice here was resilience to eventual consistency after successful npm publish. The Rust release flow already models this class of problem better by distinguishing existence checks from publish attempts. This fix brings the JavaScript publish flow closer to that standard.

--- a/experiments/test-publish-verification.mjs
+++ b/experiments/test-publish-verification.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/**
+ * Minimal regression experiment for npm publish verification timing.
+ *
+ * Scenario:
+ * - First verification checks return 404 while npm registry metadata propagates
+ * - A naive implementation retries `npm publish`
+ * - The correct implementation keeps polling verification without re-publishing
+ */
+
+const VERIFY_RETRIES = 12;
+
+async function sleep(_ms) {}
+
+function makeVerifier(failuresBeforeSuccess) {
+  let attempts = 0;
+  return async function verifyPublishedVersion(version) {
+    for (let attempt = 1; attempt <= VERIFY_RETRIES; attempt++) {
+      attempts++;
+      const visible = attempts > failuresBeforeSuccess;
+      if (visible) return { ok: true, attempt, version };
+      await sleep(0);
+    }
+    return { ok: false, attempt: VERIFY_RETRIES, version };
+  };
+}
+
+async function run() {
+  const version = '1.7.1';
+  const verifyPublishedVersion = makeVerifier(2);
+  const result = await verifyPublishedVersion(version);
+
+  if (!result.ok) {
+    console.error('Expected verification to succeed after transient 404s');
+    process.exit(1);
+  }
+
+  if (result.attempt !== 3) {
+    console.error(`Expected success on attempt 3, got ${result.attempt}`);
+    process.exit(1);
+  }
+
+  console.log('Verification polling handles transient registry lag correctly.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/js/.changeset/retry-publish-verification.md
+++ b/js/.changeset/retry-publish-verification.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Retry npm publish verification long enough to tolerate registry propagation delays after a successful publish.

--- a/js/tests/unit/publish-verification.test.js
+++ b/js/tests/unit/publish-verification.test.js
@@ -1,0 +1,58 @@
+import { jest } from '@jest/globals';
+
+const originalFetch = global.fetch;
+
+beforeAll(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    text: async () => `
+      ({
+        use: async (name) => {
+          if (name === 'command-stream') return { $: () => ({ run: async () => ({ code: 0, stdout: '', stderr: '' }) }) };
+          if (name === 'lino-arguments') return { makeConfig: () => ({ shouldPull: false, jsRoot: 'js' }) };
+          throw new Error('Unexpected dynamic import: ' + name);
+        }
+      })
+    `,
+  });
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('publish verification', () => {
+  test('keeps polling verification through transient npm 404s', async () => {
+    const { verifyPublishedVersionWithRunner } = await import(
+      '../../../scripts/publish-to-npm.mjs'
+    );
+
+    const runVerify = jest
+      .fn()
+      .mockResolvedValueOnce({
+        code: 1,
+        stdout: '',
+        stderr: 'npm error code E404',
+      })
+      .mockResolvedValueOnce({
+        code: 1,
+        stdout: '',
+        stderr: 'npm error code E404',
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '1.7.1\n',
+        stderr: '',
+      });
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+
+    const published = await verifyPublishedVersionWithRunner(
+      '1.7.1',
+      runVerify,
+      sleepFn
+    );
+
+    expect(published).toBe(true);
+    expect(runVerify).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/js/tests/unit/publish-verification.test.js
+++ b/js/tests/unit/publish-verification.test.js
@@ -22,9 +22,8 @@ afterAll(() => {
 
 describe('publish verification', () => {
   test('keeps polling verification through transient npm 404s', async () => {
-    const { verifyPublishedVersionWithRunner } = await import(
-      '../../../scripts/publish-to-npm.mjs'
-    );
+    const { verifyPublishedVersionWithRunner } =
+      await import('../../../scripts/publish-to-npm.mjs');
 
     const runVerify = jest
       .fn()

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -18,6 +18,7 @@
  */
 
 import { readFileSync, appendFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 import {
   getJsRoot,
   getPackageJsonPath,
@@ -58,6 +59,8 @@ const jsRoot = getJsRoot({ jsRoot: jsRootConfig, verbose: true });
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 10000; // 10 seconds
+const VERIFY_RETRIES = 12;
+const VERIFY_RETRY_DELAY = 5000; // 5 seconds
 const originalCwd = process.cwd();
 
 const FAILURE_PATTERNS = [
@@ -96,6 +99,41 @@ function setOutput(key, value) {
   if (outputFile) {
     appendFileSync(outputFile, `${key}=${value}\n`);
   }
+}
+
+async function verifyPublishedVersion(version) {
+  return verifyPublishedVersionWithRunner(version, async () =>
+    $`npm view "${PACKAGE_NAME}@${version}" version`.run({
+      capture: true,
+    }),
+    sleep
+  );
+}
+
+export async function verifyPublishedVersionWithRunner(
+  version,
+  runVerify,
+  sleepFn = sleep
+) {
+  for (let attempt = 1; attempt <= VERIFY_RETRIES; attempt++) {
+    console.log(
+      `Verifying publish (attempt ${attempt} of ${VERIFY_RETRIES})...`
+    );
+    const verifyResult = await runVerify();
+
+    if (verifyResult.code === 0 && (verifyResult.stdout || '').trim() === version)
+      return true;
+
+    if (attempt < VERIFY_RETRIES) {
+      const output = `${verifyResult.stdout || ''}\n${verifyResult.stderr || ''}`.trim();
+      if (output) {
+        console.log(`Version not visible on npm yet: ${output}`);
+      }
+      await sleepFn(VERIFY_RETRY_DELAY);
+    }
+  }
+
+  return false;
 }
 
 async function main() {
@@ -217,16 +255,13 @@ async function main() {
           throw new Error(`npm publish failed with exit code ${publishResult.code}: ${combinedOutput}`);
         }
 
-        // Verify the version was actually published
-        console.log('Verifying publish...');
-        await sleep(5000);
-        const verifyResult =
-          await $`npm view "${PACKAGE_NAME}@${currentVersion}" version`.run({
-            capture: true,
-          });
-        if (verifyResult.code !== 0) {
+        // npm metadata can lag briefly after a successful publish.
+        // Keep verification retries separate from publish retries so we don't
+        // attempt to publish the same version again while the registry catches up.
+        const published = await verifyPublishedVersion(currentVersion);
+        if (!published) {
           throw new Error(
-            `Publish verification failed: version ${currentVersion} not found on npm after publish`
+            `Publish verification failed: version ${currentVersion} not found on npm after ${VERIFY_RETRIES} checks`
           );
         }
 
@@ -254,4 +289,7 @@ async function main() {
   }
 }
 
-main();
+const entrypoint = process.argv[1] ? fileURLToPath(import.meta.url) === process.argv[1] : false;
+if (entrypoint) {
+  main();
+}


### PR DESCRIPTION
## Summary
Fixes the JavaScript release failure from issue #66 by separating post-publish verification retries from publish retries.

## Root cause
The failing run published `@link-assistant/web-capture@1.7.1` successfully, but `npm view` still returned a transient `E404` for a few seconds while registry metadata propagated. The old script treated that as a publish failure and retried `npm publish`, which then failed because the same version had already been published.

## Reproduction
1. Run the release flow so `npm publish` succeeds.
2. Make the first one or two `npm view @link-assistant/web-capture@<version> version` checks return transient `E404`.
3. Observe the old script re-run `npm publish` and fail with "You cannot publish over the previously published versions".

## Changes
- retry only the verification step after a successful publish
- poll `npm view` up to 12 times with 5 second spacing before failing verification
- export the verification helper in an import-safe way so it can be regression tested
- add issue analysis and preserved logs under `docs/case-studies/issue-66/`
- keep a small experiment in `experiments/test-publish-verification.mjs`

## Testing
- `node --check scripts/publish-to-npm.mjs`
- `cd js && npm test -- --runTestsByPath tests/unit/publish-verification.test.js tests/unit/cli.test.js`
- `node experiments/test-publish-verification.mjs`

## Evidence
- Issue: https://github.com/link-assistant/web-capture/issues/66
- PR: https://github.com/link-assistant/web-capture/pull/67
- Case study: `docs/case-studies/issue-66/README.md`
