### PR TITLE
fix(js): accept positional CLI URL arguments

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-04-15T16:31:35.487Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-04-15T16:31:35.487Z

--- a/js/.changeset/fix-cli-positional-url.md
+++ b/js/.changeset/fix-cli-positional-url.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Fix the JavaScript CLI so strict argument parsing accepts positional capture URLs while still rejecting unknown options.

--- a/js/bin/web-capture.js
+++ b/js/bin/web-capture.js
@@ -16,6 +16,12 @@ const config = makeConfig({
       .usage(
         'web-capture - Capture web pages as HTML, Markdown, or PNG\n\nUsage:\n  web-capture --serve [--port <port>]       Start as API server\n  web-capture <url> [options]               Capture a URL to file/stdout'
       )
+      .command('$0 [url]', 'Capture a URL or start the API server', (yargs) =>
+        yargs.positional('url', {
+          type: 'string',
+          description: 'URL to capture',
+        })
+      )
       .option('serve', {
         alias: 's',
         type: 'boolean',
@@ -77,6 +83,7 @@ const config = makeConfig({
       .option('output', {
         alias: 'o',
         type: 'string',
+        nargs: 1,
         description:
           'Output file path (default: stdout for text, auto-generated for images)',
       })
@@ -231,6 +238,19 @@ const config = makeConfig({
     path: '.lenv',
   },
 });
+
+function getUrlArgument() {
+  if (typeof config.url === 'string' && config.url.length > 0) {
+    return config.url;
+  }
+
+  const separatorIndex = process.argv.indexOf('--');
+  if (separatorIndex !== -1 && separatorIndex < process.argv.length - 1) {
+    return process.argv[separatorIndex + 1];
+  }
+
+  return null;
+}
 
 async function startServer(port) {
   // Import the Express app
@@ -824,8 +844,7 @@ async function captureUrl(url, options) {
 }
 
 async function main() {
-  // Get positional arguments (non-option arguments)
-  const url = config._ && config._.length > 0 ? config._[0] : null;
+  const url = getUrlArgument();
 
   if (config.serve) {
     // Server mode

--- a/js/tests/unit/cli.test.js
+++ b/js/tests/unit/cli.test.js
@@ -1,5 +1,6 @@
 // Unit tests for CLI argument parsing and functionality
 import { spawn } from 'child_process';
+import http from 'node:http';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
@@ -30,6 +31,38 @@ function runCli(args, options = {}) {
     });
 
     proc.on('error', reject);
+  });
+}
+
+function startFixtureServer() {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(
+        '<!doctype html><html><body><h1>Issue 68</h1><p>Captured from positional URL.</p></body></html>'
+      );
+    });
+
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        server,
+        url: `http://127.0.0.1:${port}/article`,
+      });
+    });
+  });
+}
+
+function stopFixtureServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
   });
 }
 
@@ -78,12 +111,63 @@ describe('CLI', () => {
   });
 
   describe('URL validation', () => {
-    test('rejects invalid URL', async () => {
-      const result = await runCli(['not-a-valid-url-without-dots']);
-      // Should fail with invalid URL or show help due to strict mode
+    test('accepts a URL as a positional argument', async () => {
+      const { server, url } = await startFixtureServer();
+
+      try {
+        const result = await runCli([
+          url,
+          '--format',
+          'markdown',
+          '--output',
+          '-',
+        ]);
+
+        expect(result.code).toBe(0);
+        expect(result.stderr).not.toContain('Unknown argument');
+        expect(result.stdout).toContain('Issue 68');
+        expect(result.stdout).toContain('Captured from positional URL.');
+      } finally {
+        await stopFixtureServer(server);
+      }
+    }, 15000);
+
+    test('accepts a URL after the -- argument separator', async () => {
+      const { server, url } = await startFixtureServer();
+
+      try {
+        const result = await runCli([
+          '--format',
+          'markdown',
+          '--output',
+          '-',
+          '--',
+          url,
+        ]);
+
+        expect(result.code).toBe(0);
+        expect(result.stderr).not.toContain('Missing URL');
+        expect(result.stdout).toContain('Issue 68');
+      } finally {
+        await stopFixtureServer(server);
+      }
+    }, 15000);
+
+    test('rejects unknown options', async () => {
+      const result = await runCli([
+        '--unknown-option-for-issue-68',
+        'https://example.com',
+      ]);
+
       expect(result.code).toBe(1);
-      // Either an error message or help output (from yargs strict mode)
-      expect(result.stdout.length + result.stderr.length).toBeGreaterThan(0);
+      expect(result.stderr).toContain('Unknown argument');
+    });
+
+    test('rejects invalid URL', async () => {
+      const result = await runCli(['http://[invalid-url']);
+      // Should fail before trying to capture.
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain('Invalid URL');
     }, 15000);
   });
 


### PR DESCRIPTION
## Summary
Fixes #68.

The JavaScript CLI now accepts capture URLs as positional arguments while keeping yargs strict option validation enabled.

## Root Cause
`js/bin/web-capture.js` enabled `.strict()` without declaring the URL positional argument. yargs rejected `web-capture https://example.com` as an unknown argument before `main()` could run. The code also looked for `config._[0]`, but `lino-arguments` drops yargs' `_` array from the returned config object, so separator-based inputs like `-- https://example.com` could not be recovered there either.

## Changes
- Declared the default yargs command as `$0 [url]` so strict mode accepts the URL positional.
- Read the parsed `config.url` field and added a narrow fallback for URLs passed after the `--` separator.
- Marked `--output` / `-o` with `nargs: 1` so documented stdout output forms like `--output -` keep working under strict mode.
- Added CLI regression tests for positional URLs, `--` separator URLs, unknown-option rejection, and immediate invalid-URL validation.
- Added a patch changeset for the JS package.

## Reproduction and Regression Coverage
Before this fix, the new CLI tests failed for both:

```bash
web-capture http://127.0.0.1:<port>/article --format markdown --output -
web-capture --format markdown --output - -- http://127.0.0.1:<port>/article
```

After the fix, both forms capture content successfully, and strict mode still rejects unknown options.

## Verification
- `npm test -- tests/unit/cli.test.js` passes.
- `npm test -- tests/unit` passes: 207 tests.
- `npm test -- --testPathIgnorePatterns="docker.test.js"` passes: 245 tests, 16 skipped live Habr tests.
- `npm run lint` passes with existing warnings only.
- `npm run format:check` passes.
- `npm run check:duplication` passes.
- `node scripts/validate-changeset.mjs` passes.
- Manual smoke test for `--capture api --archive zip -- URL` produced a non-empty ZIP.

Docker-specific tests were not run locally because Docker is not installed in this environment.
