### PR TITLE
Add Habr archive markdown compatibility controls

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-04-17T22:19:54.039Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-04-17T22:19:54.039Z

--- a/js/.changeset/habr-archive-markdown.md
+++ b/js/.changeset/habr-archive-markdown.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Add Habr archive-compatible markdown controls for figure-numbered image localization and preserved code block whitespace.

--- a/js/src/lib.js
+++ b/js/src/lib.js
@@ -312,6 +312,7 @@ export function convertRelativeUrls(html, baseUrl) {
  * @param {boolean} [options.extractMetadata=true] - Extract article metadata
  * @param {boolean} [options.postProcess=true] - Apply post-processing pipeline
  * @param {boolean} [options.detectCodeLanguage=true] - Detect/correct code languages
+ * @param {boolean} [options.preserveCodeWhitespace=false] - Keep original whitespace inside code blocks
  * @returns {Object} Result with { markdown, metadata }
  */
 export function convertHtmlToMarkdownEnhanced(html, baseUrl, options = {}) {
@@ -320,6 +321,7 @@ export function convertHtmlToMarkdownEnhanced(html, baseUrl, options = {}) {
     extractMetadata: shouldExtractMetadata = true,
     postProcess = true,
     detectCodeLanguage = true,
+    preserveCodeWhitespace = false,
   } = options;
 
   // Ensure all URLs are absolute before Markdown conversion
@@ -422,7 +424,7 @@ export function convertHtmlToMarkdownEnhanced(html, baseUrl, options = {}) {
   // Handle code language detection/correction
   if (detectCodeLanguage) {
     $('pre code').each(function () {
-      const codeText = $(this).text().trim();
+      const codeText = $(this).text();
       const language =
         $(this)
           .attr('class')
@@ -441,6 +443,12 @@ export function convertHtmlToMarkdownEnhanced(html, baseUrl, options = {}) {
       ) {
         $(this).removeClass(`language-${language}`).addClass('language-coq');
       }
+    });
+  }
+
+  if (preserveCodeWhitespace) {
+    $('pre code').each(function () {
+      $(this).text($(this).text().replace(/\r\n?/g, '\n'));
     });
   }
 

--- a/js/src/localize-images.js
+++ b/js/src/localize-images.js
@@ -24,7 +24,8 @@ import { retry } from './retry.js';
  * @returns {Object[]} Array of {fullMatch, altText, url}
  */
 export function extractImageReferences(markdownText) {
-  const imageRegex = /!\[([^\]]*)\]\((https?:\/\/[^)]+)\)/g;
+  const imageRegex =
+    /!\[([^\]]*)\]\((https?:\/\/[^\s)]+)(?:\s+["'][^"']*["'])?\)/g;
   const images = [];
   let match;
 
