### PR TITLE
Fix Rust release race with concurrent JS release (issue #94)

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -254,6 +254,9 @@ jobs:
         if: steps.release_check.outputs.should_release == 'true' && steps.release_check.outputs.needs_auto_bump == 'true'
         id: auto_bump
         working-directory: .
+        # Uses scripts/safe-git-push.mjs for fetch+rebase+retry so concurrent
+        # pushes from the Rust release workflow don't cause non-fast-forward
+        # rejections. See docs/case-studies/issue-94.
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -263,7 +266,7 @@ jobs:
           git add -A
           NEW_VERSION=$(node -p "require('./js/package.json').version")
           git commit -m "chore(js): auto-bump to ${NEW_VERSION} for unreleased changes"
-          git push origin main
+          node scripts/safe-git-push.mjs --branch main
           echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "Auto-bumped to ${NEW_VERSION}"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -255,6 +255,9 @@ jobs:
       - name: Auto-bump patch version for unreleased changes
         if: steps.release_check.outputs.should_release == 'true' && steps.release_check.outputs.needs_auto_bump == 'true'
         id: auto_bump
+        # Uses scripts/safe-git-push.mjs for fetch+rebase+retry so concurrent
+        # pushes from the JS release workflow don't cause non-fast-forward
+        # rejections. See docs/case-studies/issue-94.
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -262,7 +265,7 @@ jobs:
           git add -A
           NEW_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
           git commit -m "chore(rust): auto-bump to ${NEW_VERSION} for unreleased changes"
-          git push origin main
+          node ../scripts/safe-git-push.mjs --branch main
           echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "Auto-bumped to ${NEW_VERSION}"
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-04-20T21:23:57.671Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-04-20T21:23:57.671Z

--- a/docs/case-studies/issue-94/README.md
+++ b/docs/case-studies/issue-94/README.md
@@ -1,0 +1,118 @@
+# Case Study: Issue #94 — Rust CI/CD release is broken
+
+- Issue: https://github.com/link-assistant/web-capture/issues/94
+- Failing run: https://github.com/link-assistant/web-capture/actions/runs/24686173280/job/72197673668
+- Head SHA under test: `4a3dc433a560210b8bc08ff77711382bf2468dc1`
+  (merge of PR #93 — Google Docs capture fixes)
+- PR fixing this issue: #95 (branch `issue-94-2e4653a0a183`)
+
+## Timeline / sequence of events
+
+All timestamps UTC from the workflow log (download with
+`gh run view 24686173280 --repo link-assistant/web-capture --log`; the logs
+folder is `.gitignore`d):
+
+| Time | Event |
+| --- | --- |
+| 19:31:12 | Two workflows start simultaneously on the same push-to-`main` event (merge of PR #93): `JavaScript Checks and Release` (run 24686173274) and `Rust Checks and Release` (run 24686173280). |
+| 19:31:17 | Rust `detect-changes` sees `rust-code-changed=false` for the JS-only PR merge. |
+| 19:32:03 – 19:34:35 | Rust test matrix runs on `4a3dc43…` (green on ubuntu / macos / windows). |
+| 19:42:15 | Rust `build` job finishes. |
+| 19:42:18 | Rust `release` job starts on base commit `4a3dc43…`. |
+| ~19:42:19 | Meanwhile the JS `release` job (which had parallel workspace) runs `instant-version-bump.mjs` (patch), commits `1.7.10` and pushes to `main` → new head `aef6f59`. |
+| 19:42:49 | Rust `release_check` decides `should_release=true`, `needs_auto_bump=true` (publishable paths changed since `rust-v0.3.2`). |
+| 19:42:51 | `rust-version-bump.mjs` bumps Cargo.toml 0.3.2 → 0.3.3, commits `c6f4e7c` on top of local `4a3dc43…`, then `git push origin main` fails: `! [rejected] main -> main (non-fast-forward)`. |
+| 19:42:51 | Release job exits with code 1. All later steps (`Determine release version`, `Build release`, `Publish to crates.io`, `Create GitHub Release`) are skipped. |
+
+Net effect: the JS release (npm `1.7.10`) went out; the Rust release (crates.io `0.3.3`) was never published, and `rust/src/browser.rs` + `rust/src/gdocs.rs` changes from PR #93 remain unreleased.
+
+## Root cause
+
+The Rust `release` job's `Auto-bump patch version for unreleased changes` step does **not** sync with `origin/main` before committing and pushing, and has **no retry**:
+
+```yaml
+# .github/workflows/rust.yml  (broken)
+- name: Auto-bump patch version for unreleased changes
+  if: steps.release_check.outputs.should_release == 'true' && steps.release_check.outputs.needs_auto_bump == 'true'
+  id: auto_bump
+  run: |
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    node ../scripts/rust-version-bump.mjs --bump-type patch --description "Auto-release unreleased changes"
+    git add -A
+    NEW_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+    git commit -m "chore(rust): auto-bump to ${NEW_VERSION} for unreleased changes"
+    git push origin main     # <-- fails with non-fast-forward when JS release pushed first
+```
+
+Because the JS and Rust workflows both trigger on the same `push` event to `main` and both try to auto-bump and push to `main`, whichever one finishes its auto-bump first "wins" and the other gets `! [rejected] main -> main (non-fast-forward)`.
+
+### Why the concurrency guard didn't help
+Each workflow has its own per-workflow concurrency group (`${{ github.workflow }}-${{ github.ref }}`). JS and Rust workflows are different workflows, so they can run concurrently. They must — JS needs its own `npm` auth context. The right fix is to make the pushes tolerant to each other (fetch + rebase + retry), not to serialize the whole workflow.
+
+### The same anti-pattern also exists in JS auto-bump
+`.github/workflows/js.yml` uses the same inline pattern (`instant-version-bump.mjs → git commit → git push origin main`) with no fetch/rebase/retry. In this run JS won the race; a symmetric run where Rust pushes first would have broken JS. The upstream JS template already got this right (`scripts/version-and-commit.mjs` has `git fetch origin main` + rebase before commit), and the JS `publish-to-npm.mjs --should-pull` also pulls before publishing — but neither path is used by the auto-bump block, so the window of races stays open.
+
+## Upstream template comparison
+
+- `link-foundation/rust-ai-driven-development-pipeline-template` (`scripts/version-and-commit.rs`) does:
+  - `git fetch origin <branch>` before committing, and rebases if behind.
+  - **Retries** `git push` up to 3 times, running `git pull --rebase origin <branch>` between attempts.
+  - Pushes `--tags` separately after the commit push succeeds.
+- `link-foundation/js-ai-driven-development-pipeline-template` (`scripts/version-and-commit.mjs`) does `git fetch origin main` + rebase before committing (handled by `version-and-commit.mjs`, which is only invoked in the **changeset** path in our repo — the **auto-bump** path uses raw inline shell without this protection).
+
+So the templates already contain the best practice; this repo copied an older / truncated version of the auto-bump block that doesn't invoke the sync-aware script. The issue should also be reported upstream in the Rust template, since the auto-bump path in the current template's `release.yml` only works because `version-and-commit.rs` is always used — but if other templates or downstream repos copy the inline block, they inherit the bug. (See `proposed-upstream-issue.md`.)
+
+## Requirements extracted from the issue
+
+1. **R1:** Find the root cause of the failed CI/CD release (issue #94).
+2. **R2:** Compare every workflow / CI-CD script in this repo against the two upstream templates and reuse best practices.
+3. **R3:** Compile all related logs and data into `docs/case-studies/issue-94/` for reconstructable case study.
+4. **R4:** Reconstruct timeline, enumerate requirements, identify root causes, and propose solution(s) for each requirement.
+5. **R5:** Report the same issue upstream if the template is affected, with reproducible example, workaround and suggested fix.
+6. **R6:** Add debug output / verbose mode if the current data is insufficient to pin down the root cause.
+
+## Solution plan
+
+### R1 — Fix the Rust release race (chosen solution)
+
+Make the Rust auto-bump step "race-safe" by teaching it to fetch, rebase if behind, push with retries, and resync between retries. Two matching touch points:
+
+1. `.github/workflows/rust.yml` — replace the inline shell with a call to a dedicated `scripts/rust-version-and-commit.mjs` flow that does the same safe-push dance the JS template already does.
+2. `scripts/rust-version-and-commit.mjs` — already exists for manual instant release; extend it to support auto-bump (pre-fetch / rebase / retryable push) so both manual and auto release paths share one race-safe implementation.
+
+Apply the same hardening to the JS auto-bump inline shell to prevent the mirror-image race.
+
+### R2 — Cross-compare scripts
+Done (see `upstream-templates/`). The one concrete bug found is the missing fetch-rebase-retry in both auto-bump steps. All other workflow structure (detect-changes, concurrency groups, permissions, OIDC, etc.) already matches the templates.
+
+### R3/R4 — Case study
+This document plus `upstream-templates/` (reference files) complete R3/R4. The
+raw CI logs for run 24686173280 were reviewed during analysis but not
+committed because the repo `.gitignore` excludes `*.log` — retrieve them with
+`gh run view 24686173280 --repo link-assistant/web-capture --log` if needed.
+
+### R5 — Upstream issue
+Drafted in `proposed-upstream-issue.md`. To be filed under `link-foundation/rust-ai-driven-development-pipeline-template` (the repo whose template is used here) as a defensive hardening suggestion so multi-package monorepos using both the JS and Rust templates never hit this race.
+
+### R6 — Debug / verbose
+Added `DEBUG` / `--verbose` support so the next failure (if any) prints `git remote -v`, `git rev-parse HEAD`, `git rev-parse origin/main`, and the full push stderr.
+
+## How to reproduce locally
+
+```bash
+# Simulate the race: two clones of main try to commit+push concurrently.
+git clone https://github.com/link-assistant/web-capture.git repo-a
+git clone https://github.com/link-assistant/web-capture.git repo-b
+cd repo-a && echo "# a" >> rust/CHANGELOG.md && git add -A && git commit -m "a" && git push origin main &
+cd ../repo-b && echo "# b" >> rust/CHANGELOG.md && git add -A && git commit -m "b" && git push origin main &
+wait
+# Exactly one of the two pushes is rejected with:
+#   ! [rejected]        main -> main (non-fast-forward)
+```
+
+## Verification after fix
+
+- Dry-run: `node scripts/rust-version-and-commit.mjs --bump-type patch --dry-run` (added verbose mode) executes fetch/rebase/retry path in a clean clone without pushing.
+- Real run: manual `workflow_dispatch` → `instant` release on a feature branch simulating divergence still succeeds.
+- Observed from CI: next merge to `main` that triggers both JS and Rust release concurrently publishes both npm and crates.io releases without a non-fast-forward error.

--- a/docs/case-studies/issue-94/proposed-upstream-issue.md
+++ b/docs/case-studies/issue-94/proposed-upstream-issue.md
@@ -1,0 +1,66 @@
+# Proposed upstream issue (Rust template & JS template): harden auto-bump against concurrent pushes
+
+Target repos:
+- https://github.com/link-foundation/rust-ai-driven-development-pipeline-template
+- https://github.com/link-foundation/js-ai-driven-development-pipeline-template
+
+## Problem
+
+When a monorepo uses both templates, a push to `main` triggers both `Rust Checks and Release` and `JavaScript Checks and Release`. Each workflow's `release` job calls its own auto-bump, commits a version bump to `main`, and pushes. Whichever pushes first wins; the other fails with:
+
+```
+! [rejected]        main -> main (non-fast-forward)
+error: failed to push some refs to 'https://github.com/…'
+```
+
+See a real failure at https://github.com/link-assistant/web-capture/actions/runs/24686173280/job/72197673668 (step "Auto-bump patch version for unreleased changes" in `Rust - Release`).
+
+## Root cause
+
+The auto-bump step does:
+
+```yaml
+git commit -m "…"
+git push origin main
+```
+
+with no pre-fetch / rebase / push-retry. A sibling workflow (other language's release) that auto-bumps on the same push event races and one of them loses.
+
+## Reproducer
+
+Two clones of the default branch race each other:
+
+```bash
+git clone <repo> a && git clone <repo> b
+(cd a && echo 1 >> x && git add . && git commit -m a && git push origin main) &
+(cd b && echo 2 >> y && git add . && git commit -m b && git push origin main) &
+wait
+# One push is rejected with "non-fast-forward".
+```
+
+## Workaround for affected downstream users
+
+In the inline auto-bump shell, replace `git push origin main` with:
+
+```bash
+git fetch origin main
+git rebase origin/main
+for i in 1 2 3; do
+  git push origin main && break
+  echo "push attempt $i failed; pulling and retrying"
+  git pull --rebase origin main || { git rebase --abort; exit 1; }
+done
+```
+
+## Suggested fix (upstream)
+
+`rust-ai-driven-development-pipeline-template/scripts/version-and-commit.rs` already implements fetch + rebase + 3× retry for `git push` (lines ~460–522). The problem is any repo that copies the inline `Auto-bump patch version …` YAML block from a release workflow without calling `version-and-commit.rs` inherits the race. Two fixes make the templates robust:
+
+1. Remove the inline `git commit && git push origin main` in the auto-bump step and always delegate to `scripts/version-and-commit.rs` (or equivalent `mjs`), which already does the safe push.
+2. Add an integration test (`scripts/simulate-concurrent-release.sh`) that clones the repo twice and tries to push concurrent version bumps; CI should show the retry happy-path.
+
+For the JS template, mirror the same refactor: `scripts/version-and-commit.mjs` already does `git fetch origin main` + rebase before commit. The **auto-bump** path in the release YAML should also route through it (or through `instant-version-bump.mjs` + a new safe-push helper) instead of raw `git push origin main`.
+
+## Impact
+
+Every monorepo that uses both templates (or any template that adds a second workflow pushing to the same default branch) will eventually hit this on a high-traffic merge. In `link-assistant/web-capture` it already broke a crates.io release.

--- a/docs/case-studies/issue-94/upstream-templates/js-instant-version-bump.mjs
+++ b/docs/case-studies/issue-94/upstream-templates/js-instant-version-bump.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+
+/**
+ * Instant version bump script for manual releases
+ * Bypasses the changeset workflow and directly updates version and changelog
+ *
+ * Usage: node scripts/instant-version-bump.mjs --bump-type <major|minor|patch> [--description <description>] [--js-root <path>]
+ *
+ * Configuration:
+ * - CLI: --js-root <path> to explicitly set JavaScript root
+ * - Environment: JS_ROOT=<path>
+ *
+ * Uses link-foundation libraries:
+ * - use-m: Dynamic package loading without package.json dependencies
+ * - command-stream: Modern shell command execution with streaming support
+ * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
+ *
+ * Addresses issues documented in:
+ * - Issue #21: Supporting both single and multi-language repository structures
+ * - Reference: link-assistant/agent PR #112 (--legacy-peer-deps fix)
+ * - Reference: link-assistant/agent PR #114 (configurable package root)
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import {
+  getJsRoot,
+  getPackageJsonPath,
+  needsCd,
+  parseJsRootConfig,
+} from './js-paths.mjs';
+
+// Load use-m dynamically
+const { use } = eval(
+  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+);
+
+// Import link-foundation libraries
+const { $ } = await use('command-stream');
+const { makeConfig } = await use('lino-arguments');
+
+// Parse CLI arguments using lino-arguments
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .option('bump-type', {
+        type: 'string',
+        default: getenv('BUMP_TYPE', ''),
+        describe: 'Version bump type: major, minor, or patch',
+        choices: ['major', 'minor', 'patch'],
+      })
+      .option('description', {
+        type: 'string',
+        default: getenv('DESCRIPTION', ''),
+        describe: 'Description for the version bump',
+      })
+      .option('js-root', {
+        type: 'string',
+        default: getenv('JS_ROOT', ''),
+        describe:
+          'JavaScript package root directory (auto-detected if not specified)',
+      }),
+});
+
+// Store the original working directory to restore after cd commands
+// IMPORTANT: command-stream's cd is a virtual command that calls process.chdir()
+const originalCwd = process.cwd();
+
+try {
+  const { bumpType, description, jsRoot: jsRootArg } = config;
+
+  // Get JavaScript package root (auto-detect or use explicit config)
+  const jsRootConfig = jsRootArg || parseJsRootConfig();
+  const jsRoot = getJsRoot({ jsRoot: jsRootConfig, verbose: true });
+
+  const finalDescription = description || `Manual ${bumpType} release`;
+
+  if (!bumpType || !['major', 'minor', 'patch'].includes(bumpType)) {
+    console.error(
+      'Usage: node scripts/instant-version-bump.mjs --bump-type <major|minor|patch> [--description <description>] [--js-root <path>]'
+    );
+    process.exit(1);
+  }
+
+  console.log(`\nBumping version (${bumpType})...`);
+
+  // Get current version
+  const packageJsonPath = getPackageJsonPath({ jsRoot });
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  const oldVersion = packageJson.version;
+  console.log(`Current version: ${oldVersion}`);
+
+  // Bump version using npm version (doesn't create git tag)
+  // IMPORTANT: cd is a virtual command that calls process.chdir(), so we restore after
+  if (needsCd({ jsRoot })) {
+    await $`cd ${jsRoot} && npm version ${bumpType} --no-git-tag-version`;
+    process.chdir(originalCwd);
+  } else {
+    await $`npm version ${bumpType} --no-git-tag-version`;
+  }
+
+  // Get new version
+  const updatedPackageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  const newVersion = updatedPackageJson.version;
+  console.log(`New version: ${newVersion}`);
+
+  // Update CHANGELOG.md
+  console.log('\nUpdating CHANGELOG.md...');
+  const changelogPath =
+    jsRoot === '.' ? 'CHANGELOG.md' : join(jsRoot, 'CHANGELOG.md');
+  let changelog = readFileSync(changelogPath, 'utf-8');
+
+  // Create new changelog entry
+  const newEntry = `## ${newVersion}
+
+### ${bumpType.charAt(0).toUpperCase() + bumpType.slice(1)} Changes
+
+- ${finalDescription}
+
+`;
+
+  // Insert new entry after the first heading (# Changelog or similar)
+  // Look for the first ## heading and insert before it
+  const firstVersionMatch = changelog.match(/^## /m);
+
+  if (firstVersionMatch) {
+    const insertPosition = firstVersionMatch.index;
+    changelog =
+      changelog.slice(0, insertPosition) +
+      newEntry +
+      changelog.slice(insertPosition);
+  } else {
+    // If no version headings exist, append after the main heading
+    const mainHeadingMatch = changelog.match(/^# .+$/m);
+    if (mainHeadingMatch) {
+      const insertPosition =
+        mainHeadingMatch.index + mainHeadingMatch[0].length;
+      changelog = `${changelog.slice(0, insertPosition)}\n\n${newEntry}${changelog.slice(insertPosition)}`;
+    } else {
+      // If no headings at all, prepend
+      changelog = `${newEntry}\n${changelog}`;
+    }
+  }
+
+  writeFileSync(changelogPath, changelog, 'utf-8');
+  console.log('✅ CHANGELOG.md updated');
+
+  // Synchronize package-lock.json
+  console.log('\nSynchronizing package-lock.json...');
+
+  // Use --legacy-peer-deps to handle peer dependency conflicts
+  // This addresses npm ERESOLVE errors documented in issue #111 / PR #112
+  // IMPORTANT: cd is a virtual command that calls process.chdir(), so we restore after
+  if (needsCd({ jsRoot })) {
+    await $`cd ${jsRoot} && npm install --package-lock-only --legacy-peer-deps`;
+    process.chdir(originalCwd);
+  } else {
+    await $`npm install --package-lock-only --legacy-peer-deps`;
+  }
+
+  console.log('\n✅ Instant version bump complete');
+  console.log(`Version: ${oldVersion} → ${newVersion}`);
+} catch (error) {
+  // Restore cwd on error
+  process.chdir(originalCwd);
+  console.error('Error during instant version bump:', error.message);
+  if (process.env.DEBUG) {
+    console.error('Stack trace:', error.stack);
+  }
+  process.exit(1);
+}

--- a/docs/case-studies/issue-94/upstream-templates/js-template-release.yml
+++ b/docs/case-studies/issue-94/upstream-templates/js-template-release.yml
@@ -1,0 +1,537 @@
+name: Checks and release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Manual release support - consolidated here to work with npm trusted publishing
+  # npm only allows ONE workflow file as trusted publisher, so all publishing
+  # must go through this workflow (release.yml)
+  workflow_dispatch:
+    inputs:
+      release_mode:
+        description: 'Manual release mode'
+        required: true
+        type: choice
+        default: 'instant'
+        options:
+          - instant
+          - changeset-pr
+      bump_type:
+        description: 'Manual release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      description:
+        description: 'Manual release description (optional)'
+        required: false
+        type: string
+
+# Concurrency: Only one workflow run per branch at a time
+# - For main branch (releases): cancel older runs to prevent blocking newer releases
+#   When multiple commits are pushed quickly, we want the latest to release, not wait
+# - For PR branches: queue runs to avoid cancelling checks on force-pushes
+# See: docs/case-studies/issue-25/DETAILED-COMPARISON.md for context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+
+jobs:
+  # === DETECT CHANGES - determines which jobs should run ===
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    outputs:
+      mjs-changed: ${{ steps.changes.outputs.mjs-changed }}
+      js-changed: ${{ steps.changes.outputs.js-changed }}
+      package-changed: ${{ steps.changes.outputs.package-changed }}
+      docs-changed: ${{ steps.changes.outputs.docs-changed }}
+      workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
+      any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: changes
+        run: node scripts/detect-code-changes.mjs
+
+  # === FAST CHECKS - run before slow tests for fastest feedback ===
+  # See: hive-mind CI/CD best practices principle #5 (fast-fail job ordering)
+
+  # Syntax check all .mjs files with node --check (~7s)
+  test-compilation:
+    name: Test Compilation
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check .mjs syntax
+        run: bash scripts/check-mjs-syntax.sh
+
+  # Enforce 1500-line limit on .mjs files and release.yml
+  check-file-line-limits:
+    name: Check File Line Limits
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true' ||
+      needs.detect-changes.outputs.workflow-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/simulate-fresh-merge.sh
+
+      - name: Check file line limits
+        run: bash scripts/check-file-line-limits.sh
+
+  # === VERSION CHANGE CHECK ===
+  # Prohibit manual version changes in package.json - versions should only be changed by CI/CD
+  version-check:
+    name: Check for Manual Version Changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for version changes in package.json
+        env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-version.mjs
+
+  # === CHANGESET CHECK - only runs on PRs with code changes ===
+  # Docs-only PRs (./docs folder, markdown files) don't require changesets
+  changeset-check:
+    name: Check for Changesets
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check for changesets
+        env:
+          # Pass PR context to the validation script
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Skip changeset check for automated version PRs
+          if [[ "${{ github.head_ref }}" == "changeset-release/"* ]]; then
+            echo "Skipping changeset check for automated release PR"
+            exit 0
+          fi
+
+          # Run changeset validation script
+          # This validates that exactly ONE changeset was ADDED by this PR
+          # Pre-existing changesets from other merged PRs are ignored
+          node scripts/validate-changeset.mjs
+
+  # === LINT AND FORMAT CHECK ===
+  # Lint runs independently of changeset-check - it's a fast check that should always run
+  # See: https://github.com/link-assistant/hive-mind/pull/1024 for why this dependency was removed
+  # IMPORTANT: ESLint includes max-lines rule (1500 lines) to ensure files stay maintainable
+  # See docs/case-studies/issue-23 for why fresh merge simulation is critical
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true' ||
+      needs.detect-changes.outputs.docs-changed == 'true' ||
+      needs.detect-changes.outputs.package-changed == 'true' ||
+      needs.detect-changes.outputs.workflow-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # For PRs, fetch enough history to merge with base branch
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/simulate-fresh-merge.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Check code duplication
+        run: npm run check:duplication
+
+      - name: Check for secrets
+        run: npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"
+
+  # Test matrix: 3 runtimes (Node.js, Bun, Deno) x 3 OS (Ubuntu, macOS, Windows)
+  # IMPORTANT: Tests must validate the ACTUAL merge result, not a stale merge preview.
+  # See docs/case-studies/issue-23 for why this is critical.
+  # Fast-fail: slow test matrix only runs after fast checks pass (hive-mind principle #5)
+  test:
+    name: Test (${{ matrix.runtime }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs:
+      [
+        detect-changes,
+        changeset-check,
+        test-compilation,
+        lint,
+        check-file-line-limits,
+      ]
+    # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
+    # Run if: push event, OR changeset-check succeeded, OR changeset-check was skipped (docs-only PR)
+    # AND all fast checks passed (or were skipped for irrelevant changes)
+    if: |
+      !cancelled() &&
+      (github.event_name == 'push' || needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped') &&
+      (needs.test-compilation.result == 'success' || needs.test-compilation.result == 'skipped') &&
+      (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
+      (needs.check-file-line-limits.result == 'success' || needs.check-file-line-limits.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        runtime: [node, bun, deno]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # For PRs, fetch enough history to merge with base branch
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        shell: bash
+        run: bash scripts/simulate-fresh-merge.sh
+
+      - name: Setup Node.js
+        if: matrix.runtime == 'node'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies (Node.js)
+        if: matrix.runtime == 'node'
+        run: npm install
+
+      - name: Run tests (Node.js)
+        if: matrix.runtime == 'node'
+        run: npm test
+
+      - name: Setup Bun
+        if: matrix.runtime == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun install
+
+      - name: Run tests (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun test
+
+      - name: Setup Deno
+        if: matrix.runtime == 'deno'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run tests (Deno)
+        if: matrix.runtime == 'deno'
+        run: deno test --allow-read
+
+  # === DOCUMENTATION VALIDATION ===
+  # Validate documentation files when docs change (hive-mind principle #12)
+  validate-docs:
+    name: Validate Documentation
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.docs-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check documentation file sizes
+        run: |
+          LIMIT=2500
+          FAILURES=()
+
+          echo "Checking that documentation files are under ${LIMIT} lines..."
+
+          while IFS= read -r -d '' file; do
+            line_count=$(wc -l < "$file")
+            if [ "$line_count" -gt "$LIMIT" ]; then
+              echo "ERROR: $file has $line_count lines (limit: ${LIMIT})"
+              echo "::error file=$file::Documentation file has $line_count lines (limit: ${LIMIT})"
+              FAILURES+=("$file")
+            fi
+          done < <(find docs -name "*.md" -type f -print0 2>/dev/null)
+
+          if [ "${#FAILURES[@]}" -gt 0 ]; then
+            echo "The following docs exceed the ${LIMIT} line limit:"
+            printf '  %s\n' "${FAILURES[@]}"
+            exit 1
+          else
+            echo "All documentation files are within the ${LIMIT} line limit."
+          fi
+
+      - name: Check required documentation files exist
+        run: |
+          REQUIRED_FILES=(
+            "docs/BEST-PRACTICES.md"
+            "docs/CONTRIBUTING.md"
+            "README.md"
+            "CHANGELOG.md"
+          )
+
+          MISSING=()
+          for file in "${REQUIRED_FILES[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "ERROR: Required documentation file missing: $file"
+              MISSING+=("$file")
+            else
+              echo "Found: $file"
+            fi
+          done
+
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo ""
+            echo "Missing required documentation files:"
+            printf '  %s\n' "${MISSING[@]}"
+            exit 1
+          else
+            echo "All required documentation files present."
+          fi
+
+  # Release - only runs on main after tests pass (for push events)
+  release:
+    name: Release
+    needs: [lint, test]
+    # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
+    # This is needed because lint/test jobs have a transitive dependency on changeset-check
+    if: |
+      !cancelled() &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success'
+    runs-on: ubuntu-latest
+    # Permissions required for npm OIDC trusted publishing
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update npm for OIDC trusted publishing
+        run: node scripts/setup-npm.mjs
+
+      - name: Check for changesets
+        id: check_changesets
+        run: node scripts/check-changesets.mjs
+
+      - name: Check if release is needed
+        id: check_release
+        env:
+          HAS_CHANGESETS: ${{ steps.check_changesets.outputs.has_changesets }}
+        run: node scripts/check-release-needed.mjs
+
+      - name: Merge multiple changesets
+        if: steps.check_changesets.outputs.has_changesets == 'true' && steps.check_changesets.outputs.changeset_count > 1
+        run: |
+          echo "Multiple changesets detected, merging..."
+          node scripts/merge-changesets.mjs
+
+      - name: Version packages and commit to main
+        if: steps.check_changesets.outputs.has_changesets == 'true'
+        id: version
+        run: node scripts/version-and-commit.mjs --mode changeset
+
+      - name: Publish to npm
+        # Run if version was committed, if a previous attempt already committed (for re-runs),
+        # or if check-release-needed detected an unpublished version (self-healing, issue #36)
+        if: >-
+          steps.version.outputs.version_committed == 'true' ||
+          steps.version.outputs.already_released == 'true' ||
+          (steps.check_release.outputs.should_release == 'true' && steps.check_release.outputs.skip_bump == 'true')
+        id: publish
+        run: node scripts/publish-to-npm.mjs --should-pull
+
+      - name: Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}"
+
+      - name: Format GitHub release notes
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+
+  # Manual Instant Release - triggered via workflow_dispatch with instant mode
+  # This job is in release.yml because npm trusted publishing
+  # only allows one workflow file to be registered as a trusted publisher
+  instant-release:
+    name: Instant Release
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'instant'
+    runs-on: ubuntu-latest
+    # Permissions required for npm OIDC trusted publishing
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update npm for OIDC trusted publishing
+        run: node scripts/setup-npm.mjs
+
+      - name: Version packages and commit to main
+        id: version
+        run: node scripts/version-and-commit.mjs --mode instant --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Publish to npm
+        # Run if version was committed OR if a previous attempt already committed (for re-runs)
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        id: publish
+        run: node scripts/publish-to-npm.mjs
+
+      - name: Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}"
+
+      - name: Format GitHub release notes
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+
+  # Manual Changeset PR - creates a pull request with the changeset for review
+  changeset-pr:
+    name: Create Changeset PR
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changeset-pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create changeset file
+        run: node scripts/create-manual-changeset.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Format changeset with Prettier
+        run: |
+          # Run Prettier on the changeset file to ensure it matches project style
+          npx prettier --write ".changeset/*.md" || true
+
+          echo "Formatted changeset files"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: add changeset for manual ${{ github.event.inputs.bump_type }} release'
+          branch: changeset-manual-release-${{ github.run_id }}
+          delete-branch: true
+          title: 'chore: manual ${{ github.event.inputs.bump_type }} release'
+          body: |
+            ## Manual Release Request
+
+            This PR was created by a manual workflow trigger to prepare a **${{ github.event.inputs.bump_type }}** release.
+
+            ### Release Details
+            - **Type:** ${{ github.event.inputs.bump_type }}
+            - **Description:** ${{ github.event.inputs.description || 'Manual release' }}
+            - **Triggered by:** @${{ github.actor }}
+
+            ### Next Steps
+            1. Review the changeset in this PR
+            2. Merge this PR to main
+            3. The automated release workflow will create a version PR
+            4. Merge the version PR to publish to npm and create a GitHub release

--- a/docs/case-studies/issue-94/upstream-templates/js-version-and-commit.mjs
+++ b/docs/case-studies/issue-94/upstream-templates/js-version-and-commit.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env bun
+
+/**
+ * Version packages and commit to main
+ * Usage: node scripts/version-and-commit.mjs --mode <changeset|instant> [--bump-type <type>] [--description <desc>] [--js-root <path>]
+ *   changeset: Run changeset version
+ *   instant: Run instant version bump with bump_type (patch|minor|major) and optional description
+ *
+ * Configuration:
+ * - CLI: --js-root <path> to explicitly set JavaScript root
+ * - Environment: JS_ROOT=<path>
+ *
+ * Uses link-foundation libraries:
+ * - use-m: Dynamic package loading without package.json dependencies
+ * - command-stream: Modern shell command execution with streaming support
+ * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
+ *
+ * Addresses issues documented in:
+ * - Issue #21: Supporting both single and multi-language repository structures
+ * - Reference: link-assistant/agent PR #112 (--legacy-peer-deps fix)
+ * - Reference: link-assistant/agent PR #114 (configurable package root)
+ */
+
+import { readFileSync, appendFileSync, readdirSync } from 'fs';
+
+import {
+  getJsRoot,
+  getPackageJsonPath,
+  getChangesetDir,
+  needsCd,
+  parseJsRootConfig,
+} from './js-paths.mjs';
+
+// Load use-m dynamically
+const { use } = eval(
+  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+);
+
+// Import link-foundation libraries
+const { $ } = await use('command-stream');
+const { makeConfig } = await use('lino-arguments');
+
+// Parse CLI arguments using lino-arguments
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .option('mode', {
+        type: 'string',
+        default: getenv('MODE', 'changeset'),
+        describe: 'Version mode: changeset or instant',
+        choices: ['changeset', 'instant'],
+      })
+      .option('bump-type', {
+        type: 'string',
+        default: getenv('BUMP_TYPE', ''),
+        describe: 'Version bump type for instant mode: major, minor, or patch',
+      })
+      .option('description', {
+        type: 'string',
+        default: getenv('DESCRIPTION', ''),
+        describe: 'Description for instant version bump',
+      })
+      .option('js-root', {
+        type: 'string',
+        default: getenv('JS_ROOT', ''),
+        describe:
+          'JavaScript package root directory (auto-detected if not specified)',
+      }),
+});
+
+const { mode, bumpType, description, jsRoot: jsRootArg } = config;
+
+// Get JavaScript package root (auto-detect or use explicit config)
+const jsRootConfig = jsRootArg || parseJsRootConfig();
+const jsRoot = getJsRoot({ jsRoot: jsRootConfig, verbose: true });
+
+// Debug: Log parsed configuration
+console.log('Parsed configuration:', {
+  mode,
+  bumpType,
+  description: description || '(none)',
+  jsRoot,
+});
+
+// Detect if positional arguments were used (common mistake)
+const args = process.argv.slice(2);
+if (args.length > 0 && !args[0].startsWith('--')) {
+  console.error('Error: Positional arguments detected!');
+  console.error('Command line arguments:', args);
+  console.error('');
+  console.error(
+    'This script requires named arguments (--mode, --bump-type, --description, --js-root).'
+  );
+  console.error('Usage:');
+  console.error('  Changeset mode:');
+  console.error(
+    '    node scripts/version-and-commit.mjs --mode changeset [--js-root <path>]'
+  );
+  console.error('  Instant mode:');
+  console.error(
+    '    node scripts/version-and-commit.mjs --mode instant --bump-type <major|minor|patch> [--description <desc>] [--js-root <path>]'
+  );
+  console.error('');
+  console.error('Examples:');
+  console.error(
+    '  node scripts/version-and-commit.mjs --mode instant --bump-type patch --description "Fix bug"'
+  );
+  console.error('  node scripts/version-and-commit.mjs --mode changeset');
+  console.error(
+    '  node scripts/version-and-commit.mjs --mode changeset --js-root js'
+  );
+  process.exit(1);
+}
+
+// Validation: Ensure mode is set correctly
+if (mode !== 'changeset' && mode !== 'instant') {
+  console.error(`Invalid mode: "${mode}". Expected "changeset" or "instant".`);
+  console.error('Command line arguments:', process.argv.slice(2));
+  process.exit(1);
+}
+
+// Validation: Ensure bump type is provided for instant mode
+if (mode === 'instant' && !bumpType) {
+  console.error('Error: --bump-type is required for instant mode');
+  console.error(
+    'Usage: node scripts/version-and-commit.mjs --mode instant --bump-type <major|minor|patch> [--description <desc>] [--js-root <path>]'
+  );
+  process.exit(1);
+}
+
+// Store the original working directory to restore after cd commands
+// IMPORTANT: command-stream's cd is a virtual command that calls process.chdir()
+const originalCwd = process.cwd();
+
+/**
+ * Append to GitHub Actions output file
+ * @param {string} key
+ * @param {string} value
+ */
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+}
+
+/**
+ * Count changeset files (excluding README.md)
+ */
+function countChangesets() {
+  try {
+    const changesetDir = getChangesetDir({ jsRoot });
+    const files = readdirSync(changesetDir);
+    return files.filter((f) => f.endsWith('.md') && f !== 'README.md').length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Get package version
+ * @param {string} source - 'local' or 'remote'
+ */
+async function getVersion(source = 'local') {
+  const packageJsonPath = getPackageJsonPath({ jsRoot });
+  if (source === 'remote') {
+    const result = await $`git show origin/main:${packageJsonPath}`.run({
+      capture: true,
+    });
+    return JSON.parse(result.stdout).version;
+  }
+  return JSON.parse(readFileSync(packageJsonPath, 'utf8')).version;
+}
+
+async function main() {
+  try {
+    // Configure git
+    await $`git config user.name "github-actions[bot]"`;
+    await $`git config user.email "github-actions[bot]@users.noreply.github.com"`;
+
+    // Check if remote main has advanced (handles re-runs after partial success)
+    console.log('Checking for remote changes...');
+    await $`git fetch origin main`;
+
+    const localHeadResult = await $`git rev-parse HEAD`.run({ capture: true });
+    const localHead = localHeadResult.stdout.trim();
+
+    const remoteHeadResult = await $`git rev-parse origin/main`.run({
+      capture: true,
+    });
+    const remoteHead = remoteHeadResult.stdout.trim();
+
+    if (localHead !== remoteHead) {
+      console.log(
+        `Remote main has advanced (local: ${localHead}, remote: ${remoteHead})`
+      );
+      console.log('This may indicate a previous attempt partially succeeded.');
+
+      // Check if the remote version is already the expected bump
+      const remoteVersion = await getVersion('remote');
+      console.log(`Remote version: ${remoteVersion}`);
+
+      // Check if there are changesets to process
+      const changesetCount = countChangesets();
+
+      if (changesetCount === 0) {
+        console.log('No changesets to process and remote has advanced.');
+        console.log(
+          'Assuming version bump was already completed in a previous attempt.'
+        );
+        setOutput('version_committed', 'false');
+        setOutput('already_released', 'true');
+        setOutput('new_version', remoteVersion);
+        return;
+      } else {
+        console.log('Rebasing on remote main to incorporate changes...');
+        await $`git rebase origin/main`;
+      }
+    }
+
+    // Get current version before bump
+    const oldVersion = await getVersion();
+    console.log(`Current version: ${oldVersion}`);
+
+    if (mode === 'instant') {
+      console.log('Running instant version bump...');
+      // Run instant version bump script
+      // Pass --js-root to ensure consistent path handling
+      // Rely on command-stream's auto-quoting for proper argument handling
+      if (description) {
+        await $`node scripts/instant-version-bump.mjs --bump-type ${bumpType} --description ${description} --js-root ${jsRoot}`;
+      } else {
+        await $`node scripts/instant-version-bump.mjs --bump-type ${bumpType} --js-root ${jsRoot}`;
+      }
+    } else {
+      console.log('Running changeset version...');
+      // Run changeset version to bump versions and update CHANGELOG
+      // IMPORTANT: cd is a virtual command that calls process.chdir(), so we restore after
+      if (needsCd({ jsRoot })) {
+        await $`cd ${jsRoot} && npm run changeset:version`;
+        process.chdir(originalCwd);
+      } else {
+        await $`npm run changeset:version`;
+      }
+    }
+
+    // Get new version after bump
+    const newVersion = await getVersion();
+    console.log(`New version: ${newVersion}`);
+    setOutput('new_version', newVersion);
+
+    // Check if there are changes to commit
+    const statusResult = await $`git status --porcelain`.run({ capture: true });
+    const status = statusResult.stdout.trim();
+
+    if (status) {
+      console.log('Changes detected, committing...');
+
+      // Stage all changes (package.json, package-lock.json, CHANGELOG.md, deleted changesets)
+      await $`git add -A`;
+
+      // Commit with version number as message
+      const commitMessage = newVersion;
+      const escapedMessage = commitMessage.replace(/"/g, '\\"');
+      await $`git commit -m "${escapedMessage}"`;
+
+      // Push directly to main
+      await $`git push origin main`;
+
+      console.log('\u2705 Version bump committed and pushed to main');
+      setOutput('version_committed', 'true');
+    } else {
+      console.log('No changes to commit');
+      setOutput('version_committed', 'false');
+    }
+  } catch (error) {
+    // Restore cwd on error
+    process.chdir(originalCwd);
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/docs/case-studies/issue-94/upstream-templates/rust-template-release.yml
+++ b/docs/case-studies/issue-94/upstream-templates/rust-template-release.yml
@@ -1,0 +1,488 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      release_mode:
+        description: 'Manual release mode'
+        required: true
+        type: choice
+        default: 'instant'
+        options:
+          - instant
+          - changelog-pr
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      description:
+        description: 'Release description (optional)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  # Support both CARGO_REGISTRY_TOKEN (cargo's native env var) and CARGO_TOKEN (for backwards compatibility)
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+  CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+
+jobs:
+  # === DETECT CHANGES - determines which jobs should run ===
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    outputs:
+      rs-changed: ${{ steps.changes.outputs.rs-changed }}
+      toml-changed: ${{ steps.changes.outputs.toml-changed }}
+      docs-changed: ${{ steps.changes.outputs.docs-changed }}
+      workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
+      any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Detect changes
+        id: changes
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: rust-script scripts/detect-code-changes.rs
+
+  # === CHANGELOG CHECK - only runs on PRs with code changes ===
+  # Docs-only PRs (./docs folder, markdown files) don't require changelog fragments
+  changelog:
+    name: Changelog Fragment Check
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Check for changelog fragments
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: rust-script scripts/check-changelog-fragment.rs
+
+  # === VERSION CHECK - prevents manual version modification in PRs ===
+  # This ensures versions are only modified by the automated release pipeline
+  version-check:
+    name: Version Modification Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Check for manual version changes
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: rust-script scripts/check-version-modification.rs
+
+  # === LINT AND FORMAT CHECK ===
+  # Lint runs independently of changelog check - it's a fast check that should always run
+  # See: https://github.com/link-assistant/hive-mind/pull/1024 for why this dependency was removed
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    # Note: always() is required because detect-changes is skipped on workflow_dispatch,
+    # and without always(), this job would also be skipped even though its condition includes workflow_dispatch.
+    # See: https://github.com/actions/runner/issues/491
+    if: |
+      always() && !cancelled() && (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.rs-changed == 'true' ||
+        needs.detect-changes.outputs.toml-changed == 'true' ||
+        needs.detect-changes.outputs.docs-changed == 'true' ||
+        needs.detect-changes.outputs.workflow-changed == 'true'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features
+
+      - name: Check file size limit
+        run: rust-script scripts/check-file-size.rs
+
+  # === TEST ===
+  # Test runs independently of changelog check
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: [detect-changes, changelog]
+    # Run if: push event, OR changelog succeeded, OR changelog was skipped (docs-only PR)
+    if: always() && !cancelled() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changelog.result == 'success' || needs.changelog.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: cargo test --all-features --verbose
+
+      - name: Run doc tests
+        run: cargo test --doc --verbose
+
+  # === CODE COVERAGE ===
+  # Generate and upload code coverage using cargo-llvm-cov
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      always() && !cancelled() && (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.rs-changed == 'true' ||
+        needs.detect-changes.outputs.toml-changed == 'true'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+
+  # === BUILD ===
+  # Build package - only runs if lint and test pass
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    if: always() && !cancelled() && needs.lint.result == 'success' && needs.test.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
+      - name: Build release
+        run: cargo build --release --verbose
+
+      - name: Check package
+        run: cargo package --list --allow-dirty
+
+  # === AUTO RELEASE ===
+  # Automatic release on push to main using changelog fragments
+  # This job automatically bumps version based on fragments in changelog.d/
+  auto-release:
+    name: Auto Release
+    needs: [lint, test, build]
+    # Note: always() ensures consistent behavior with other jobs that depend on jobs using always().
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Configure git
+        run: rust-script scripts/git-config.rs
+
+      - name: Determine bump type from changelog fragments
+        id: bump_type
+        run: rust-script scripts/get-bump-type.rs
+
+      - name: Check if version already released or no fragments
+        id: check
+        env:
+          HAS_FRAGMENTS: ${{ steps.bump_type.outputs.has_fragments }}
+        run: rust-script scripts/check-release-needed.rs
+
+      - name: Collect changelog and bump version
+        id: version
+        if: steps.check.outputs.should_release == 'true' && steps.check.outputs.skip_bump != 'true'
+        run: |
+          rust-script scripts/version-and-commit.rs \
+            --bump-type "${{ steps.bump_type.outputs.bump_type }}"
+
+      - name: Get current version
+        id: current_version
+        if: steps.check.outputs.should_release == 'true'
+        run: rust-script scripts/get-version.rs
+
+      - name: Build release
+        if: steps.check.outputs.should_release == 'true'
+        run: cargo build --release
+
+      - name: Publish to Crates.io
+        if: steps.check.outputs.should_release == 'true'
+        id: publish-crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: rust-script scripts/publish-crate.rs
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Use new_version from version-and-commit when available (tag-checked), else fall back to Cargo.toml version
+          RELEASE_VERSION="${{ steps.version.outputs.new_version }}"
+          if [ -z "$RELEASE_VERSION" ]; then
+            RELEASE_VERSION="${{ steps.current_version.outputs.version }}"
+          fi
+          rust-script scripts/create-github-release.rs --release-version "$RELEASE_VERSION" --repository "${{ github.repository }}"
+
+  # === MANUAL INSTANT RELEASE ===
+  # Manual release via workflow_dispatch - only after CI passes
+  manual-release:
+    name: Instant Release
+    needs: [lint, test, build]
+    # Note: always() is required to evaluate the condition when dependencies use always().
+    # The build job ensures lint and test passed before this job runs.
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_mode == 'instant' &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Configure git
+        run: rust-script scripts/git-config.rs
+
+      - name: Collect changelog fragments
+        run: rust-script scripts/collect-changelog.rs
+
+      - name: Version and commit
+        id: version
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          DESCRIPTION: ${{ github.event.inputs.description }}
+        run: rust-script scripts/version-and-commit.rs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Build release
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        run: cargo build --release
+
+      - name: Publish to Crates.io
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        id: publish-crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: rust-script scripts/publish-crate.rs
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: rust-script scripts/create-github-release.rs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}"
+
+  # === MANUAL CHANGELOG PR ===
+  changelog-pr:
+    name: Create Changelog PR
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changelog-pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Create changelog fragment
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          DESCRIPTION: ${{ github.event.inputs.description }}
+        run: rust-script scripts/create-changelog-fragment.rs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: add changelog for manual ${{ github.event.inputs.bump_type }} release'
+          branch: changelog-manual-release-${{ github.run_id }}
+          delete-branch: true
+          title: 'chore: manual ${{ github.event.inputs.bump_type }} release'
+          body: |
+            ## Manual Release Request
+
+            This PR was created by a manual workflow trigger to prepare a **${{ github.event.inputs.bump_type }}** release.
+
+            ### Release Details
+            - **Type:** ${{ github.event.inputs.bump_type }}
+            - **Description:** ${{ github.event.inputs.description || 'Manual release' }}
+            - **Triggered by:** @${{ github.actor }}
+
+            ### Next Steps
+            1. Review the changelog fragment in this PR
+            2. Merge this PR to main
+            3. The automated release workflow will publish to crates.io and create a GitHub release
+
+  # === DEPLOY DOCUMENTATION ===
+  # Deploy Rust API documentation to GitHub Pages after a successful release
+  deploy-docs:
+    name: Deploy Rust Documentation
+    needs: [auto-release, manual-release]
+    if: |
+      always() && !cancelled() && (
+        needs.auto-release.result == 'success' ||
+        needs.manual-release.result == 'success'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build documentation
+        run: cargo doc --no-deps --all-features
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/doc

--- a/docs/case-studies/issue-94/upstream-templates/version-and-commit.rs
+++ b/docs/case-studies/issue-94/upstream-templates/version-and-commit.rs
@@ -1,0 +1,532 @@
+#!/usr/bin/env rust-script
+//! Bump version in Cargo.toml and commit changes
+//! Used by the CI/CD pipeline for releases
+//!
+//! IMPORTANT: This script checks crates.io (the source of truth for Rust packages),
+//! NOT git tags. This is critical because:
+//! - Git tags can exist without the package being published
+//! - GitHub releases create tags but don't publish to crates.io
+//! - Only crates.io publication means users can actually install the package
+//!
+//! Supports both single-language and multi-language repository structures:
+//! - Single-language: Cargo.toml and changelog.d/ in repository root
+//! - Multi-language: Cargo.toml and changelog.d/ in rust/ subfolder
+//!
+//! Usage: rust-script scripts/version-and-commit.rs --bump-type <major|minor|patch> [--description <desc>] [--rust-root <path>] [--tag-prefix <prefix>] [--release-label <label>]
+//!
+//! ```cargo
+//! [dependencies]
+//! regex = "1"
+//! chrono = "0.4"
+//! ureq = "2"
+//! serde = { version = "1", features = ["derive"] }
+//! serde_json = "1"
+//! ```
+
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, exit};
+use regex::Regex;
+use chrono::Utc;
+use serde::Deserialize;
+
+#[path = "rust-paths.rs"]
+mod rust_paths;
+
+fn get_arg(name: &str) -> Option<String> {
+    let args: Vec<String> = env::args().collect();
+    let flag = format!("--{}", name);
+
+    if let Some(idx) = args.iter().position(|a| a == &flag) {
+        return args.get(idx + 1).cloned();
+    }
+
+    let env_name = name.to_uppercase().replace('-', "_");
+    env::var(&env_name).ok().filter(|s| !s.is_empty())
+}
+
+fn get_changelog_dir(rust_root: &str) -> String {
+    if rust_root == "." {
+        "./changelog.d".to_string()
+    } else {
+        format!("{}/changelog.d", rust_root)
+    }
+}
+
+fn get_changelog_path(rust_root: &str) -> String {
+    if rust_root == "." {
+        "./CHANGELOG.md".to_string()
+    } else {
+        format!("{}/CHANGELOG.md", rust_root)
+    }
+}
+
+fn set_output(key: &str, value: &str) {
+    if let Ok(output_file) = env::var("GITHUB_OUTPUT") {
+        if let Err(e) = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&output_file)
+            .and_then(|mut f| writeln!(f, "{}={}", key, value))
+        {
+            eprintln!("Warning: Could not write to GITHUB_OUTPUT: {}", e);
+        }
+    }
+    println!("Output: {}={}", key, value);
+}
+
+fn exec(command: &str, args: &[&str]) -> Result<String, String> {
+    match Command::new(command).args(args).output() {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                Err(format!("Command failed: {}", stderr))
+            }
+        }
+        Err(e) => Err(format!("Failed to execute: {}", e)),
+    }
+}
+
+fn exec_check(command: &str, args: &[&str]) -> bool {
+    Command::new(command)
+        .args(args)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+struct Version {
+    major: u32,
+    minor: u32,
+    patch: u32,
+    #[allow(dead_code)]
+    pre_release: Option<String>,
+}
+
+impl Version {
+    fn parse(content: &str) -> Option<Version> {
+        let re = Regex::new(r#"(?m)^version\s*=\s*"(\d+)\.(\d+)\.(\d+)(?:-([^"]+))?""#).ok()?;
+        let caps = re.captures(content)?;
+        Some(Version {
+            major: caps.get(1)?.as_str().parse().ok()?,
+            minor: caps.get(2)?.as_str().parse().ok()?,
+            patch: caps.get(3)?.as_str().parse().ok()?,
+            pre_release: caps.get(4).map(|m| m.as_str().to_string()),
+        })
+    }
+
+    fn bump(&self, bump_type: &str) -> String {
+        match bump_type {
+            "major" => format!("{}.0.0", self.major + 1),
+            "minor" => format!("{}.{}.0", self.major, self.minor + 1),
+            _ => format!("{}.{}.{}", self.major, self.minor, self.patch + 1),
+        }
+    }
+}
+
+fn update_cargo_toml(cargo_toml_path: &str, new_version: &str) -> Result<(), String> {
+    let content = fs::read_to_string(cargo_toml_path)
+        .map_err(|e| format!("Failed to read {}: {}", cargo_toml_path, e))?;
+
+    let re = Regex::new(r#"(?m)^(version\s*=\s*")[^"]+(")"#).unwrap();
+    let new_content = re.replace(&content, format!("${{1}}{}${{2}}", new_version).as_str());
+
+    fs::write(cargo_toml_path, new_content.as_ref())
+        .map_err(|e| format!("Failed to write {}: {}", cargo_toml_path, e))?;
+
+    println!("Updated {} to version {}", cargo_toml_path, new_version);
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct CratesIoCrate {
+    versions: Option<Vec<CratesIoVersionEntry>>,
+}
+
+#[derive(Deserialize)]
+struct CratesIoVersionEntry {
+    num: String,
+    yanked: bool,
+}
+
+fn get_crate_name(cargo_toml_path: &str) -> Result<String, String> {
+    let content = fs::read_to_string(cargo_toml_path)
+        .map_err(|e| format!("Failed to read {}: {}", cargo_toml_path, e))?;
+
+    let re = Regex::new(r#"(?m)^name\s*=\s*"([^"]+)""#).unwrap();
+
+    if let Some(caps) = re.captures(&content) {
+        Ok(caps.get(1).unwrap().as_str().to_string())
+    } else {
+        Err(format!("Could not find name in {}", cargo_toml_path))
+    }
+}
+
+fn check_tag_exists(tag_prefix: &str, version: &str) -> bool {
+    exec_check("git", &["rev-parse", &format!("{}{}", tag_prefix, version)])
+}
+
+fn check_version_on_crates_io(crate_name: &str, version: &str) -> bool {
+    let url = format!("https://crates.io/api/v1/crates/{}/{}", crate_name, version);
+    match ureq::get(&url)
+        .set("User-Agent", "rust-script-version-and-commit")
+        .call()
+    {
+        Ok(response) => response.status() == 200,
+        Err(_) => false,
+    }
+}
+
+fn get_max_published_version(crate_name: &str) -> Option<(u32, u32, u32)> {
+    let url = format!("https://crates.io/api/v1/crates/{}", crate_name);
+    match ureq::get(&url)
+        .set("User-Agent", "rust-script-version-and-commit")
+        .call()
+    {
+        Ok(response) => {
+            if response.status() == 200 {
+                if let Ok(body) = response.into_string() {
+                    if let Ok(data) = serde_json::from_str::<CratesIoCrate>(&body) {
+                        if let Some(versions) = data.versions {
+                            let mut max: Option<(u32, u32, u32)> = None;
+                            for v in &versions {
+                                if v.yanked { continue; }
+                                let base = match v.num.split('-').next() {
+                                    Some(b) => b,
+                                    None => continue,
+                                };
+                                let parts: Vec<&str> = base.split('.').collect();
+                                if parts.len() == 3 {
+                                    if let (Ok(a), Ok(b), Ok(c)) = (
+                                        parts[0].parse::<u32>(),
+                                        parts[1].parse::<u32>(),
+                                        parts[2].parse::<u32>(),
+                                    ) {
+                                        let tuple = (a, b, c);
+                                        if max.map_or(true, |m| tuple > m) {
+                                            max = Some(tuple);
+                                        }
+                                    }
+                                }
+                            }
+                            return max;
+                        }
+                    }
+                }
+            }
+            None
+        }
+        Err(_) => None,
+    }
+}
+
+fn ensure_version_exceeds_published(
+    version_str: &str,
+    crate_name: &str,
+    tag_prefix: &str,
+    max_published: Option<(u32, u32, u32)>,
+) -> String {
+    let parts: Vec<&str> = version_str.split('-').next().unwrap_or(version_str).split('.').collect();
+    if parts.len() != 3 {
+        return version_str.to_string();
+    }
+
+    let mut major: u32 = parts[0].parse().unwrap_or(0);
+    let mut minor: u32 = parts[1].parse().unwrap_or(0);
+    let mut patch: u32 = parts[2].parse().unwrap_or(0);
+
+    if let Some((pub_major, pub_minor, pub_patch)) = max_published {
+        if (major, minor, patch) <= (pub_major, pub_minor, pub_patch) {
+            println!(
+                "Version {}.{}.{} is not greater than max published {}.{}.{}, adjusting to {}.{}.{}",
+                major, minor, patch,
+                pub_major, pub_minor, pub_patch,
+                pub_major, pub_minor, pub_patch + 1
+            );
+            major = pub_major;
+            minor = pub_minor;
+            patch = pub_patch + 1;
+        }
+    }
+
+    let mut candidate = format!("{}.{}.{}", major, minor, patch);
+    let mut safety_counter = 0;
+    while (check_tag_exists(tag_prefix, &candidate) || check_version_on_crates_io(crate_name, &candidate))
+        && safety_counter < 100
+    {
+        println!(
+            "Version {} already has a git tag or is published on crates.io, bumping patch",
+            candidate
+        );
+        patch += 1;
+        candidate = format!("{}.{}.{}", major, minor, patch);
+        safety_counter += 1;
+    }
+
+    if safety_counter >= 100 {
+        eprintln!("Error: Could not find an unpublished version after 100 attempts");
+        exit(1);
+    }
+
+    candidate
+}
+
+fn strip_frontmatter(content: &str) -> String {
+    let re = Regex::new(r"(?s)^---\s*\n.*?\n---\s*\n(.*)$").unwrap();
+    if let Some(caps) = re.captures(content) {
+        caps.get(1).unwrap().as_str().trim().to_string()
+    } else {
+        content.trim().to_string()
+    }
+}
+
+fn collect_changelog(changelog_dir: &str, changelog_file: &str, version: &str) {
+    let dir_path = Path::new(changelog_dir);
+    if !dir_path.exists() {
+        return;
+    }
+
+    let mut files: Vec<_> = match fs::read_dir(dir_path) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.extension().map_or(false, |ext| ext == "md")
+                    && p.file_name().map_or(false, |name| name != "README.md")
+            })
+            .collect(),
+        Err(_) => return,
+    };
+
+    if files.is_empty() {
+        return;
+    }
+
+    files.sort();
+
+    let fragments: Vec<String> = files
+        .iter()
+        .filter_map(|f| fs::read_to_string(f).ok())
+        .map(|c| strip_frontmatter(&c))
+        .filter(|c| !c.is_empty())
+        .collect();
+
+    if fragments.is_empty() {
+        return;
+    }
+
+    let date_str = Utc::now().format("%Y-%m-%d").to_string();
+    let new_entry = format!("\n## [{}] - {}\n\n{}\n", version, date_str, fragments.join("\n\n"));
+
+    if Path::new(changelog_file).exists() {
+        let mut content = fs::read_to_string(changelog_file).unwrap_or_default();
+        let lines: Vec<&str> = content.lines().collect();
+        let mut insert_index = None;
+
+        for (i, line) in lines.iter().enumerate() {
+            if line.starts_with("## [") {
+                insert_index = Some(i);
+                break;
+            }
+        }
+
+        if let Some(idx) = insert_index {
+            let mut new_lines: Vec<String> = lines[..idx].iter().map(|s| s.to_string()).collect();
+            new_lines.push(new_entry.clone());
+            new_lines.extend(lines[idx..].iter().map(|s| s.to_string()));
+            content = new_lines.join("\n");
+        } else {
+            content.push_str(&new_entry);
+        }
+
+        fs::write(changelog_file, content).expect("Failed to write changelog");
+    }
+
+    println!("Collected {} changelog fragment(s)", files.len());
+}
+
+fn main() {
+    let bump_type = match get_arg("bump-type") {
+        Some(bt) => bt,
+        None => {
+            eprintln!("Usage: rust-script scripts/version-and-commit.rs --bump-type <major|minor|patch> [--description <desc>] [--rust-root <path>] [--tag-prefix <prefix>] [--release-label <label>]");
+            exit(1);
+        }
+    };
+
+    if !["major", "minor", "patch"].contains(&bump_type.as_str()) {
+        eprintln!("Invalid bump type: {}. Must be major, minor, or patch.", bump_type);
+        exit(1);
+    }
+
+    let description = get_arg("description");
+    let tag_prefix = get_arg("tag-prefix").unwrap_or_else(|| "v".to_string());
+    let release_label = get_arg("release-label");
+    let rust_root = match rust_paths::get_rust_root(None, true) {
+        Ok(root) => root,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let cargo_toml = rust_paths::get_cargo_toml_path(&rust_root);
+    let package_manifest = match rust_paths::get_package_manifest_path(&cargo_toml) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+    let changelog_dir = get_changelog_dir(&rust_root);
+    let changelog_file = get_changelog_path(&rust_root);
+
+    // Configure git
+    let _ = exec("git", &["config", "user.name", "github-actions[bot]"]);
+    let _ = exec("git", &["config", "user.email", "github-actions[bot]@users.noreply.github.com"]);
+
+    // Get current version
+    let content = match fs::read_to_string(&package_manifest) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error reading {}: {}", package_manifest.display(), e);
+            exit(1);
+        }
+    };
+
+    let current = match Version::parse(&content) {
+        Some(v) => v,
+        None => {
+            eprintln!("Error: Could not parse version from {}", package_manifest.display());
+            exit(1);
+        }
+    };
+
+    let initial_bump = current.bump(&bump_type);
+
+    let crate_name = match get_crate_name(package_manifest.to_string_lossy().as_ref()) {
+        Ok(name) => name,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
+    };
+
+    let max_published = get_max_published_version(&crate_name);
+    if let Some((ma, mi, pa)) = max_published {
+        println!("Max published version on crates.io: {}.{}.{}", ma, mi, pa);
+    } else {
+        println!("No versions published on crates.io yet (or crate not found)");
+    }
+
+    println!("Initial bump ({}) from {}.{}.{}: {}", bump_type, current.major, current.minor, current.patch, initial_bump);
+
+    let new_version = ensure_version_exceeds_published(&initial_bump, &crate_name, &tag_prefix, max_published);
+
+    if new_version != initial_bump {
+        println!(
+            "Adjusted version from {} to {} to exceed published versions",
+            initial_bump, new_version
+        );
+    }
+
+    println!("Final release version: {}", new_version);
+
+    // Update version in Cargo.toml
+    if let Err(e) = update_cargo_toml(package_manifest.to_string_lossy().as_ref(), &new_version) {
+        eprintln!("Error: {}", e);
+        exit(1);
+    }
+
+    // Collect changelog fragments
+    collect_changelog(&changelog_dir, &changelog_file, &new_version);
+
+    // Stage Cargo.toml and CHANGELOG.md
+    let package_manifest_str = package_manifest.to_string_lossy().to_string();
+    let _ = exec("git", &["add", &package_manifest_str, &changelog_file]);
+
+    // Check if there are changes to commit
+    if exec_check("git", &["diff", "--cached", "--quiet"]) {
+        println!("No changes to commit");
+        set_output("version_committed", "false");
+        set_output("new_version", &new_version);
+        return;
+    }
+
+    // Fetch latest remote state before committing (supports concurrent release workflows)
+    let current_branch = exec("git", &["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|_| "main".to_string());
+    if let Err(e) = exec("git", &["fetch", "origin", &current_branch]) {
+        eprintln!("Warning: Could not fetch origin/{}: {}", current_branch, e);
+    } else {
+        let local = exec("git", &["rev-parse", "HEAD"]).unwrap_or_default();
+        let remote = exec("git", &["rev-parse", &format!("origin/{}", current_branch)]).unwrap_or_default();
+        if !local.is_empty() && !remote.is_empty() && local != remote {
+            println!("Local branch is behind remote, rebasing...");
+            if let Err(e) = exec("git", &["rebase", &format!("origin/{}", current_branch)]) {
+                eprintln!("Error rebasing onto origin/{}: {}", current_branch, e);
+                let _ = exec("git", &["rebase", "--abort"]);
+                exit(1);
+            }
+        }
+    }
+
+    // Commit changes
+    let label_suffix = release_label.as_ref().map(|l| format!(" ({})", l)).unwrap_or_default();
+    let commit_msg = match &description {
+        Some(desc) => format!("chore: release {}{}{}\n\n{}", tag_prefix, new_version, label_suffix, desc),
+        None => format!("chore: release {}{}{}", tag_prefix, new_version, label_suffix),
+    };
+
+    if let Err(e) = exec("git", &["commit", "-m", &commit_msg]) {
+        eprintln!("Error committing: {}", e);
+        exit(1);
+    }
+    println!("Committed version {}", new_version);
+
+    // Create tag
+    let tag_name = format!("{}{}", tag_prefix, new_version);
+    let tag_msg = match &description {
+        Some(desc) => format!("Release {}{}\n\n{}", tag_name, label_suffix, desc),
+        None => format!("Release {}{}", tag_name, label_suffix),
+    };
+
+    if let Err(e) = exec("git", &["tag", "-a", &tag_name, "-m", &tag_msg]) {
+        eprintln!("Error creating tag: {}", e);
+        exit(1);
+    }
+    println!("Created tag {}", tag_name);
+
+    // Push changes and tag with retry (handles concurrent pushes in multi-workflow repos)
+    let max_push_attempts = 3;
+    for attempt in 1..=max_push_attempts {
+        match exec("git", &["push"]) {
+            Ok(_) => break,
+            Err(e) => {
+                if attempt < max_push_attempts {
+                    eprintln!("Push failed (attempt {}/{}): {}", attempt, max_push_attempts, e);
+                    eprintln!("Pulling with rebase and retrying...");
+                    if let Err(rebase_err) = exec("git", &["pull", "--rebase", "origin", &current_branch]) {
+                        eprintln!("Error during pull --rebase: {}", rebase_err);
+                        let _ = exec("git", &["rebase", "--abort"]);
+                        exit(1);
+                    }
+                } else {
+                    eprintln!("Error pushing after {} attempts: {}", max_push_attempts, e);
+                    exit(1);
+                }
+            }
+        }
+    }
+
+    if let Err(e) = exec("git", &["push", "--tags"]) {
+        eprintln!("Error pushing tags: {}", e);
+        exit(1);
+    }
+    println!("Pushed changes and tags");
+
+    set_output("version_committed", "true");
+    set_output("new_version", &new_version);
+}

--- a/experiments/test-safe-git-push.mjs
+++ b/experiments/test-safe-git-push.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+/**
+ * Reproducible test for `scripts/safe-git-push.mjs` (issue #94).
+ *
+ * Simulates the race that broke the Rust release workflow:
+ *   1. Create a bare "origin" repo with a single commit on main.
+ *   2. Clone it twice — A and B — simulating two concurrent release workflows.
+ *   3. Each clone commits a different change.
+ *   4. Clone A pushes first (wins).
+ *   5. Clone B runs `scripts/safe-git-push.mjs --branch main`.
+ *
+ * Expected: Clone B detects non-fast-forward, rebases, and pushes successfully.
+ * Control:  Verify that a raw `git push origin main` in Clone B fails with
+ *           "non-fast-forward", exactly as in the broken CI run.
+ *
+ * Usage:    node experiments/test-safe-git-push.mjs [--keep]
+ *           --keep: leave the sandbox on disk for inspection
+ */
+
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, "..");
+
+const keep = process.argv.includes("--keep");
+
+function sh(cmd, opts = {}) {
+  return execSync(cmd, {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+    shell: "/bin/sh",
+    ...opts,
+  });
+}
+
+function tryPush(dir) {
+  try {
+    sh("git push origin main", { cwd: dir });
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      stderr: (err.stderr || "").toString(),
+      stdout: (err.stdout || "").toString(),
+    };
+  }
+}
+
+const sandbox = mkdtempSync(join(tmpdir(), "safe-git-push-"));
+console.log(`Sandbox: ${sandbox}`);
+
+try {
+  const origin = join(sandbox, "origin.git");
+  const seed = join(sandbox, "seed");
+  const cloneA = join(sandbox, "clone-a");
+  const cloneB = join(sandbox, "clone-b");
+  const cloneControl = join(sandbox, "clone-control");
+
+  // --- Build bare origin with a single main commit ---
+  mkdirSync(origin);
+  sh("git init --bare --initial-branch=main", { cwd: origin });
+  mkdirSync(seed);
+  sh("git init --initial-branch=main", { cwd: seed });
+  sh(`git remote add origin ${origin}`, { cwd: seed });
+  writeFileSync(join(seed, "README.md"), "# test repo\n");
+  sh("git add README.md", { cwd: seed });
+  sh('git -c user.email=t@t -c user.name=test commit -m "initial"', {
+    cwd: seed,
+  });
+  sh("git push -u origin main", { cwd: seed });
+
+  // --- Clone A and Clone B simulate two release workflows ---
+  sh(`git clone ${origin} ${cloneA}`);
+  sh(`git clone ${origin} ${cloneB}`);
+  sh(`git clone ${origin} ${cloneControl}`);
+
+  for (const c of [cloneA, cloneB, cloneControl]) {
+    sh("git config user.email t@t", { cwd: c });
+    sh("git config user.name tester", { cwd: c });
+  }
+
+  writeFileSync(join(cloneA, "a.txt"), "a\n");
+  sh('git add a.txt && git commit -m "A bump"', {
+    cwd: cloneA,
+    shell: "/bin/sh",
+  });
+  writeFileSync(join(cloneB, "b.txt"), "b\n");
+  sh('git add b.txt && git commit -m "B bump"', {
+    cwd: cloneB,
+    shell: "/bin/sh",
+  });
+  writeFileSync(join(cloneControl, "b.txt"), "b\n");
+  sh('git add b.txt && git commit -m "B bump (control)"', {
+    cwd: cloneControl,
+    shell: "/bin/sh",
+  });
+
+  // --- A wins the race ---
+  sh("git push origin main", { cwd: cloneA });
+  console.log("A pushed OK");
+
+  // --- Control: raw `git push` from B should fail with non-fast-forward ---
+  const raw = tryPush(cloneControl);
+  if (raw.ok) {
+    console.error("FAIL: raw push from control clone unexpectedly succeeded");
+    process.exit(1);
+  }
+  const rawStderr = (raw.stderr || "").toLowerCase();
+  if (
+    !rawStderr.includes("non-fast-forward") &&
+    !rawStderr.includes("fetch first") &&
+    !rawStderr.includes("updates were rejected")
+  ) {
+    console.error(
+      "FAIL: raw push from control clone failed for the wrong reason:",
+    );
+    console.error(raw.stderr);
+    process.exit(1);
+  }
+  console.log("Control reproduced the non-fast-forward rejection as expected.");
+
+  // --- Under test: safe-git-push.mjs should recover via fetch-rebase-retry ---
+  const scriptPath = join(REPO_ROOT, "scripts", "safe-git-push.mjs");
+  sh(`node ${scriptPath} --branch main --verbose`, {
+    cwd: cloneB,
+    stdio: "inherit",
+  });
+
+  // --- Verify origin now has A's and B's commits ---
+  const log = sh("git log --oneline origin/main", {
+    cwd: cloneA + "",
+  }).toString();
+  console.log("\nFinal origin/main log (from A after fetch):");
+  sh("git -C " + cloneA + " fetch origin");
+  const finalLog = sh("git log --oneline origin/main", { cwd: cloneA });
+  console.log(finalLog);
+  if (!/A bump/.test(finalLog) || !/B bump/.test(finalLog)) {
+    console.error("FAIL: expected both A and B commits on origin/main");
+    process.exit(1);
+  }
+  console.log("PASS: safe-git-push.mjs recovered from the race.");
+} finally {
+  if (!keep) {
+    rmSync(sandbox, { recursive: true, force: true });
+  } else {
+    console.log(`(kept sandbox at ${sandbox})`);
+  }
+}

--- a/scripts/rust-version-and-commit.mjs
+++ b/scripts/rust-version-and-commit.mjs
@@ -117,8 +117,10 @@ async function main() {
       const commitMessage = `chore(rust): bump version to ${newVersion}`;
       await $`git commit -m "${commitMessage}"`;
 
-      // Push to main
-      await $`git push origin main`;
+      // Push to main with fetch+rebase+retry to tolerate concurrent release
+      // workflows (e.g. JS release) racing to push to main.
+      // See docs/case-studies/issue-94.
+      await $`node ../scripts/safe-git-push.mjs --branch main`;
 
       console.log('Version bump committed and pushed to main');
       setOutput('version_committed', 'true');

--- a/scripts/safe-git-push.mjs
+++ b/scripts/safe-git-push.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+/**
+ * Safe git push with fetch-rebase-retry semantics.
+ *
+ * Problem this solves:
+ *   When multiple release workflows (e.g. JavaScript and Rust) run concurrently
+ *   on the same push-to-main event, each may commit a version bump and push.
+ *   The second push fails with `! [rejected] main -> main (non-fast-forward)`.
+ *
+ *   See docs/case-studies/issue-94/README.md for the original incident.
+ *
+ * Behavior:
+ *   1. Fetch `origin <branch>`.
+ *   2. If local HEAD is behind `origin/<branch>`, rebase onto it.
+ *   3. Try `git push origin <branch>` up to --max-attempts times (default 5).
+ *   4. Between attempts, `git pull --rebase origin <branch>` to absorb
+ *      concurrent pushes; if rebase fails cleanly, abort and exit non-zero.
+ *
+ * Usage:
+ *   node scripts/safe-git-push.mjs [--branch <name>] [--max-attempts <n>] [--verbose]
+ *
+ * Environment:
+ *   BRANCH, MAX_ATTEMPTS, DEBUG  (mirror the CLI flags)
+ *
+ * Exit codes:
+ *   0 on successful push, 1 on unrecoverable failure.
+ */
+
+import { appendFileSync } from "fs";
+
+const { use } = eval(
+  await (await fetch("https://unpkg.com/use-m/use.js")).text(),
+);
+
+const { $ } = await use("command-stream");
+const { makeConfig } = await use("lino-arguments");
+
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .option("branch", {
+        type: "string",
+        default: getenv("BRANCH", "main"),
+        describe: "Branch to push",
+      })
+      .option("max-attempts", {
+        type: "number",
+        default: Number(getenv("MAX_ATTEMPTS", "5")),
+        describe: "Maximum number of push attempts",
+      })
+      .option("verbose", {
+        type: "boolean",
+        default: Boolean(getenv("DEBUG", "")),
+        describe: "Verbose logging",
+      }),
+});
+
+const { branch, maxAttempts, verbose } = config;
+
+function log(msg) {
+  console.log(`[safe-git-push] ${msg}`);
+}
+
+function logDebug(msg) {
+  if (verbose) console.log(`[safe-git-push][debug] ${msg}`);
+}
+
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) appendFileSync(outputFile, `${key}=${value}\n`);
+}
+
+async function run(cmd, args, { capture = false } = {}) {
+  const result = await $`${cmd} ${args}`.run({ capture: true });
+  const stdout = (result.stdout || "").trim();
+  const stderr = (result.stderr || "").trim();
+  if (verbose) {
+    if (stdout) logDebug(`stdout: ${stdout}`);
+    if (stderr) logDebug(`stderr: ${stderr}`);
+    logDebug(`exit: ${result.code}`);
+  }
+  if (capture) return { code: result.code, stdout, stderr };
+  if (result.code !== 0) {
+    const err = new Error(
+      `Command failed (exit ${result.code}): ${cmd} ${args.join(" ")}\n${stderr || stdout}`,
+    );
+    err.code = result.code;
+    err.stdout = stdout;
+    err.stderr = stderr;
+    throw err;
+  }
+  return { code: 0, stdout, stderr };
+}
+
+async function main() {
+  log(`Pushing to origin/${branch} (up to ${maxAttempts} attempts)`);
+
+  if (verbose) {
+    await run("git", ["remote", "-v"], { capture: true }).then((r) =>
+      logDebug(`remotes:\n${r.stdout}`),
+    );
+    await run("git", ["rev-parse", "HEAD"], { capture: true }).then((r) =>
+      logDebug(`local HEAD: ${r.stdout}`),
+    );
+  }
+
+  // Pre-sync: fetch and rebase if behind.
+  try {
+    await run("git", ["fetch", "origin", branch]);
+  } catch (err) {
+    log(`Warning: initial fetch failed: ${err.message}`);
+  }
+
+  let localHead = "";
+  let remoteHead = "";
+  try {
+    localHead = (await run("git", ["rev-parse", "HEAD"], { capture: true }))
+      .stdout;
+    remoteHead = (
+      await run("git", ["rev-parse", `origin/${branch}`], { capture: true })
+    ).stdout;
+  } catch (err) {
+    log(`Warning: could not resolve HEADs before push: ${err.message}`);
+  }
+
+  if (localHead && remoteHead && localHead !== remoteHead) {
+    // If local is strictly behind, rebasing is safe; if diverged, rebase still
+    // replays our bump commit on top of remote.
+    log(
+      `Local (${localHead.slice(0, 7)}) differs from origin/${branch} (${remoteHead.slice(0, 7)}); rebasing before push`,
+    );
+    try {
+      await run("git", ["rebase", `origin/${branch}`]);
+    } catch (err) {
+      log(`Initial rebase failed: ${err.message}`);
+      try {
+        await run("git", ["rebase", "--abort"], { capture: true });
+      } catch (_) {
+        /* ignore */
+      }
+      setOutput("pushed", "false");
+      process.exit(1);
+    }
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    log(`Push attempt ${attempt}/${maxAttempts}…`);
+    const pushResult = await run("git", ["push", "origin", branch], {
+      capture: true,
+    });
+    if (pushResult.code === 0) {
+      log(`Push succeeded on attempt ${attempt}`);
+      setOutput("pushed", "true");
+      setOutput("attempts", String(attempt));
+      process.exit(0);
+    }
+
+    const combined = `${pushResult.stdout}\n${pushResult.stderr}`.toLowerCase();
+    const isNonFastForward =
+      combined.includes("non-fast-forward") ||
+      combined.includes("fetch first") ||
+      combined.includes("updates were rejected") ||
+      combined.includes("tip of your current branch is behind");
+
+    log(
+      `Push attempt ${attempt} failed (exit ${pushResult.code})${
+        isNonFastForward ? " — non-fast-forward" : ""
+      }`,
+    );
+    if (pushResult.stderr) log(`stderr: ${pushResult.stderr}`);
+
+    if (!isNonFastForward) {
+      // Auth / network / hook rejection: retrying won't help; fail fast.
+      setOutput("pushed", "false");
+      process.exit(pushResult.code || 1);
+    }
+
+    if (attempt === maxAttempts) break;
+
+    log(
+      `Running git pull --rebase origin ${branch} to integrate remote changes…`,
+    );
+    const pullResult = await run(
+      "git",
+      ["pull", "--rebase", "origin", branch],
+      { capture: true },
+    );
+    if (pullResult.code !== 0) {
+      log(`pull --rebase failed (exit ${pullResult.code})`);
+      if (pullResult.stderr) log(`stderr: ${pullResult.stderr}`);
+      try {
+        await run("git", ["rebase", "--abort"], { capture: true });
+      } catch (_) {
+        /* ignore */
+      }
+      setOutput("pushed", "false");
+      process.exit(1);
+    }
+  }
+
+  log(`Giving up after ${maxAttempts} push attempts`);
+  setOutput("pushed", "false");
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(`[safe-git-push] fatal: ${err.message}`);
+  if (verbose && err.stack) console.error(err.stack);
+  process.exit(1);
+});

--- a/scripts/version-and-commit.mjs
+++ b/scripts/version-and-commit.mjs
@@ -227,8 +227,10 @@ async function main() {
       const escapedMessage = commitMessage.replace(/"/g, '\\"');
       await $`git commit -m "${escapedMessage}"`;
 
-      // Push directly to main
-      await $`git push origin main`;
+      // Push directly to main with fetch+rebase+retry so concurrent
+      // workflows (e.g. Rust release) pushing at the same time don't cause
+      // a non-fast-forward rejection. See docs/case-studies/issue-94.
+      await $`node ../scripts/safe-git-push.mjs --branch main`;
 
       console.log("\u2705 Version bump committed and pushed to main");
       setOutput("version_committed", "true");


### PR DESCRIPTION
## Summary

Fixes #94 — the Rust release workflow failed with `! [rejected] main -> main (non-fast-forward)` in [run 24686173280](https://github.com/link-assistant/web-capture/actions/runs/24686173280/job/72197673668) because the JS release workflow auto-bumped `1.7.10` and pushed to `main` first, while the Rust workflow tried to push `0.3.3` on top of the now-stale local `4a3dc43…`. All downstream Rust steps (crates.io publish, GitHub Release) were skipped, so `rust/src/browser.rs` + `rust/src/gdocs.rs` changes from PR #93 never made it to crates.io.

## Root cause

Both `.github/workflows/js.yml` and `.github/workflows/rust.yml` auto-bump on the same push-to-`main` event. Each workflow has its own per-workflow concurrency group (`${{ github.workflow }}-${{ github.ref }}`), so they run in parallel — they must, since JS needs its own npm OIDC context. Whichever auto-bump finishes first wins; the other's inline `git push origin main` fails with non-fast-forward and the whole release job aborts.

Full timeline, log excerpts, and upstream-template comparison in [`docs/case-studies/issue-94/README.md`](docs/case-studies/issue-94/README.md).

## Fix

New shared helper `scripts/safe-git-push.mjs`:
- `git fetch origin <branch>` up front, rebase if local diverges
- Up to `--max-attempts` (default 5) `git push` attempts
- Between attempts, `git pull --rebase origin <branch>` to absorb concurrent pushes
- Fails fast on non-retriable errors (auth, hook rejection) instead of looping
- `--verbose` / `DEBUG` prints remotes, HEADs, and full push stderr (R6)

All four touch points now go through it:
- `.github/workflows/rust.yml` — auto-bump step
- `.github/workflows/js.yml` — auto-bump step
- `scripts/rust-version-and-commit.mjs` — manual/instant Rust release
- `scripts/version-and-commit.mjs` — manual/instant JS release

## Test plan

- [x] `experiments/test-safe-git-push.mjs` — reproduces the race locally (two clones commit in parallel, one pushes first; the script under test rebases and retries on the loser). Control assertion verifies a raw `git push` still fails with "non-fast-forward".
- [x] `npm run lint` — no new errors
- [x] `npm run format:check` — passes
- [x] Existing Jest suites pass (`publish-verification` etc.)
- [ ] On merge, next JS+Rust concurrent release on `main` publishes both npm and crates.io without non-fast-forward (validates in production)

## Requirements coverage (from issue)

- R1 (root cause): documented in case-study README
- R2 (compare vs upstream templates): `docs/case-studies/issue-94/upstream-templates/` + findings in README
- R3/R4 (case study + timeline): `docs/case-studies/issue-94/`
- R5 (upstream issue): drafted in `docs/case-studies/issue-94/proposed-upstream-issue.md` (to be filed against the link-foundation templates)
- R6 (debug/verbose): `--verbose` flag on `safe-git-push.mjs`

## Reproduction

```bash
node experiments/test-safe-git-push.mjs
# Sandbox: /tmp/safe-git-push-…
# A pushed OK
# Control reproduced the non-fast-forward rejection as expected.
# PASS: safe-git-push.mjs recovered from the race.
```