### PR TITLE
Fix Rust Habr formula markdown extraction

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -254,26 +254,18 @@ pub fn convert_html_to_markdown_enhanced(
     base_url: Option<&str>,
     options: &EnhancedOptions,
 ) -> Result<EnhancedMarkdownResult> {
-    let conversion_html = if let Some(body_selector) = options.body_selector.as_deref() {
-        let body_html = markdown::select_html(html, body_selector);
-        let title_selector = options
-            .content_selector
-            .as_deref()
-            .map_or_else(|| "h1".to_string(), |selector| format!("{selector} h1, h1"));
-        let title_html = markdown::select_html(html, &title_selector);
-        match (title_html, body_html) {
-            (Some(title), Some(body)) => format!("{title}\n{body}"),
-            (None, Some(body)) => body,
-            _ => html.to_string(),
-        }
-    } else if let Some(content_selector) = options.content_selector.as_deref() {
-        markdown::select_html(html, content_selector).unwrap_or_else(|| html.to_string())
-    } else {
-        html.to_string()
-    };
+    let mut html_for_markdown = scope_html_with_selectors(html, options);
+
+    if options.extract_latex {
+        html_for_markdown = replace_latex_formula_elements(&html_for_markdown);
+    }
+
+    if options.detect_code_language {
+        html_for_markdown = correct_code_languages(&html_for_markdown);
+    }
 
     // Start with basic markdown conversion
-    let mut md = markdown::convert_html_to_markdown(&conversion_html, base_url)?;
+    let mut md = markdown::convert_html_to_markdown(&html_for_markdown, base_url)?;
 
     // Extract metadata if requested
     let extracted_metadata = if options.extract_metadata {
@@ -305,9 +297,191 @@ pub fn convert_html_to_markdown_enhanced(
         md = postprocess::post_process_markdown(&md, &postprocess::PostProcessOptions::default());
     }
 
+    if options.extract_latex {
+        md = normalize_extracted_latex_markdown(&md);
+    }
+
     Ok(EnhancedMarkdownResult {
         markdown: md,
         metadata: extracted_metadata,
+    })
+}
+
+fn normalize_extracted_latex_markdown(markdown: &str) -> String {
+    let re = regex::Regex::new(r"\$([^$\n]+)\$").expect("valid regex");
+    re.replace_all(markdown, |caps: &regex::Captures<'_>| {
+        let formula = caps.get(1).map_or("", |m| m.as_str()).replace(r"\\", r"\");
+        format!("${formula}$")
+    })
+    .into_owned()
+}
+
+fn scope_html_with_selectors(html: &str, options: &EnhancedOptions) -> String {
+    if let Some(body_selector) = options.body_selector.as_deref() {
+        let body_html = markdown::select_html(html, body_selector);
+        let title_selector = options
+            .content_selector
+            .as_deref()
+            .map_or_else(|| "h1".to_string(), |selector| format!("{selector} h1, h1"));
+        let title_html = markdown::select_html(html, &title_selector);
+        return match (title_html, body_html) {
+            (Some(title), Some(body)) => format!("{title}\n{body}"),
+            (None, Some(body)) => body,
+            _ => html.to_string(),
+        };
+    }
+
+    options
+        .content_selector
+        .as_deref()
+        .and_then(|selector| markdown::select_html(html, selector))
+        .unwrap_or_else(|| html.to_string())
+}
+
+fn replace_latex_formula_elements(html: &str) -> String {
+    let mut result = html.to_string();
+
+    let img_formula_re = regex::Regex::new(r"(?is)<img\b[^>]*>").expect("valid regex");
+    result = img_formula_re
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            let tag = caps.get(0).map_or("", |m| m.as_str());
+            if is_formula_img_tag(tag) {
+                extract_attr(tag, "source")
+                    .or_else(|| extract_attr(tag, "alt"))
+                    .map_or_else(
+                        || tag.to_string(),
+                        |latex| format!("${}$", normalize_latex_for_html(&latex)),
+                    )
+            } else {
+                tag.to_string()
+            }
+        })
+        .into_owned();
+
+    let math_attr_re = regex::Regex::new(
+        r"(?is)<(?P<tag>mjx-container|span|div)\b(?P<attrs>[^>]*)>.*?</(?P<tag_close>mjx-container|span|div)>",
+    )
+    .expect("valid regex");
+    math_attr_re
+        .replace_all(&result, |caps: &regex::Captures<'_>| {
+            let full = caps.get(0).map_or("", |m| m.as_str());
+            let attrs = caps.name("attrs").map_or("", |m| m.as_str());
+            let tag = caps
+                .name("tag")
+                .map_or("", |m| m.as_str())
+                .to_ascii_lowercase();
+            let tag_close = caps
+                .name("tag_close")
+                .map_or("", |m| m.as_str())
+                .to_ascii_lowercase();
+
+            if tag != tag_close || !is_math_attrs(&tag, attrs) {
+                return full.to_string();
+            }
+
+            extract_attr(attrs, "data-tex")
+                .or_else(|| extract_attr(attrs, "data-latex"))
+                .or_else(|| extract_annotation_tex(full))
+                .map_or_else(
+                    || full.to_string(),
+                    |latex| format!("${}$", normalize_latex_for_html(&latex)),
+                )
+        })
+        .into_owned()
+}
+
+fn correct_code_languages(html: &str) -> String {
+    let code_re = regex::Regex::new(r"(?is)<code\b(?P<attrs>[^>]*)>(?P<body>.*?)</code>")
+        .expect("valid regex");
+
+    code_re
+        .replace_all(html, |caps: &regex::Captures<'_>| {
+            let full = caps.get(0).map_or("", |m| m.as_str());
+            let attrs = caps.name("attrs").map_or("", |m| m.as_str());
+            let body = caps.name("body").map_or("", |m| m.as_str());
+
+            if !has_matlab_language(attrs) || !looks_like_coq(body) {
+                return full.to_string();
+            }
+
+            let updated_attrs = attrs
+                .replace("language-matlab", "language-coq")
+                .replace(r#"class="matlab""#, r#"class="coq""#)
+                .replace("class='matlab'", "class='coq'");
+
+            format!("<code{updated_attrs}>{body}</code>")
+        })
+        .into_owned()
+}
+
+fn is_formula_img_tag(tag: &str) -> bool {
+    extract_attr(tag, "source").is_some()
+        || extract_attr(tag, "class").is_some_and(|classes| classes.contains("formula"))
+}
+
+fn is_math_attrs(tag: &str, attrs: &str) -> bool {
+    tag == "mjx-container"
+        || extract_attr(attrs, "class").is_some_and(|classes| {
+            classes.contains("katex") || classes.contains("math") || classes.contains("MathJax")
+        })
+}
+
+fn has_matlab_language(attrs: &str) -> bool {
+    extract_attr(attrs, "class").is_some_and(|classes| {
+        classes
+            .split_whitespace()
+            .any(|class| class == "language-matlab" || class == "matlab")
+    })
+}
+
+fn looks_like_coq(text: &str) -> bool {
+    let decoded = crate::html::decode_html_entities(text);
+    [
+        "Require Import",
+        "Definition",
+        "Fixpoint",
+        "Lemma",
+        "Theorem",
+        "Proof",
+        "Qed",
+        "Notation",
+        "Inductive",
+    ]
+    .iter()
+    .any(|needle| decoded.contains(needle))
+}
+
+fn normalize_latex_for_html(latex: &str) -> String {
+    latex.trim().replace('\\', "&#92;")
+}
+
+fn extract_annotation_tex(html: &str) -> Option<String> {
+    let re = regex::Regex::new(
+        r#"(?is)<annotation\b[^>]*encoding\s*=\s*["']application/x-tex["'][^>]*>(.*?)</annotation>"#,
+    )
+    .ok()?;
+
+    re.captures(html).and_then(|caps| {
+        let text = caps.get(1)?.as_str().trim();
+        (!text.is_empty()).then(|| crate::html::decode_html_entities(text))
+    })
+}
+
+fn extract_attr(tag: &str, attr: &str) -> Option<String> {
+    let re = regex::Regex::new(&format!(
+        r#"(?is)\b{}\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))"#,
+        regex::escape(attr)
+    ))
+    .ok()?;
+
+    re.captures(tag).and_then(|caps| {
+        let value = caps
+            .get(1)
+            .or_else(|| caps.get(2))
+            .or_else(|| caps.get(3))?
+            .as_str()
+            .trim();
+        (!value.is_empty()).then(|| crate::html::decode_html_entities(value))
     })
 }
 

