### PR TITLE
Preserve <br>-separated lines in JS `--capture api` list items

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-05-05T20:43:31.390Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-05-05T20:43:31.390Z

--- a/experiments/repro-br-li.mjs
+++ b/experiments/repro-br-li.mjs
@@ -1,0 +1,20 @@
+import { convertHtmlToMarkdown, convertHtmlToMarkdownEnhanced } from '../js/src/lib.js';
+
+const HTML = `<ol>
+  <li><strong>Glossary entry.</strong>Some lead text.<br>
+    <strong>TAG1</strong> – Definition one.<br>
+    <strong>TAG2</strong> – Definition two.<br>
+    <strong>TAG3</strong> – Definition three.
+  </li>
+</ol>`;
+
+console.log('=== convertHtmlToMarkdown ===');
+console.log(JSON.stringify(convertHtmlToMarkdown(HTML)));
+console.log('--- raw ---');
+console.log(convertHtmlToMarkdown(HTML));
+
+console.log('\n=== convertHtmlToMarkdownEnhanced ===');
+const { markdown } = convertHtmlToMarkdownEnhanced(HTML);
+console.log(JSON.stringify(markdown));
+console.log('--- raw ---');
+console.log(markdown);

--- a/experiments/repro-br-pipeline.mjs
+++ b/experiments/repro-br-pipeline.mjs
@@ -1,0 +1,25 @@
+import { convertHtmlToMarkdown } from '../js/src/lib.js';
+import {
+  preprocessGoogleDocsExportHtml,
+  normalizeGoogleDocsExportMarkdown,
+} from '../js/src/gdocs-preprocess.js';
+
+const HTML = `<ol>
+  <li><strong>Glossary entry.</strong>Some lead text.<br>
+    <strong>TAG1</strong> – Definition one.<br>
+    <strong>TAG2</strong> – Definition two.<br>
+    <strong>TAG3</strong> – Definition three.
+  </li>
+</ol>`;
+
+const pre = preprocessGoogleDocsExportHtml(HTML);
+console.log('=== preprocess.html ===');
+console.log(pre.html);
+const raw = convertHtmlToMarkdown(pre.html);
+console.log('=== raw markdown ===');
+console.log(JSON.stringify(raw));
+console.log(raw);
+const norm = normalizeGoogleDocsExportMarkdown(raw);
+console.log('=== normalized ===');
+console.log(JSON.stringify(norm));
+console.log(norm);

--- a/experiments/repro-br-variations.mjs
+++ b/experiments/repro-br-variations.mjs
@@ -1,0 +1,32 @@
+// Try several plausible representations of "Shift+Enter inside a list item" from Google Docs export-html.
+import { convertHtmlToMarkdown } from '../js/src/lib.js';
+import {
+  preprocessGoogleDocsExportHtml,
+  normalizeGoogleDocsExportMarkdown,
+} from '../js/src/gdocs-preprocess.js';
+
+const cases = {
+  'plain <br> with newline': `<ol><li><strong>Glossary entry.</strong>Some lead text.<br>
+<strong>TAG1</strong> – Definition one.<br>
+<strong>TAG2</strong> – Definition two.<br>
+<strong>TAG3</strong> – Definition three.</li></ol>`,
+
+  'plain <br> no newline (raw)': `<ol><li><strong>Glossary entry.</strong>Some lead text.<br><strong>TAG1</strong> – Definition one.<br><strong>TAG2</strong> – Definition two.<br><strong>TAG3</strong> – Definition three.</li></ol>`,
+
+  '<br> with bold-styled spans (Gdocs hoisted)': `<ol><li><span style="font-weight:700">Glossary entry.</span>Some lead text.<br><span style="font-weight:700">TAG1</span> – Definition one.<br><span style="font-weight:700">TAG2</span> – Definition two.<br><span style="font-weight:700">TAG3</span> – Definition three.</li></ol>`,
+
+  'br inside <p> wrapped (Gdocs <p> child of <li>)': `<ol><li><p><strong>Glossary entry.</strong>Some lead text.<br><strong>TAG1</strong> – Definition one.<br><strong>TAG2</strong> – Definition two.<br><strong>TAG3</strong> – Definition three.</p></li></ol>`,
+
+  'span containing the br (Gdocs)': `<ol><li><span style="font-weight:700">Glossary entry.</span><span>Some lead text.<br></span><span style="font-weight:700">TAG1</span><span> – Definition one.<br></span><span style="font-weight:700">TAG2</span><span> – Definition two.<br></span><span style="font-weight:700">TAG3</span><span> – Definition three.</span></li></ol>`,
+};
+
+for (const [label, html] of Object.entries(cases)) {
+  console.log(`========== ${label} ==========`);
+  const pre = preprocessGoogleDocsExportHtml(html);
+  const raw = convertHtmlToMarkdown(pre.html);
+  const norm = normalizeGoogleDocsExportMarkdown(raw);
+  console.log('--- raw markdown ---');
+  console.log(JSON.stringify(raw));
+  console.log('--- normalized markdown ---');
+  console.log(JSON.stringify(norm));
+}

