### PR TITLE
Coalesce <br><br> hard-break runs into a paragraph break

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-05-05T21:29:08.064Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-05-05T21:29:08.064Z

--- a/experiments/repro-br-paragraph.mjs
+++ b/experiments/repro-br-paragraph.mjs
@@ -1,0 +1,22 @@
+import { convertHtmlToMarkdown, convertHtmlToMarkdownEnhanced } from '../js/src/lib.js';
+
+const HTML = `<!doctype html>
+<html><body>
+<p>
+  <span>Caption A:</span><br>
+  <img alt="" src="data:image/png;base64,iVBORw0KGgo="><br><br>
+  <span>Caption B:</span><br>
+  <img alt="" src="data:image/png;base64,iVBORw0KGgo=">
+</p>
+</body></html>`;
+
+console.log('=== convertHtmlToMarkdown ===');
+console.log(JSON.stringify(convertHtmlToMarkdown(HTML)));
+console.log('--- raw ---');
+console.log(convertHtmlToMarkdown(HTML));
+
+console.log('\n=== convertHtmlToMarkdownEnhanced ===');
+const { markdown } = convertHtmlToMarkdownEnhanced(HTML);
+console.log(JSON.stringify(markdown));
+console.log('--- raw ---');
+console.log(markdown);

--- a/js/.changeset/issue-121-paragraph-vs-line-break.md
+++ b/js/.changeset/issue-121-paragraph-vs-line-break.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Fix `<br><br>` collapsing into two CommonMark hard breaks (`  \n  \n`) instead of a paragraph break (`\n\n`). Google Docs export-html marks paragraph boundaries with `<br><br>`, which Turndown faithfully emitted as two trailing-two-space-newline pairs. Renderers (GitHub, MkDocs, Pandoc) then joined the surrounding lines into a single `<p>` with a `<br>`, cramming captions against images with no vertical spacing, and the "blank" separator line in the markdown source actually carried trailing whitespace that polluted diffs. Two or more adjacent hard breaks now coalesce to `\n\n` after Turndown runs, restoring true paragraph breaks. Applied in both `convertHtmlToMarkdown` (used by `--capture api`) and `convertHtmlToMarkdownEnhanced`.

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -42,6 +42,7 @@
         "jest": "^29.7.0",
         "jscpd": "^4.0.5",
         "lint-staged": "^16.2.6",
+        "markdown-it": "^14.1.1",
         "nock": "^13.5.4",
         "prettier": "^3.6.2",
         "supertest": "^6.3.4"
@@ -7920,6 +7921,16 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/links-notation": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz",
@@ -8317,6 +8328,31 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/markdown-table": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -8339,6 +8375,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -9510,6 +9553,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10868,6 +10921,13 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
       "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "license": "MIT"
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/undici": {

--- a/js/package.json
+++ b/js/package.json
@@ -62,6 +62,7 @@
     "jest": "^29.7.0",
     "jscpd": "^4.0.5",
     "lint-staged": "^16.2.6",
+    "markdown-it": "^14.1.1",
     "nock": "^13.5.4",
     "prettier": "^3.6.2",
     "supertest": "^6.3.4"

--- a/js/src/lib.js
+++ b/js/src/lib.js
@@ -184,7 +184,19 @@ export function convertHtmlToMarkdown(html, baseUrl) {
   preserveTableCellLineBreaks(turndown);
   // Decode HTML entities to unicode after markdown conversion
   // Preserve non-breaking spaces as &nbsp; entities for clear marking
-  return he.decode(turndown.turndown($.html())).replace(/\u00A0/g, '&nbsp;');
+  return coalesceBrRunsToParagraphBreak(
+    he.decode(turndown.turndown($.html())).replace(/\u00A0/g, '&nbsp;')
+  );
+}
+
+// Coalesce runs of CommonMark hard breaks (`  \n`) into a single paragraph
+// break. Google Docs export wraps every visual line break in `<br>`, including
+// `<br><br>` at paragraph boundaries; Turndown faithfully emits two trailing-
+// two-space-newline pairs for that, which renders as `<br><br>` joined inside
+// one `<p>` instead of two paragraphs. Two or more adjacent hard breaks always
+// mean "paragraph break" in the source HTML, so collapse them to `\n\n`.
+function coalesceBrRunsToParagraphBreak(markdown) {
+  return markdown.replace(/(?: {2,}\n){2,}/g, '\n\n');
 }
 
 // Lift <br> nodes out of inline parents when they sit at the leading or
