### PR TITLE
fix(js): add js- prefix to tags/releases to match Rust convention

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-04-20T11:07:04.608Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-04-20T11:07:04.608Z

--- a/docs/case-studies/issue-88/ANALYSIS.md
+++ b/docs/case-studies/issue-88/ANALYSIS.md
@@ -1,0 +1,99 @@
+# Case Study: Issue #88 — JavaScript CI/CD Missing `js-` Tag Prefix
+
+## Issue
+
+**URL:** https://github.com/link-assistant/web-capture/issues/88  
+**Title:** JavaScript CI/CD should also have prefix in tags/releases (`js-`), like we have with Rust (`rust-`)  
+**Labels:** bug  
+
+## Requirements
+
+1. JS GitHub releases must use `js-v<version>` tags (e.g., `js-v1.7.8`), matching the Rust convention of `rust-v<version>`.
+2. JS release names must be descriptive (e.g., `JS v1.7.8`), matching Rust's `Rust v0.3.2`.
+3. Compare all CI/CD files with the two template repositories and adopt best practices:
+   - https://github.com/link-foundation/js-ai-driven-development-pipeline-template
+   - https://github.com/link-foundation/rust-ai-driven-development-pipeline-template
+4. Report the same issue to the JS template repository if it has the same bug.
+
+## Timeline of Events
+
+- The repo was set up with both a Rust and a JavaScript package.
+- Rust releases were implemented with `rust-v<version>` tags from the start (see `rust-create-github-release.mjs`, line 67: `const tag = \`rust-v${version}\``).
+- The JavaScript `create-github-release.mjs` was written using `v<version>` (line 53), without a language prefix.
+- JS releases accumulated with tags like `v1.7.8`, `v1.7.7`, etc., while Rust releases used `rust-v0.3.2`.
+- Issue #88 was filed to align JS tags with the Rust convention.
+
+## Root Cause Analysis
+
+### Primary Root Cause
+
+**File:** `scripts/create-github-release.mjs`, line 53  
+```javascript
+// BEFORE (wrong):
+const tag = `v${version}`;
+
+// AFTER (correct):
+const tag = `js-v${version}`;
+```
+
+The JS script was written without considering the multi-language nature of the repository. When both JS and Rust packages share the same GitHub repository, tags must be namespaced by language to avoid ambiguity and conflicts.
+
+### Secondary Issue
+
+**File:** `scripts/format-github-release.mjs`, line 57  
+```javascript
+// BEFORE (wrong):
+const tag = `v${version}`;
+
+// AFTER (correct):
+const tag = `js-v${version}`;
+```
+
+This script retrieves and updates the GitHub release by tag. It must use the same tag format as `create-github-release.mjs`.
+
+### Release Name Issue
+
+**File:** `scripts/create-github-release.mjs`, line 81  
+```javascript
+// BEFORE (wrong — just shows "1.7.8"):
+name: version,
+
+// AFTER (correct — shows "JS v1.7.8"):
+name: `JS v${version}`,
+```
+
+Rust uses `Rust v${version}` as the release name, which is clear in the GitHub releases list. JS should do the same.
+
+## Template Comparison
+
+### JS Template (`link-foundation/js-ai-driven-development-pipeline-template`)
+
+**Finding:** The JS template has the **same bug** — `scripts/create-github-release.mjs` also uses `v${version}` without a prefix. A separate GitHub issue should be filed against the template repository.
+
+### Rust Template (`link-foundation/rust-ai-driven-development-pipeline-template`)
+
+**Finding:** The Rust template uses `v${version}` by default (not `rust-v`). The web-capture Rust scripts correctly override this with the `rust-v` prefix. However, the templates themselves could benefit from explicit prefix support.
+
+## Fix Applied
+
+Two files were modified:
+
+### 1. `scripts/create-github-release.mjs`
+
+- Tag changed from `v${version}` → `js-v${version}`
+- Release name changed from `version` → `` `JS v${version}` ``
+- Default release notes changed from `Release ${version}` → `JS Release ${version}`
+
+### 2. `scripts/format-github-release.mjs`
+
+- Tag changed from `v${version}` → `js-v${version}` (so the formatter can find and update the correct release)
+
+## Impact
+
+- **New releases:** Will use `js-v<version>` tags going forward.
+- **Existing releases:** Already-created releases with `v<version>` tags are unaffected (they remain in the GitHub releases list with the old naming).
+- **No breaking changes** to npm publishing or versioning — only the GitHub tag/release name changes.
+
+## Related Issues to File in Template Repositories
+
+1. **JS Template:** File issue at https://github.com/link-foundation/js-ai-driven-development-pipeline-template reporting that `scripts/create-github-release.mjs` uses `v${version}` but multi-language repos need `js-v${version}`.

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -50,7 +50,7 @@ if (!version || !repository) {
   process.exit(1);
 }
 
-const tag = `v${version}`;
+const tag = `js-v${version}`;
 
 console.log(`Creating GitHub release for ${tag}...`);
 
@@ -70,7 +70,7 @@ try {
   }
 
   if (!releaseNotes) {
-    releaseNotes = `Release ${version}`;
+    releaseNotes = `JS Release ${version}`;
   }
 
   // Create release using GitHub API with JSON input
@@ -78,7 +78,7 @@ try {
   // (Previously caused apostrophes like "didn't" to appear as "didn'''" in releases)
   const payload = JSON.stringify({
     tag_name: tag,
-    name: version,
+    name: `JS v${version}`,
     body: releaseNotes,
   });
 

--- a/scripts/format-github-release.mjs
+++ b/scripts/format-github-release.mjs
@@ -54,7 +54,7 @@ if (!version || !repository || !commitSha) {
   process.exit(1);
 }
 
-const tag = `v${version}`;
+const tag = `js-v${version}`;
 
 try {
   // Get the release ID for this version


### PR DESCRIPTION
## Summary

- `scripts/create-github-release.mjs`: tag changed from `v<version>` → `js-v<version>`; release name changed from bare version number → `JS v<version>`
- `scripts/format-github-release.mjs`: tag changed from `v<version>` → `js-v<version>` so the formatter can find the correct release
- Added case study in `docs/case-studies/issue-88/ANALYSIS.md`

Fixes #88.

## Root Cause

JS GitHub releases used `v<version>` tags (e.g., `v1.7.8`) while Rust releases used `rust-v<version>` (e.g., `rust-v0.3.2`). Both languages live in the same repo so tags need a language prefix to be unambiguous.

The Rust scripts already had `rust-v${version}` hardcoded in `scripts/rust-create-github-release.mjs` (line 67). The JS equivalent (`scripts/create-github-release.mjs`) was missing the analogous `js-` prefix.

## Changes

| File | Change |
|------|--------|
| `scripts/create-github-release.mjs` | Tag: `v${version}` → `js-v${version}`; Name: `version` → `JS v${version}` |
| `scripts/format-github-release.mjs` | Tag: `v${version}` → `js-v${version}` |
| `docs/case-studies/issue-88/ANALYSIS.md` | New case study file |

## Template Issue

The JS template (`link-foundation/js-ai-driven-development-pipeline-template`) has the same bug. Filed as: https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/38

## Test Plan

- [x] Verify `scripts/create-github-release.mjs` uses `js-v${version}` as tag
- [x] Verify `scripts/format-github-release.mjs` uses `js-v${version}` as tag
- [x] Verify release name is `JS v${version}` matching Rust's `Rust v${version}`
- [ ] Next JS release after merge will create a `js-v<version>` tag