--- a/js/.changeset/issue-119-br-in-list-item.md
+++ b/js/.changeset/issue-119-br-in-list-item.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Fix `--capture api` collapsing `<br>`-separated lines inside list items into one run. The Google Docs export-html path lost line breaks when a `<br>` was the leading or trailing child of an inline element (e.g. a `<span>` between bold runs), because Turndown trims inner content of inline elements with edge whitespace. The HTML pre-processing now hoists those edge `<br>`s out of their inline parents before Turndown sees them, restoring CommonMark hard breaks. Additionally, the post-processor's double-space collapse no longer eats the two trailing spaces that mark a hard break.

--- a/js/src/lib.js
+++ b/js/src/lib.js
@@ -164,6 +164,10 @@ export function convertHtmlToMarkdown(html, baseUrl) {
     $table.replaceWith($newTable);
   });
 
+  // Hoist <br>s out of inline edges so Turndown's flanking-whitespace trim
+  // does not eat the hard break. See liftBrFromInlineEdges for details.
+  liftBrFromInlineEdges($);
+
   // Convert cleaned HTML to Markdown
   const turndown = new TurndownService({
     headingStyle: 'atx',
@@ -181,6 +185,72 @@ export function convertHtmlToMarkdown(html, baseUrl) {
   // Decode HTML entities to unicode after markdown conversion
   // Preserve non-breaking spaces as &nbsp; entities for clear marking
   return he.decode(turndown.turndown($.html())).replace(/\u00A0/g, '&nbsp;');
+}
+
+// Lift <br> nodes out of inline parents when they sit at the leading or
+// trailing edge.
+//
+// Turndown calls `content.trim()` on the inner markdown of any inline element
+// whose `flankingWhitespace` is non-empty (turndown.cjs.js:902), which strips
+// the `  \n` hard break that the <br> rule emits. Google Docs export-html
+// commonly produces `<strong>X</strong><span> Y.<br></span><strong>Z</strong>`
+// — the trailing <br> inside a leading-space <span> gets `.trim()`-ed away,
+// so X/Y/Z collapse onto one line.
+//
+// Hoisting trailing/leading <br>s out of their inline wrapper sidesteps the
+// trim entirely. The hard break then attaches at the parent level, which
+// Turndown handles correctly.
+function liftBrFromInlineEdges($) {
+  const inlineParents = new Set([
+    'span',
+    'a',
+    'strong',
+    'b',
+    'em',
+    'i',
+    'u',
+    's',
+    'del',
+    'ins',
+    'sub',
+    'sup',
+    'mark',
+    'small',
+    'q',
+    'cite',
+    'code',
+    'abbr',
+    'time',
+    'kbd',
+    'samp',
+    'var',
+    'font',
+  ]);
+
+  // Hoist <br>s repeatedly until none sit at an inline edge — this handles
+  // nested wrappers like `<span><em>foo<br></em></span>`.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    $('br').each(function () {
+      const el = this;
+      const parent = el.parent;
+      if (!parent || !inlineParents.has(parent.tagName)) {
+        return;
+      }
+      const isFirst = parent.children[0] === el;
+      const isLast = parent.children[parent.children.length - 1] === el;
+      if (!isFirst && !isLast) {
+        return;
+      }
+      if (isLast) {
+        $(parent).after(el);
+      } else {
+        $(parent).before(el);
+      }
+      changed = true;
+    });
+  }
 }
 
 function preserveLeadingHeadingNumbering($) {
@@ -673,6 +743,9 @@ export function convertHtmlToMarkdownEnhanced(html, baseUrl, options = {}) {
     }
     $table.replaceWith($newTable);
   });
