### PR TITLE
Number consecutive top-level <ol>s continuously across JS and Rust (fixes #118)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-05-05T17:17:56.704Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-05-05T17:17:56.704Z

--- a/js/.changeset/issue-118-ol-continuous-numbering.md
+++ b/js/.changeset/issue-118-ol-continuous-numbering.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Number consecutive top-level `<ol>`s continuously across the document (1, 2, 3, ... N) so JS and Rust HTML→Markdown converters agree. `<ol start="N">` resets the counter and is honoured by both implementations. Nested ordered lists keep their own per-list numbering.

--- a/js/src/gdocs-preprocess.js
+++ b/js/src/gdocs-preprocess.js
@@ -245,6 +245,12 @@ function renderNestedListGroup($, group, classStyles) {
   const openTags = [];
   const itemOpen = [];
 
+  const topLevelStart =
+    group[0]?.tagName?.toLowerCase() === 'ol'
+      ? $(group[0]).attr('start')
+      : undefined;
+  let topLevelOpened = false;
+
   const closeItem = (level) => {
     if (itemOpen[level]) {
       html += '</li>';
@@ -261,7 +267,21 @@ function renderNestedListGroup($, group, classStyles) {
   const openList = (level, tagName) => {
     openTags[level] = tagName;
     itemOpen[level] = false;
-    html += `<${tagName}>`;
+    if (
+      level === 0 &&
+      !topLevelOpened &&
+      tagName === 'ol' &&
+      topLevelStart !== undefined &&
+      topLevelStart !== ''
+    ) {
+      html += `<ol start="${topLevelStart}">`;
+      topLevelOpened = true;
+    } else {
+      if (level === 0) {
+        topLevelOpened = true;
+      }
+      html += `<${tagName}>`;
+    }
   };
 
   for (const list of group) {

--- a/js/src/lib.js
+++ b/js/src/lib.js
@@ -59,6 +59,10 @@ export function convertHtmlToMarkdown(html, baseUrl) {
   //    Demoting avoids ATX heading prefix, leaving the sub-number on a clean line.
   preserveLeadingHeadingNumbering($);
 
+  // Number consecutive top-level <ol>s continuously across the document
+  // (1, 2, 3 ... N) so JS and Rust agree. <ol start="N"> resets the counter.
+  applyContinuousOrderedListNumbering($);
+
   // Remove <a> tags with no direct text content (including only whitespace or only child elements)
   $('a').each(function () {
     // Get all text nodes directly under this <a>
@@ -225,6 +229,28 @@ function preserveLeadingHeadingNumbering($) {
       $p.html(`<strong>${inner}</strong>`);
     }
     $h.replaceWith($p);
+  });
+}
+
+// Walk every top-level <ol> in document order and assign a `start` attribute
+// so consecutive lists number continuously (1, 2, 3, ... N). An explicit
+// `start="N"` resets the running counter to N and is preserved.
+//
+// Top-level here means "not inside another <ol> or <ul>" — nested ordered
+// lists keep their own numbering and Turndown's per-list start handling.
+function applyContinuousOrderedListNumbering($) {
+  let counter = 1;
+  $('ol').each(function () {
+    if ($(this).parents('ol, ul').length > 0) {
+      return;
+    }
+    const explicitStart = parseInt($(this).attr('start') ?? '', 10);
+    if (Number.isFinite(explicitStart)) {
+      counter = explicitStart;
+    } else {
+      $(this).attr('start', String(counter));
+    }
+    counter += $(this).children('li').length;
   });
 }
 
@@ -505,6 +531,9 @@ export function convertHtmlToMarkdownEnhanced(html, baseUrl, options = {}) {
 
   // Preserve hierarchical heading numbering (see convertHtmlToMarkdown).
   preserveLeadingHeadingNumbering($);
+
+  // Continuous numbering across consecutive top-level <ol>s (see convertHtmlToMarkdown).
+  applyContinuousOrderedListNumbering($);
 
   // Remove empty links (same logic as convertHtmlToMarkdown)
   $('a').each(function () {

--- a/js/tests/fixtures/ol-continuous-numbering.html
+++ b/js/tests/fixtures/ol-continuous-numbering.html
@@ -1,0 +1,12 @@
+<ol>
+  <li><strong>First</strong></li>
+  <li><strong>Second</strong></li>
+</ol>
+<p>Some prose between lists.</p>
+<ol>
+  <li><strong>Third</strong></li>
+  <li><strong>Fourth</strong></li>
+</ol>
+<ol start="13">
+  <li><strong>Top-level numbered heading.</strong></li>
+</ol>

--- a/js/tests/unit/html2md-ol-numbering.test.js
+++ b/js/tests/unit/html2md-ol-numbering.test.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { convertHtmlToMarkdown } from '../../src/lib.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const HTML = fs.readFileSync(
+  path.join(__dirname, '..', 'fixtures', 'ol-continuous-numbering.html'),
+  'utf8'
+);
+
+it('numbers consecutive top-level ordered lists continuously', () => {
+  const md = convertHtmlToMarkdown(HTML);
+  expect(md).toMatch(/^\s*1\.\s+\*\*First\*\*/m);
+  expect(md).toMatch(/^\s*2\.\s+\*\*Second\*\*/m);
+  expect(md).toMatch(/^\s*3\.\s+\*\*Third\*\*/m);
+  expect(md).toMatch(/^\s*4\.\s+\*\*Fourth\*\*/m);
+  expect(md).toMatch(/^\s*13\.\s+\*\*Top-level/m);
+});

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "web-capture"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/rust/src/gdocs.rs
+++ b/rust/src/gdocs.rs
@@ -721,6 +721,7 @@ struct ExportListBlock {
     end: usize,
     tag: String,
     inner: String,
+    start_attr: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -732,6 +733,7 @@ struct ExportListItem {
 
 fn nest_google_docs_lists(html: &str, class_styles: &HashMap<String, String>) -> String {
     let list_re = Regex::new(r"(?is)<(ul|ol)\b([^>]*)>(.*?)</(ul|ol)>").expect("valid regex");
+    let start_attr_re = Regex::new(r#"(?i)\bstart\s*=\s*"([^"]*)""#).expect("valid regex");
     let blocks: Vec<ExportListBlock> = list_re
         .captures_iter(html)
         .filter_map(|caps| {
@@ -741,11 +743,20 @@ fn nest_google_docs_lists(html: &str, class_styles: &HashMap<String, String>) ->
                 return None;
             }
             let whole = caps.get(0)?;
+            let attrs = caps.get(2).map_or("", |m| m.as_str());
+            let start_attr = if open_tag == "ol" {
+                start_attr_re
+                    .captures(attrs)
+                    .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+            } else {
+                None
+            };
             Some(ExportListBlock {
                 start: whole.start(),
                 end: whole.end(),
                 tag: open_tag,
                 inner: caps.get(3).map_or("", |m| m.as_str()).to_string(),
+                start_attr,
             })
         })
         .collect();
@@ -786,6 +797,7 @@ fn nest_google_docs_lists(html: &str, class_styles: &HashMap<String, String>) ->
     out
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_nested_list_group(
     group: &[ExportListBlock],
     class_styles: &HashMap<String, String>,
@@ -815,10 +827,13 @@ fn render_nested_list_group(
         return unchanged;
     }
 
+    let top_level_start = group.first().and_then(|block| block.start_attr.clone());
+
     let mut html = String::new();
     let mut current_level: Option<usize> = None;
     let mut open_tags: Vec<Option<String>> = Vec::new();
     let mut item_open: Vec<bool> = Vec::new();
+    let mut top_level_opened = false;
 
     for item in items {
         let level = item.level;
@@ -830,12 +845,19 @@ fn render_nested_list_group(
 
         while current_level.is_none_or(|current| current < level) {
             let next_level = current_level.map_or(0, |current| current + 1);
+            let start_attr = if next_level == 0 && !top_level_opened {
+                top_level_opened = true;
+                top_level_start.as_deref()
+            } else {
+                None
+            };
             open_rendered_list(
                 &mut html,
                 &mut open_tags,
                 &mut item_open,
                 next_level,
                 &item.tag,
+                start_attr,
             );
             current_level = Some(next_level);
         }
@@ -846,9 +868,35 @@ fn render_nested_list_group(
             .is_some_and(|tag| tag != item.tag)
         {
             close_rendered_list(&mut html, &mut open_tags, &mut item_open, level);
-            open_rendered_list(&mut html, &mut open_tags, &mut item_open, level, &item.tag);
+            let start_attr = if level == 0 && !top_level_opened {
+                top_level_opened = true;
+                top_level_start.as_deref()
+            } else {
+                None
+            };
+            open_rendered_list(
+                &mut html,
+                &mut open_tags,
+                &mut item_open,
+                level,
+                &item.tag,
+                start_attr,
+            );
         } else if open_tags[level].is_none() {
-            open_rendered_list(&mut html, &mut open_tags, &mut item_open, level, &item.tag);
+            let start_attr = if level == 0 && !top_level_opened {
+                top_level_opened = true;
+                top_level_start.as_deref()
+            } else {
+                None
+            };
+            open_rendered_list(
+                &mut html,
+                &mut open_tags,
+                &mut item_open,
+                level,
+                &item.tag,
+                start_attr,
+            );
         }
 
         close_rendered_item(&mut html, &mut item_open, level);
@@ -883,10 +931,16 @@ fn open_rendered_list(
     item_open: &mut Vec<bool>,
     level: usize,
     tag: &str,
+    start_attr: Option<&str>,
 ) {
     ensure_list_stack(open_tags, item_open, level);
     html.push('<');
     html.push_str(tag);
+    if let Some(start) = start_attr {
+        if tag == "ol" && !start.is_empty() {
+            write!(html, r#" start="{start}""#).expect("write to String");
+        }
+    }
     html.push('>');
     open_tags[level] = Some(tag.to_string());
     item_open[level] = false;

--- a/rust/src/markdown.rs
+++ b/rust/src/markdown.rs
@@ -48,8 +48,19 @@ pub fn convert_html_to_markdown(html: &str, base_url: Option<&str>) -> Result<St
     // silently dropping inline images.
     let heading_safe_html = hoist_images_from_headings(&cleaned_html);
 
+    // Compute the number that each top-level <ol> item should carry, in
+    // document order, so we can rewrite html2md's per-list-restarting "1."
+    // prefixes into a single continuous sequence (matching the JS converter's
+    // output) and honour explicit `<ol start="N">` attributes.
+    let ol_item_numbers = compute_top_level_ordered_list_item_numbers(&heading_safe_html);
+
     // Convert to Markdown using html2md
     let markdown = html2md::parse_html(&heading_safe_html);
+
+    // Renumber unindented ordered-list lines in the markdown output to match
+    // the precomputed numbers. Indented lines (nested lists) are left alone
+    // so html2md's per-list "1." restart for nested levels is preserved.
+    let markdown = renumber_top_level_ordered_list_lines(&markdown, &ol_item_numbers);
 
     // Decode HTML entities to unicode characters
     let decoded_markdown = crate::html::decode_html_entities(&markdown);
@@ -192,6 +203,89 @@ fn hoist_images_from_headings(html: &str) -> String {
     }
 
     result
+}
+
+/// Walk every top-level `<ol>` in document order and return the number that
+/// each direct `<li>` child should carry. Without an explicit `start="N"`,
+/// lists continue the running counter from the previous list (e.g. 1, 2 then
+/// 3, 4 across two consecutive `<ol>`s). With `start="N"`, the counter resets
+/// to `N` for that list and subsequent lists continue from there.
+///
+/// Top-level here means "not nested inside another `<ol>` or `<ul>`" — nested
+/// lists keep their own per-list numbering, matching `html2md`'s default.
+fn compute_top_level_ordered_list_item_numbers(html: &str) -> Vec<u32> {
+    let document = Html::parse_document(html);
+    let Ok(ol_selector) = Selector::parse("ol") else {
+        return Vec::new();
+    };
+    let mut numbers = Vec::new();
+    let mut counter: u32 = 1;
+    for ol in document.select(&ol_selector) {
+        let nested = ol.ancestors().any(|n| {
+            n.value()
+                .as_element()
+                .is_some_and(|e| e.name() == "ol" || e.name() == "ul")
+        });
+        if nested {
+            continue;
+        }
+        if let Some(start) = ol
+            .value()
+            .attr("start")
+            .and_then(|s| s.trim().parse::<u32>().ok())
+        {
+            counter = start;
+        }
+        let li_count = ol
+            .children()
+            .filter(|n| n.value().as_element().is_some_and(|e| e.name() == "li"))
+            .count();
+        for _ in 0..li_count {
+            numbers.push(counter);
+            counter = counter.saturating_add(1);
+        }
+    }
+    numbers
+}
+
+/// Replace the prefix of each unindented `^\d+\.\s` line in `markdown` with
+/// the next number from `numbers`, in document order. Indented lines (nested
+/// list items) are skipped so `html2md`'s per-list "1." restart for nested
+/// levels is preserved. Setext heading underlines (`====` / `----`) are
+/// detected so a `1. Headings` line followed by an underline is not treated
+/// as a list item. Lines beyond the end of `numbers` are left untouched.
+fn renumber_top_level_ordered_list_lines(markdown: &str, numbers: &[u32]) -> String {
+    use std::fmt::Write;
+
+    let item_re = Regex::new(r"^(\d+)\.(\s)").expect("valid regex");
+    let setext_re = Regex::new(r"^(=+|-+)\s*$").expect("valid regex");
+    let lines: Vec<&str> = markdown.split_inclusive('\n').collect();
+    let mut out = String::with_capacity(markdown.len());
+    let mut idx: usize = 0;
+
+    for (i, line) in lines.iter().enumerate() {
+        let body = line.strip_suffix('\n').unwrap_or(line);
+        if let Some(caps) = item_re.captures(body) {
+            let next_body = lines
+                .get(i + 1)
+                .map_or("", |l| l.strip_suffix('\n').unwrap_or(l));
+            let is_setext_heading = setext_re.is_match(next_body);
+            if !is_setext_heading {
+                if let Some(&n) = numbers.get(idx) {
+                    let after = &body[caps.get(0).expect("match 0").end()..];
+                    let sep = caps.get(2).expect("group 2").as_str();
+                    write!(out, "{n}.{sep}{after}").expect("write to String");
+                    if line.ends_with('\n') {
+                        out.push('\n');
+                    }
+                    idx += 1;
+                    continue;
+                }
+            }
+        }
+        out.push_str(line);
+    }
+    out
 }
 
 /// Clean up Markdown output

--- a/rust/tests/fixtures/ol-continuous-numbering.html
+++ b/rust/tests/fixtures/ol-continuous-numbering.html
@@ -1,0 +1,12 @@
+<ol>
+  <li><strong>First</strong></li>
+  <li><strong>Second</strong></li>
+</ol>
+<p>Some prose between lists.</p>
+<ol>
+  <li><strong>Third</strong></li>
+  <li><strong>Fourth</strong></li>
+</ol>
+<ol start="13">
+  <li><strong>Top-level numbered heading.</strong></li>
+</ol>

--- a/rust/tests/integration/html2md_ol_numbering.rs
+++ b/rust/tests/integration/html2md_ol_numbering.rs
@@ -1,0 +1,16 @@
+use web_capture::markdown::convert_html_to_markdown;
+
+const HTML: &str = include_str!("../fixtures/ol-continuous-numbering.html");
+
+#[test]
+fn numbers_consecutive_top_level_ordered_lists_continuously() {
+    let md = convert_html_to_markdown(HTML, None).unwrap();
+    assert!(md.contains("1. **First**"), "got:\n{md}");
+    assert!(md.contains("2. **Second**"), "got:\n{md}");
+    assert!(md.contains("3. **Third**"), "got:\n{md}");
+    assert!(md.contains("4. **Fourth**"), "got:\n{md}");
+    assert!(
+        md.contains("13. **Top-level"),
+        "must honour <ol start=13>; got:\n{md}"
+    );
+}

--- a/rust/tests/integration/mod.rs
+++ b/rust/tests/integration/mod.rs
@@ -6,4 +6,5 @@ mod gdocs;
 mod gdocs_image_parity;
 mod gdocs_public_doc;
 mod heading_numbering;
+mod html2md_ol_numbering;
 mod themed_image;


### PR DESCRIPTION
Fixes #118.

## Problem

JS and Rust HTML→Markdown converters emitted different ordered-list numbering for the same input:

- **JS (Turndown)**: restarted counter per `<ol>` but honoured `<ol start="N">`.
- **Rust (html2md)**: restarted counter per `<ol>` and ignored `<ol start="N">`.

Same HTML → different `.md`, breaking parity for documents with multiple top-level `<ol>`s or explicit `start=`.

## Fix

Aligned both implementations on **continuous numbering across consecutive top-level `<ol>`s in document order, with `<ol start="N">` honoured** (resets the running counter to N for that list, subsequent lists continue from there).

- **Top-level** = not nested inside another `<ol>` or `<ul>`. Nested lists keep their own per-list `1.` numbering, matching the prior behaviour.
- Setext heading underlines (`---`/`===`) are detected so a `1. Headings` line followed by a setext underline isn't misidentified as a list item.

### JS (`js/src/lib.js`)

New `applyContinuousOrderedListNumbering($)` runs as a cheerio pre-pass in both `convertHtmlToMarkdown` and `convertHtmlToMarkdownEnhanced`. Walks each top-level `<ol>` and writes a `start` attribute so Turndown emits the correct numbers. Honours an existing `start="N"` (resets the counter and preserves the attribute).

### Rust (`rust/src/markdown.rs`)

`html2md` ignores `start=`, so we go DOM → numbers → markdown post-pass:

1. `compute_top_level_ordered_list_item_numbers` walks the parsed DOM and produces a `Vec<u32>` with one number per direct `<li>` of every top-level `<ol>`, in document order, honouring `start="N"`.
2. `renumber_top_level_ordered_list_lines` iterates `html2md` output line by line and replaces unindented `^\d+\.\s` line prefixes with sequential numbers from the precomputed `Vec`. Indented (nested-list) lines are left alone. Setext heading underlines are detected via next-line lookahead.

## Tests

Shared fixture `tests/fixtures/ol-continuous-numbering.html` (identical content in both `js/` and `rust/`) covers two consecutive top-level `<ol>`s plus an `<ol start="13">`:

```html
<ol>
  <li><strong>First</strong></li>
  <li><strong>Second</strong></li>
</ol>
<p>Some prose between lists.</p>
<ol>
  <li><strong>Third</strong></li>
  <li><strong>Fourth</strong></li>
</ol>
<ol start="13">
  <li><strong>Top-level numbered heading.</strong></li>
</ol>
```

- `js/tests/unit/html2md-ol-numbering.test.js` — passes ✓
- `rust/tests/integration/html2md_ol_numbering.rs` — passes ✓

Both assert `1. **First** ... 2. **Second** ... 3. **Third** ... 4. **Fourth** ... 13. **Top-level**`.

## Test plan

- [x] `cargo test` — 93 integration + 92 unit + 2 doctests all pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `node --experimental-vm-modules ./node_modules/.bin/jest tests/unit` — only failures are the pre-existing browser tests blocked by missing Chrome in this env; new test passes
- [x] `npx prettier --check` — clean on changed files
- [x] No regression in existing gdocs / heading-numbering tests