@@ -74,6 +75,18 @@ export function generateLocalFilename(url, index) {
 }
 
 /**
+ * Generate a stable figure-numbered filename.
+ *
+ * @param {string} url - Image URL
+ * @param {number} index - Zero-based index
+ * @returns {string} Local filename (e.g., 'figure-1.png')
+ */
+export function generateFigureFilename(url, index) {
+  const ext = getExtensionFromUrl(url);
+  return `figure-${index + 1}${ext}`;
+}
+
+/**
  * Localize images in markdown text by downloading external images
  * and replacing URLs with local paths.
  *
@@ -83,6 +96,7 @@ export function generateLocalFilename(url, index) {
  * @param {boolean} [options.dryRun=false] - Only report what would be done
  * @param {Function} [options.onProgress] - Callback(index, total, status, url)
  * @param {string[]} [options.excludeDomains] - Domains to skip (already local)
+ * @param {Function} [options.filenameGenerator] - Callback(url, index, image) for local filenames
  * @returns {Promise<Object>} Result with updated markdown and metadata
  */
 export async function localizeImages(markdownText, options = {}) {
@@ -91,6 +105,7 @@ export async function localizeImages(markdownText, options = {}) {
     dryRun = false,
     onProgress,
     excludeDomains = [],
+    filenameGenerator = generateLocalFilename,
   } = options;
 
   const allImages = extractImageReferences(markdownText);
@@ -128,7 +143,7 @@ export async function localizeImages(markdownText, options = {}) {
 
   for (let i = 0; i < externalImages.length; i++) {
     const image = externalImages[i];
-    const localFilename = generateLocalFilename(image.url, i);
+    const localFilename = filenameGenerator(image.url, i, image);
     const relativePath = `${imagesDir}/${localFilename}`;
 
     if (onProgress) {

--- a/js/tests/unit/html2md.test.js
+++ b/js/tests/unit/html2md.test.js
@@ -1,4 +1,7 @@
-import { convertHtmlToMarkdown } from '../../src/lib.js';
+import {
+  convertHtmlToMarkdown,
+  convertHtmlToMarkdownEnhanced,
+} from '../../src/lib.js';
 
 describe('convertHtmlToMarkdown', () => {
   it('removes empty links and anchor headings', () => {
@@ -606,5 +609,46 @@ describe('convertHtmlToMarkdown', () => {
     expect(md).toMatch(
       /\|\s*description\s*\|\s*string\s*\|\s*no\s*\|\s*order description\s*\|/
     );
+  });
+});
+
+describe('convertHtmlToMarkdownEnhanced Habr compatibility', () => {
+  it('preserves article code line breaks and extracts formulas from a Habr fixture', () => {
+    const html = `
+      <article>
+        <h1>The Links Theory 0.0.2</h1>
+        <div class="article-formatted-body">
+          <p>A formula <img class="formula" source="\\mathbf{L}: L \\to L^2" alt="formula"> remains inline.</p>
+          <figure>
+            <img src="https://habrastorage.org/r/w1560/getpro/habr/upload_files/abc.png" alt="Figure 1">
+            <figcaption>Figure 1. Link multiplication.</figcaption>
+          </figure>
+          <pre><code>L = { 1 , 2 }
+L x L = {
+  (1, 1),
+  (1, 2),
+}</code></pre>
+        </div>
+      </article>
+    `;
+
+    const { markdown } = convertHtmlToMarkdownEnhanced(
+      html,
+      'https://habr.com/en/articles/895896/',
+      { preserveCodeWhitespace: true }
+    );
+
+    expect(markdown).toContain('$\\\\mathbf{L}: L \\\\to L^2$');
+    expect(markdown).toContain(
+      '![Figure 1](https://habrastorage.org/r/w1560/getpro/habr/upload_files/abc.png)'
+    );
+    expect(markdown).toContain(`\`\`\`
+L = { 1 , 2 }
+L x L = {
+  (1, 1),
+  (1, 2),
+}
+\`\`\``);
+    expect(markdown).not.toContain('L = { 1 , 2 }L x L');
   });
 });

--- a/js/tests/unit/localize-images.test.js
+++ b/js/tests/unit/localize-images.test.js
@@ -2,6 +2,8 @@ import {
   extractImageReferences,
   getExtensionFromUrl,
   generateLocalFilename,
+  generateFigureFilename,
+  localizeImages,
 } from '../../src/localize-images.js';
 
 describe('localize-images module', () => {
@@ -73,6 +75,40 @@ describe('localize-images module', () => {
       expect(generateLocalFilename('https://example.com/photo.gif', 2)).toBe(
         'image-03.gif'
       );
+    });
+  });
+
+  describe('generateFigureFilename', () => {
+    it('generates figure-numbered filenames while preserving extensions', () => {
+      expect(
+        generateFigureFilename('https://habrastorage.org/getpro/habr/a.png', 0)
+      ).toBe('figure-1.png');
+      expect(
+        generateFigureFilename('https://habrastorage.org/getpro/habr/a.jpg', 9)
+      ).toBe('figure-10.jpg');
+    });
+  });
+
+  describe('localizeImages', () => {
+    it('accepts a custom filename generator for archive-compatible paths', async () => {
+      const markdown =
+        '![Figure 1](https://habrastorage.org/r/w1560/getpro/habr/figure.png "Figure 1")';
+
+      const result = await localizeImages(markdown, {
+        dryRun: true,
+        filenameGenerator: generateFigureFilename,
+      });
+
+      expect(result.markdown).toBe('![Figure 1](images/figure-1.png)');
+      expect(result.metadata).toEqual([
+        {
+          index: 1,
+          originalUrl:
+            'https://habrastorage.org/r/w1560/getpro/habr/figure.png',
+          altText: 'Figure 1',
+          localPath: 'images/figure-1.png',
+        },
+      ]);
     });
   });
 });

--- a/rust/src/html.rs
+++ b/rust/src/html.rs
@@ -194,9 +194,7 @@ pub fn convert_to_utf8(html: &str) -> String {
 #[must_use]
 pub fn has_javascript(html: &str) -> bool {
     let pattern = r"<script[^>]*>[\s\S]*?</script>|<script[^>]*/\s*>|javascript:";
-    Regex::new(pattern)
-        .map(|re| re.is_match(html))
-        .unwrap_or(false)
+    Regex::new(pattern).is_ok_and(|re| re.is_match(html))
 }
 
 /// Check if content is valid HTML
@@ -211,9 +209,7 @@ pub fn has_javascript(html: &str) -> bool {
 #[must_use]
 pub fn is_html(html: &str) -> bool {
     let pattern = r"<html[^>]*>[\s\S]*?</html>";
-    Regex::new(pattern)
-        .map(|re| re.is_match(html))
-        .unwrap_or(false)
+    Regex::new(pattern).is_ok_and(|re| re.is_match(html))
 }
 
 /// Decode HTML entities to unicode characters.


### PR DESCRIPTION
## Summary

Fixes #78.

Adds Habr/archive-compatible controls for markdown conversion and image localization:

- adds `preserveCodeWhitespace` to `convertHtmlToMarkdownEnhanced()` so Habr code blocks keep their original line breaks instead of being collapsed or trimmed during preprocessing
- adds `generateFigureFilename()` and a `filenameGenerator` option to `localizeImages()` so downstream archives can produce stable `images/figure-1.png` style paths
- tightens markdown image reference parsing so optional image titles are stripped when localizing remote images
- adds deterministic Habr fixture coverage for formulas, figures, and multiline code blocks
- adds the required JS changeset and updates two Rust regex checks to satisfy current Clippy on CI

## Reproduction

The issue can be reproduced with Habr article-only HTML that includes an inline formula image, a Habr-hosted figure, and a multiline `<pre><code>` block. Before this change, localization only exposed sequential `image-01.*` names and markdown image titles could leak into the URL; the fixture also guards against code block line-break collapse.

## Tests

- `node --experimental-vm-modules ./node_modules/.bin/jest tests/unit/localize-images.test.js tests/unit/html2md.test.js --runInBand`
- `npm run format:check`
- `npm run lint` (passes with existing warnings)
- `npx changeset status`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`