+
+  // Hoist <br>s out of inline edges (see liftBrFromInlineEdges).
+  liftBrFromInlineEdges($);
 
   // Convert to Markdown using Turndown
   const turndown = new TurndownService({

--- a/js/src/postprocess.js
+++ b/js/src/postprocess.js
@@ -50,8 +50,9 @@ export function postProcessMarkdown(markdown, options = {}) {
     result = applyBoldFormattingFixes(result);
   }
 
-  // Fix double spaces (but not in code blocks)
-  result = result.replace(/([^\n`]) +/g, (match, char) => `${char} `);
+  // Fix double spaces (but not in code blocks, and preserve CommonMark hard
+  // breaks which require two trailing spaces before a newline).
+  result = result.replace(/([^\n`]) +(?!\n)/g, (match, char) => `${char} `);
 
   // Clean up extra spaces around em-dashes
   result = result.replace(/\s+—\s+/g, ' — ');

--- a/js/tests/fixtures/list-item-with-br.html
+++ b/js/tests/fixtures/list-item-with-br.html
@@ -1,3 +1,8 @@
 <ol>
-  <li><strong>Glossary entry.</strong><span> Some lead text.<br></span><strong>TAG1</strong><span> – Definition one.<br></span><strong>TAG2</strong><span> – Definition two.<br></span><strong>TAG3</strong><span> – Definition three.</span></li>
+  <li>
+    <strong>Glossary entry.</strong><span> Some lead text.<br /></span
+    ><strong>TAG1</strong><span> – Definition one.<br /></span
+    ><strong>TAG2</strong><span> – Definition two.<br /></span
+    ><strong>TAG3</strong><span> – Definition three.</span>
+  </li>
 </ol>

--- a/js/tests/fixtures/list-item-with-br.html
+++ b/js/tests/fixtures/list-item-with-br.html
@@ -1,0 +1,3 @@
+<ol>
+  <li><strong>Glossary entry.</strong><span> Some lead text.<br></span><strong>TAG1</strong><span> – Definition one.<br></span><strong>TAG2</strong><span> – Definition two.<br></span><strong>TAG3</strong><span> – Definition three.</span></li>
+</ol>

--- a/js/tests/unit/html2md-br-in-list-item.test.js
+++ b/js/tests/unit/html2md-br-in-list-item.test.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { convertHtmlToMarkdown } from '../../src/lib.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const HTML = fs.readFileSync(
+  path.join(__dirname, '..', 'fixtures', 'list-item-with-br.html'),
+  'utf8'
+);
+
+it('preserves <br> as a line separator inside list items', () => {
+  const md = convertHtmlToMarkdown(HTML);
+  for (const tag of ['TAG1', 'TAG2', 'TAG3']) {
+    expect(md).toMatch(
+      new RegExp(`(^|\\n)\\s*\\*{0,2}${tag}\\*{0,2}\\s*–`, 'm')
+    );
+  }
+  // Definitions must not be glued on the same line (no <br> dropped).
+  expect(md).not.toMatch(/Definition one\.[ \t]*\*{0,2}TAG2/);
+  expect(md).not.toMatch(/Definition two\.[ \t]*\*{0,2}TAG3/);
+});

--- a/rust/tests/fixtures/list-item-with-br.html
+++ b/rust/tests/fixtures/list-item-with-br.html
@@ -1,0 +1,3 @@
+<ol>
+  <li><strong>Glossary entry.</strong><span> Some lead text.<br></span><strong>TAG1</strong><span> – Definition one.<br></span><strong>TAG2</strong><span> – Definition two.<br></span><strong>TAG3</strong><span> – Definition three.</span></li>
+</ol>

--- a/rust/tests/integration/html2md_br_in_list_item.rs
+++ b/rust/tests/integration/html2md_br_in_list_item.rs
@@ -1,0 +1,24 @@
+use regex::Regex;
+use web_capture::markdown::convert_html_to_markdown;
+
+const HTML: &str = include_str!("../fixtures/list-item-with-br.html");
+
+#[test]
+fn preserves_br_as_line_separator_inside_list_items() {
+    let md = convert_html_to_markdown(HTML, None).unwrap();
+    for tag in ["TAG1", "TAG2", "TAG3"] {
+        let re = Regex::new(&format!(r"(?m)^\s*\*{{0,2}}{tag}\*{{0,2}}\s*–")).unwrap();
+        assert!(
+            re.is_match(&md),
+            "expected `{tag} – …` on its own line; got:\n{md}"
+        );
+    }
+    assert!(
+        !md.contains("Definition one.**TAG2"),
+        "TAG1/TAG2 must not be glued: {md}"
+    );
+    assert!(
+        !md.contains("Definition two.**TAG3"),
+        "TAG2/TAG3 must not be glued: {md}"
+    );
+}

--- a/rust/tests/integration/mod.rs
+++ b/rust/tests/integration/mod.rs
@@ -6,5 +6,6 @@ mod gdocs;
 mod gdocs_image_parity;
 mod gdocs_public_doc;
 mod heading_numbering;
+mod html2md_br_in_list_item;
 mod html2md_ol_numbering;
 mod themed_image;


### PR DESCRIPTION
Fixes #119.

## Summary

The JS `--capture api` (export-html → markdown) path collapsed `<br>`-separated lines inside a list item into a single run, while the other three paths (Rust-API, JS-browser, Rust-browser) handled them correctly. This PR makes all four paths agree.

## Root cause

Turndown's `replacementForNode` calls `content.trim()` on the inner markdown of any inline element whose `flankingWhitespace` is non-empty (`turndown.cjs.js:902`), which strips the trailing `  \n` hard break that the `<br>` rule emits.

The Google Docs export-html commonly produces patterns like:

```html
<strong>TAG1</strong><span> – Definition one.<br></span><strong>TAG2</strong>
```

The `<span>` has leading whitespace, so its inner content is trimmed — and the `<br>`'s hard break disappears with it. Result: `**TAG1** – Definition one.**TAG2**` on a single line.

A second, smaller bug compounded it: `js/src/postprocess.js` collapsed `text  \n` → `text \n`, eating the two trailing spaces that mark a CommonMark hard break.

## Fix

1. **`js/src/lib.js`** — new helper `liftBrFromInlineEdges($)` that hoists any `<br>` sitting at the leading or trailing edge of an inline parent (`span`, `a`, `strong`, `em`, …) out of that parent before Turndown runs. The break then attaches at the parent (block) level, which Turndown handles correctly. Wired into both `convertHtmlToMarkdown` (used by `--capture api`) and `convertHtmlToMarkdownEnhanced`.
2. **`js/src/postprocess.js`** — added negative lookahead `(?!\n)` to the double-space collapse regex so the two trailing spaces of a CommonMark hard break survive postprocessing.

## Tests

New regression tests with a shared fixture (`list-item-with-br.html`) that mirrors the realistic Google Docs export-html structure that triggered the bug:

- `js/tests/unit/html2md-br-in-list-item.test.js` — fails before fix, passes after.
- `rust/tests/integration/html2md_br_in_list_item.rs` — passes (Rust converter never had the bug; this guards parity).

## Test plan

- [x] `cd js && npm test -- tests/unit` — 254/258 pass; the 4 failures are pre-existing `browser.test.js` failures from a missing Playwright Chromium binary in the sandbox, unrelated to this change.
- [x] `cd js && npm test -- tests/unit/html2md-br-in-list-item.test.js tests/unit/html2md.test.js tests/unit/postprocess.test.js tests/unit/gdocs.test.js tests/unit/gdocs-preprocess.test.js tests/unit/html2md-ol-numbering.test.js` — 104/104 pass.
- [x] `cd rust && cargo test` — 92 unit + integration tests pass, 0 failed.
- [x] `cd js && npm run lint` — 0 errors (warnings are all pre-existing).
- [x] `cd js && npx prettier --check` on changed files — all formatted.

## Files changed

- `js/src/lib.js` — `liftBrFromInlineEdges` helper + two call sites.
- `js/src/postprocess.js` — `(?!\n)` lookahead to preserve hard breaks.
- `js/.changeset/issue-119-br-in-list-item.md` — patch changeset.
- `js/tests/fixtures/list-item-with-br.html`, `js/tests/unit/html2md-br-in-list-item.test.js` — JS regression test.
- `rust/tests/fixtures/list-item-with-br.html`, `rust/tests/integration/html2md_br_in_list_item.rs`, `rust/tests/integration/mod.rs` — Rust parity test.
- `experiments/repro-br-*.mjs` — reproduction scripts that pinpointed the bug.