### PR TITLE
Fix JavaScript CLI version lookup

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,2 @@
+# .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
+# Updated: 2026-04-14T15:38:45.969Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-04-17T22:19:40.761Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
-# Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-04-17T22:19:40.761Z

--- a/js/.changeset/cli-version-cwd.md
+++ b/js/.changeset/cli-version-cwd.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Fix JavaScript CLI version output when run from another npm project.

--- a/js/bin/web-capture.js
+++ b/js/bin/web-capture.js
@@ -9,6 +9,7 @@ import path from 'path';
 import { URL } from 'node:url';
 import { makeConfig } from 'lino-arguments';
 import makeLog from 'log-lazy';
+import packageJson from '../package.json' with { type: 'json' };
 
 function makeVerboseLog(enabled) {
   return makeLog({
@@ -213,7 +214,7 @@ const config = makeConfig({
       })
       .help('help')
       .alias('help', 'h')
-      .version()
+      .version(packageJson.version)
       .alias('version', 'v')
       .example('web-capture --serve', 'Start API server on port 3000')
       .example(

--- a/js/tests/unit/cli.test.js
+++ b/js/tests/unit/cli.test.js
@@ -1,8 +1,10 @@
 // Unit tests for CLI argument parsing and functionality
 import { spawn } from 'child_process';
 import http from 'node:http';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { dirname, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
+import packageJson from '../../package.json' with { type: 'json' };
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -107,6 +109,26 @@ describe('CLI', () => {
       expect(result.code).toBe(0);
       // yargs outputs just the version number
       expect(result.stdout).toMatch(/\d+\.\d+\.\d+/);
+    });
+
+    test('shows web-capture version when run from another npm project', async () => {
+      const callerProjectDir = mkdtempSync(join(process.cwd(), 'caller-'));
+      writeFileSync(
+        join(callerProjectDir, 'package.json'),
+        JSON.stringify({
+          name: 'caller-project',
+          version: '1.0.0',
+        })
+      );
+
+      try {
+        const result = await runCli(['--version'], { cwd: callerProjectDir });
+
+        expect(result.code).toBe(0);
+        expect(result.stdout.trim()).toBe(packageJson.version);
+      } finally {
+        rmSync(callerProjectDir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #79.

The JavaScript CLI now reads @link-assistant/web-capture's own package version and passes it explicitly to yargs, so `web-capture --version` no longer depends on the caller project's current working directory.

## Reproduction Covered

Added a CLI regression test that creates a temporary caller npm project with `version: 1.0.0`, runs `web-capture --version` from that directory, and asserts the output is the web-capture package version.

## Tests

- `npm test -- --runInBand tests/unit/cli.test.js` - passed
- `npm run lint` - passed with existing warnings
- `npm run format:check` - passed
- `npm run check:duplication` - passed

Full `npm test -- --runInBand` was attempted locally. It fails because this environment lacks Docker (`docker: not found`) and the Playwright browser binary (`Executable doesn't exist at /workspace/.cache/ms-playwright/...`); unrelated suites still ran and the CLI regression passed.