@@ -764,7 +776,9 @@ export function convertHtmlToMarkdownEnhanced(html, baseUrl, options = {}) {
 
   // Decode HTML entities to unicode after markdown conversion
   // Normalize non-breaking spaces to regular spaces in Markdown text
-  let markdown = he.decode(turndown.turndown($.html())).replace(/\u00A0/g, ' ');
+  let markdown = coalesceBrRunsToParagraphBreak(
+    he.decode(turndown.turndown($.html())).replace(/\u00A0/g, ' ')
+  );
 
   // Apply post-processing
   if (postProcess) {

--- a/js/tests/fixtures/paragraph-vs-line-break.html
+++ b/js/tests/fixtures/paragraph-vs-line-break.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <body>
+    <p>
+      <span>Caption A:</span><br />
+      <img alt="" src="data:image/png;base64,iVBORw0KGgo=" /><br /><br />
+      <span>Caption B:</span><br />
+      <img alt="" src="data:image/png;base64,iVBORw0KGgo=" />
+    </p>
+  </body>
+</html>

--- a/js/tests/unit/paragraph-vs-line-break.test.js
+++ b/js/tests/unit/paragraph-vs-line-break.test.js
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import MarkdownIt from 'markdown-it';
+import {
+  convertHtmlToMarkdown,
+  convertHtmlToMarkdownEnhanced,
+} from '../../src/lib.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const HTML = fs.readFileSync(
+  path.join(__dirname, '..', 'fixtures', 'paragraph-vs-line-break.html'),
+  'utf8'
+);
+
+describe('<br><br> coalesces to a paragraph break (not two hard breaks)', () => {
+  it('renders a paragraph break between Caption A and Caption B (convertHtmlToMarkdown)', () => {
+    const md = convertHtmlToMarkdown(HTML);
+    const lines = md.split('\n');
+    const idxA = lines.findIndex((l) => l.includes('Caption A:'));
+    const idxB = lines.findIndex((l) => l.includes('Caption B:'));
+    expect(idxA).toBeGreaterThanOrEqual(0);
+    expect(idxB).toBeGreaterThan(idxA);
+
+    const between = lines.slice(idxA + 1, idxB);
+    expect(between.some((l) => l === '')).toBe(true);
+
+    expect(md).not.toMatch(/^[ \t]+ {2}$/m);
+  });
+
+  it('renders a paragraph break between Caption A and Caption B (convertHtmlToMarkdownEnhanced)', () => {
+    const { markdown } = convertHtmlToMarkdownEnhanced(HTML);
+    const lines = markdown.split('\n');
+    const idxA = lines.findIndex((l) => l.includes('Caption A:'));
+    const idxB = lines.findIndex((l) => l.includes('Caption B:'));
+    expect(idxA).toBeGreaterThanOrEqual(0);
+    expect(idxB).toBeGreaterThan(idxA);
+
+    const between = lines.slice(idxA + 1, idxB);
+    expect(between.some((l) => l === '')).toBe(true);
+
+    expect(markdown).not.toMatch(/^[ \t]+ {2}$/m);
+  });
+
+  it('CommonMark renders Caption A and Caption B as separate paragraphs', () => {
+    const md = convertHtmlToMarkdown(HTML);
+    const html = new MarkdownIt('commonmark').render(md);
+    const aIdx = html.indexOf('Caption A:');
+    const bIdx = html.indexOf('Caption B:');
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(bIdx).toBeGreaterThan(aIdx);
+    const between = html.slice(aIdx, bIdx);
+    expect(between).toMatch(/<\/p>\s*<p>/);
+  });
+});

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -2739,7 +2739,7 @@ enquirer@^2.4.1:
     ansi-colors "^4.1.1"
     strip-ansi "^6.0.1"
 
-entities@^4.2.0, entities@^4.5.0:
+entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -4288,6 +4288,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz"
+  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+  dependencies:
+    uc.micro "^2.0.0"
+
 links-notation@^0.11.2:
   version "0.11.2"
   resolved "https://registry.npmjs.org/links-notation/-/links-notation-0.11.2.tgz"
@@ -4416,6 +4423,18 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+markdown-it@^14.1.1:
+  version "14.1.1"
+  resolved "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz"
+  integrity sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.4.0"
+    linkify-it "^5.0.0"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.1.0"
+
 markdown-table@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz"
@@ -4427,6 +4446,11 @@ math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -5097,6 +5121,11 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -5880,6 +5909,11 @@ typed-query-selector@^2.12.0, typed-query-selector@^2.12.1:
   version "2.12.1"
   resolved "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz"
   integrity sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==
+
+uc.micro@^2.0.0, uc.micro@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 undici-types@~7.18.0:
   version "7.18.2"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "web-capture"
-version = "0.3.12"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/rust/tests/fixtures/paragraph-vs-line-break.html
+++ b/rust/tests/fixtures/paragraph-vs-line-break.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <body>
+    <p>
+      <span>Caption A:</span><br />
+      <img alt="" src="data:image/png;base64,iVBORw0KGgo=" /><br /><br />
+      <span>Caption B:</span><br />
+      <img alt="" src="data:image/png;base64,iVBORw0KGgo=" />
+    </p>
+  </body>
+</html>

--- a/rust/tests/integration/mod.rs
+++ b/rust/tests/integration/mod.rs
@@ -8,4 +8,5 @@ mod gdocs_public_doc;
 mod heading_numbering;
 mod html2md_br_in_list_item;
 mod html2md_ol_numbering;
+mod paragraph_vs_line_break;
 mod themed_image;

--- a/rust/tests/integration/paragraph_vs_line_break.rs
+++ b/rust/tests/integration/paragraph_vs_line_break.rs
@@ -1,0 +1,35 @@
+use web_capture::markdown::convert_html_to_markdown;
+
+const HTML: &str = include_str!("../fixtures/paragraph-vs-line-break.html");
+
+#[test]
+fn double_br_becomes_paragraph_break_not_two_hard_breaks() {
+    let md = convert_html_to_markdown(HTML, None).unwrap();
+    let lines: Vec<&str> = md.lines().collect();
+    let idx_a = lines
+        .iter()
+        .position(|l| l.contains("Caption A:"))
+        .unwrap_or_else(|| panic!("Caption A: missing in output:\n{md}"));
+    let idx_b = lines
+        .iter()
+        .position(|l| l.contains("Caption B:"))
+        .unwrap_or_else(|| panic!("Caption B: missing in output:\n{md}"));
+    let between = &lines[idx_a + 1..idx_b];
+    assert!(
+        between.iter().any(|l| l.is_empty()),
+        "expected at least one truly empty line between Caption A and Caption B; got:\n{md}"
+    );
+}
+
+#[test]
+fn no_blank_looking_line_carries_trailing_whitespace() {
+    let md = convert_html_to_markdown(HTML, None).unwrap();
+    let bad: Vec<&str> = md
+        .lines()
+        .filter(|l| !l.is_empty() && l.trim().is_empty())
+        .collect();
+    assert!(
+        bad.is_empty(),
+        "lines that look blank must actually be blank; offenders: {bad:?}"
+    );
+}


### PR DESCRIPTION
Fixes #121.

## Summary

JS `--capture api` (export-html → markdown) emitted trailing two-space CommonMark hard breaks (`  \n`) on lines that should end paragraphs. Two adjacent hard breaks in the markdown source render as `<br><br>` inside a single `<p>` (GitHub, MkDocs, Pandoc), cramming captions against images with no vertical spacing — and the "blank" separator line actually carries trailing whitespace, polluting diffs.

## Root cause

Google Docs export-html wraps every visual line break in `<br>`, including `<br><br>` at paragraph boundaries:

```html
<p>
  Caption A:<br>
  <img …><br><br>
  Caption B:<br>
  <img …>
</p>
```

Turndown faithfully emits one trailing-two-space-newline pair for each `<br>`, producing `  \n  \n` between the two captions. CommonMark says two or more adjacent hard breaks still belong to one paragraph, so renderers cram both captions into a single `<p>`. The Rust `html2md` crate already coalesces consecutive `<br>`s correctly, so this is a JS-only bug.

## Fix

After Turndown runs, collapse runs of two or more adjacent hard breaks to `\n\n`:

```js
function coalesceBrRunsToParagraphBreak(markdown) {
  return markdown.replace(/(?: {2,}\n){2,}/g, '\n\n');
}
```

Applied in both `convertHtmlToMarkdown` (used by `--capture api`) and `convertHtmlToMarkdownEnhanced`. The regex tolerates any post-processing that might leave 2+ trailing spaces on a hard break.

## Tests

New regression tests with a shared fixture (`paragraph-vs-line-break.html`) modelled on the issue's spec — two captions separated by `<br><br>` inside a single `<p>`:

- `js/tests/unit/paragraph-vs-line-break.test.js` — verifies both `convertHtmlToMarkdown` and `convertHtmlToMarkdownEnhanced` produce a truly empty separator line (no trailing whitespace) and that markdown-it CommonMark renders the two captions as separate `<p>`s.
- `rust/tests/integration/paragraph_vs_line_break.rs` — same checks as a parity guard (Rust converter never had the bug).

## Test plan

- [x] `cd js && npm test -- tests/unit` — 257/261 pass; the 4 failures are pre-existing `browser.test.js` failures from a missing Playwright Chromium binary in the sandbox, unrelated to this change.
- [x] `cd js && npm test -- tests/unit/paragraph-vs-line-break.test.js tests/unit/html2md.test.js tests/unit/postprocess.test.js tests/unit/gdocs.test.js tests/unit/html2md-br-in-list-item.test.js` — all pass.
- [x] `cd rust && cargo test` — 92 unit + 96 integration tests pass, 0 failed.
- [x] `cd js && npm run lint` — 0 errors.
- [x] `cd js && npx prettier --check` on changed files — all formatted.
- [x] `cd rust && cargo clippy --all-targets -- -D warnings` — clean.

## Files changed

- `js/src/lib.js` — `coalesceBrRunsToParagraphBreak` helper + two call sites.
- `js/.changeset/issue-121-paragraph-vs-line-break.md` — patch changeset.
- `js/tests/fixtures/paragraph-vs-line-break.html`, `js/tests/unit/paragraph-vs-line-break.test.js` — JS regression test (uses `markdown-it` to verify CommonMark rendering).
- `js/package.json`, `js/package-lock.json`, `js/yarn.lock` — add `markdown-it` as a dev dependency.
- `rust/tests/fixtures/paragraph-vs-line-break.html`, `rust/tests/integration/paragraph_vs_line_break.rs`, `rust/tests/integration/mod.rs` — Rust parity test.
- `rust/Cargo.lock` — sync to 0.3.14 (main bumped Cargo.toml without lockfile update).
- `experiments/repro-br-paragraph.mjs` — reproduction script that pinpointed the bug.