--- a/rust/src/markdown.rs
+++ b/rust/src/markdown.rs
@@ -61,6 +61,7 @@ pub fn convert_html_to_markdown(html: &str, base_url: Option<&str>) -> Result<St
     Ok(cleaned_markdown)
 }
 
+#[must_use]
 pub fn select_html(html: &str, selector_str: &str) -> Option<String> {
     let selector = Selector::parse(selector_str).ok()?;
     let document = Html::parse_document(html);

--- a/rust/tests/unit/markdown.rs
+++ b/rust/tests/unit/markdown.rs
@@ -1,4 +1,8 @@
-use web_capture::markdown::{clean_markdown, convert_html_to_markdown};
+use web_capture::{
+    convert_html_to_markdown_enhanced,
+    markdown::{clean_markdown, convert_html_to_markdown},
+    EnhancedOptions,
+};
 
 #[test]
 fn test_convert_html_to_markdown_basic() {
@@ -58,4 +62,84 @@ fn test_clean_markdown_adds_trailing_newline() {
     let markdown = "Content";
     let result = clean_markdown(markdown);
     assert!(result.ends_with('\n'));
+}
+
+#[test]
+fn test_enhanced_markdown_extracts_habr_formula_images() {
+    let html = r#"
+        <article>
+            <p>Everything is <img class="formula inline" source="100\%" alt="100\%"> serious.</p>
+            <blockquote><p><img class="formula inline" source="\forall x, P(x)" alt="formula"></p></blockquote>
+        </article>
+    "#;
+
+    let result = convert_html_to_markdown_enhanced(
+        html,
+        None,
+        &EnhancedOptions {
+            extract_metadata: false,
+            post_process: false,
+            detect_code_language: false,
+            ..EnhancedOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        result.markdown.contains(r"Everything is $100\%$ serious."),
+        "markdown was:\n{}",
+        result.markdown
+    );
+    assert!(
+        result.markdown.contains(r"$\forall x, P(x)$"),
+        "markdown was:\n{}",
+        result.markdown
+    );
+    assert!(!result.markdown.contains("<img"));
+    assert!(!result.markdown.contains("formula inline"));
+}
+
+#[test]
+fn test_enhanced_markdown_can_disable_latex_extraction() {
+    let html = r#"<p><img class="formula inline" source="x^2" alt="x squared"></p>"#;
+
+    let result = convert_html_to_markdown_enhanced(
+        html,
+        None,
+        &EnhancedOptions {
+            extract_latex: false,
+            extract_metadata: false,
+            post_process: false,
+            detect_code_language: false,
+            content_selector: None,
+            body_selector: None,
+        },
+    )
+    .unwrap();
+
+    assert!(!result.markdown.contains("$x^2$"));
+}
+
+#[test]
+fn test_enhanced_markdown_corrects_coq_code_language() {
+    let html = r#"
+        <pre><code class="language-matlab">Require Import Coq.Init.Logic.
+Theorem example : True.
+Proof.
+Qed.</code></pre>
+    "#;
+
+    let result = convert_html_to_markdown_enhanced(
+        html,
+        None,
+        &EnhancedOptions {
+            extract_metadata: false,
+            post_process: false,
+            ..EnhancedOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.markdown.contains("Require Import Coq.Init.Logic."));
+    assert!(!result.markdown.contains("matlab"));
 }


### PR DESCRIPTION
## Summary

Fixes #77.

This updates the Rust enhanced markdown conversion path so the options advertised by the CLI are applied before HTML is converted to markdown:

- rewrites Habr `img.formula` / `img[source]` elements to inline LaTeX markdown using `source` with `alt` fallback
- rewrites supported KaTeX/MathJax-style elements that expose TeX through attributes or annotation nodes
- preserves the `--no-extract-latex` behavior by skipping those rewrites when disabled
- applies the existing Coq language correction before markdown conversion when code detection is enabled
- adds `#[must_use]` to `markdown::select_html` for current stable Clippy compatibility

## Reproduction

A Habr-like snippet containing inline and blockquote formula images previously converted to markdown with raw `<img class="formula inline" ...>` HTML still present. The new unit regression verifies those formula images become `$...$` markdown and no formula image markup remains.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p web-capture --test unit` (92 passed)