### PR TITLE
Coalesce bold runs and close them at block boundaries

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,2 @@
+# .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
+# Updated: 2026-04-14T15:38:45.969Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
 # Updated: 2026-04-14T15:38:45.969Z
+# Updated: 2026-05-06T07:09:32.134Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-06T22:55:07.509Z for PR creation at branch issue-31-e38e38b91777 for issue https://github.com/link-assistant/web-capture/issues/31
-# Updated: 2026-04-14T15:38:45.969Z
-# Updated: 2026-05-06T07:09:32.134Z

--- a/js/.changeset/issue-120-bold-coalesce-and-leakage.md
+++ b/js/.changeset/issue-120-bold-coalesce-and-leakage.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Fix structurally broken bold markup in `--capture api` output. Adjacent `<span style="font-weight:700">` siblings that the Google Docs export emits for headings, list items, and notes used to be wrapped in independent `<strong>...</strong>` pairs, producing split runs (`**13.1** **First subsection**`), stray `****` between adjacent bold blocks, and bold ranges that leaked across `<br>`/`<img>` boundaries (`**Caption A:![](images/x.png)Caption B:**`). The Google Docs preprocessor now closes `<strong>` runs at `<br>`/`<img>` boundaries, splits the wrapping `<p>` into separate paragraphs at those boundaries, drops empty `<strong></strong>` pairs, and coalesces adjacent bold siblings into a single run. Renderers can now interpret the output as valid CommonMark again.

--- a/js/src/gdocs-preprocess.js
+++ b/js/src/gdocs-preprocess.js
@@ -62,6 +62,11 @@ export function preprocessGoogleDocsExportHtml(html) {
     hoisted += 1;
   });
 
+  splitStrongAtBlockBoundaries($);
+  splitParagraphsAtBoldBoundaries($);
+  removeEmptyStrong($);
+  coalesceAdjacentStrong($);
+
   groupGoogleDocsBlockquotes($, classStyles);
   nestGoogleDocsLists($, classStyles);
   normalizeGoogleDocsTables($);
@@ -142,6 +147,172 @@ export function normalizeGoogleDocsExportMarkdown(markdown) {
     .replace(/(^|[^\w~])~([^~\n]+)~(?=$|[^\w~])/g, '$1~~$2~~')
     .replace(/\n{3,}(?=> )/g, '\n\n')
     .replace(/\n{3,}/g, '\n\n');
+}
+
+// Issue #120: a `<strong>` whose closing tag would land in a different block
+// boundary leaks bolding across paragraphs and images. Split such a strong
+// into multiple bold runs that each stop at the boundary.
+function splitStrongAtBlockBoundaries($) {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const offenders = $('strong').filter(function () {
+      return $(this).find('br, img, p, div, li').length > 0;
+    });
+    if (!offenders.length) {
+      break;
+    }
+    offenders.each(function () {
+      const $strong = $(this);
+      const segments = [];
+      let current = [];
+      const flush = () => {
+        if (current.length) {
+          segments.push({ type: 'inline', nodes: current });
+          current = [];
+        }
+      };
+      $strong.contents().each(function () {
+        if (this.type === 'tag' && this.tagName === 'br') {
+          flush();
+          segments.push({ type: 'br' });
+        } else if (this.type === 'tag' && this.tagName === 'img') {
+          flush();
+          segments.push({ type: 'img', node: this });
+        } else if (
+          this.type === 'tag' &&
+          ['p', 'div', 'li'].includes(this.tagName)
+        ) {
+          flush();
+          segments.push({ type: 'block', node: this });
+        } else {
+          current.push(this);
+        }
+      });
+      flush();
+
+      const pieces = segments.map((segment) => {
+        if (segment.type === 'br') {
+          return '<br>';
+        }
+        if (segment.type === 'img') {
+          return $.html(segment.node);
+        }
+        if (segment.type === 'block') {
+          const inner = $(segment.node).html() || '';
+          const tag = segment.node.tagName;
+          const innerWrapped = inner.trim() ? `<strong>${inner}</strong>` : '';
+          return `<${tag}>${innerWrapped}</${tag}>`;
+        }
+        const inner = segment.nodes.map((node) => $.html(node)).join('');
+        if (!inner.trim()) {
+          return inner;
+        }
+        return `<strong>${inner}</strong>`;
+      });
+      $strong.replaceWith(pieces.join(''));
+      changed = true;
+    });
+  }
+}
+
+// Issue #120: when a `<p>` contains a `<br>` adjacent to a `<strong>` or an
+// `<img>`, split it into multiple paragraphs so each bold run and image
+// becomes its own block. Without this, the markdown converter renders
+// `**Caption**  \n![](x)` (inline) instead of separate blocks.
+function splitParagraphsAtBoldBoundaries($) {
+  $('p').each(function () {
+    const $p = $(this);
+    const contents = $p.contents().toArray();
+    if (!contents.some((n) => n.type === 'tag' && n.tagName === 'br')) {
+      return;
+    }
+    const hasStrongOrImg = contents.some(
+      (n) => n.type === 'tag' && (n.tagName === 'strong' || n.tagName === 'img')
+    );
+    if (!hasStrongOrImg) {
+      return;
+    }
+    const segments = [];
+    let current = [];
+    const flush = () => {
+      const html = current
+        .map((node) => $.html(node))
+        .join('')
+        .trim();
+      if (html) {
+        segments.push(html);
+      }
+      current = [];
+    };
+    for (const node of contents) {
+      if (node.type === 'tag' && node.tagName === 'br') {
+        flush();
+      } else if (node.type === 'tag' && node.tagName === 'img') {
+        flush();
+        segments.push($.html(node));
+      } else {
+        current.push(node);
+      }
+    }
+    flush();
+    if (segments.length <= 1) {
+      return;
+    }
+    const replacement = segments.map((html) => `<p>${html}</p>`).join('');
+    $p.replaceWith(replacement);
+  });
+}
+
+// Issue #120: drop empty `<strong></strong>` so they cannot pair with a
+// neighbour and emit `****`.
+function removeEmptyStrong($) {
+  $('strong').each(function () {
+    const $strong = $(this);
+    if (!$strong.html() || !$strong.text().trim()) {
+      if (!$strong.find('img').length) {
+        $strong.remove();
+      }
+    }
+  });
+}
+
+// Issue #120: merge adjacent `<strong>` siblings (optionally separated by
+// whitespace text nodes) into a single `<strong>` so the converter emits
+// `**a b**` instead of `**a** **b**`.
+function coalesceAdjacentStrong($) {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    $('strong').each(function () {
+      const $strong = $(this);
+      if (!$strong.parent().length) {
+        return;
+      }
+      let sibling = this.next;
+      const between = [];
+      while (sibling) {
+        if (sibling.type === 'text' && /^\s*$/.test(sibling.data || '')) {
+          between.push(sibling);
+          sibling = sibling.next;
+          continue;
+        }
+        if (sibling.type === 'tag' && sibling.tagName === 'strong') {
+          const innerSelf = $strong.html() || '';
+          const innerNext = $(sibling).html() || '';
+          const joiner = between.map((node) => node.data || '').join('');
+          $strong.html(`${innerSelf}${joiner}${innerNext}`);
+          for (const node of between) {
+            $(node).remove();
+          }
+          $(sibling).remove();
+          changed = true;
+          return;
+        }
+        break;
+      }
+    });
+  }
 }
 
 function parseCssClassStyles($) {

--- a/js/tests/fixtures/bold-coalesce-and-leakage.html
+++ b/js/tests/fixtures/bold-coalesce-and-leakage.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <body>
+    <!-- Symptom A: two adjacent bold spans -->
+    <p>
+      <span style="font-weight: 700">13.1 </span
+      ><span style="font-weight: 700">First subsection</span>
+    </p>
+
+    <!-- Symptom B: outer bold ends, inner bold begins, no separator -->
+    <ol>
+      <li><span style="font-weight: 700">Item header.</span></li>
+    </ol>
+    <p><span style="font-weight: 700">Note:</span> body text.</p>
+
+    <!-- Symptom C: bold range spans across <br> and <img> -->
+    <p>
+      <span style="font-weight: 700"
+        >Caption A:<img
+          alt=""
+          src="data:image/png;base64,iVBORw0KGgo=" /><br />Caption B:<img
+          alt=""
+          src="data:image/png;base64,iVBORw0KGgo="
+      /></span>
+    </p>
+  </body>
+</html>

--- a/js/tests/unit/bold-coalesce-and-leakage.test.js
+++ b/js/tests/unit/bold-coalesce-and-leakage.test.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  normalizeGoogleDocsExportMarkdown,
+  preprocessGoogleDocsExportHtml,
+} from '../../src/gdocs.js';
+import { convertHtmlToMarkdown } from '../../src/lib.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const HTML = fs.readFileSync(
+  path.join(__dirname, '..', 'fixtures', 'bold-coalesce-and-leakage.html'),
+  'utf8'
+);
+
+describe('bold-run coalescing and block boundary handling (issue #120)', () => {
+  let md;
+  beforeAll(() => {
+    const preprocessed = preprocessGoogleDocsExportHtml(HTML);
+    md = normalizeGoogleDocsExportMarkdown(
+      convertHtmlToMarkdown(preprocessed.html)
+    );
+  });
+
+  it('A: coalesces adjacent bold spans into a single bold run', () => {
+    expect(md).toMatch(/\*\*13\.1 First subsection\*\*/);
+    expect(md).not.toMatch(/\*\*13\.1\*\*\s+\*\*First subsection\*\*/);
+  });
+
+  it('B: never emits an empty "****" pair between adjacent bold runs', () => {
+    expect(md).not.toMatch(/\*{4}/);
+  });
+
+  it('C: closes bold at block-level boundaries (<br>, <img>)', () => {
+    // No single bold run may contain an image. CommonMark bold cannot span
+    // a blank line (`\n\n`), so the inner content is restricted accordingly.
+    const strongRe = /\*\*((?:(?!\*\*|\n\n)[\s\S])+?)\*\*/g;
+    const imageRe = /!\[[^\]]*\]\([^)]+\)/;
+    for (const match of md.matchAll(strongRe)) {
+      expect(imageRe.test(match[1])).toBe(false);
+    }
+    expect(md).toMatch(/\*\*Caption A:\*\*/);
+    expect(md).toMatch(/\*\*Caption B:\*\*/);
+  });
+
+  it('D: every "**" opener has a matching closer (balanced asterisks)', () => {
+    const stripped = md
+      .replace(/`[^`]*`/g, '')
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '');
+    const count = (stripped.match(/\*\*/g) || []).length;
+    expect(count % 2).toBe(0);
+  });
+});

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "web-capture"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/rust/src/gdocs.rs
+++ b/rust/src/gdocs.rs
@@ -626,6 +626,10 @@ pub fn preprocess_google_docs_export_html(html: &str) -> GDocsExportPreprocessRe
 
     let mut out = hoist_inline_style_spans(html, &mut hoisted);
     out = hoist_class_style_spans(&out, &class_styles, &mut hoisted);
+    out = split_strong_at_block_boundaries(&out);
+    out = split_paragraphs_at_bold_boundaries(&out);
+    out = remove_empty_strong(&out);
+    out = coalesce_adjacent_strong(&out);
     out = convert_class_indented_blockquotes(&out, &class_styles);
     out = nest_google_docs_lists(&out, &class_styles);
     out = strip_google_docs_heading_noise(&out);
@@ -693,6 +697,151 @@ fn hoist_class_style_spans(
             )
         })
         .into_owned()
+}
+
+// Issue #120: a `<strong>` whose closing tag would land on the far side of a
+// `<br>`/`<img>` boundary leaks bold across an image or paragraph break.
+// Split such a strong so each piece on either side of the boundary becomes
+// its own bold run.
+fn split_strong_at_block_boundaries(html: &str) -> String {
+    let strong_re = Regex::new(r"(?is)<strong>(.*?)</strong>").expect("valid regex");
+    let boundary_re = Regex::new(r"(?is)<br\s*/?>|<img\b[^>]*/?>").expect("valid regex");
+
+    let mut current = html.to_string();
+    loop {
+        let mut changed = false;
+        let next = strong_re
+            .replace_all(&current, |caps: &regex::Captures<'_>| {
+                let inner = caps.get(1).map_or("", |m| m.as_str());
+                if !boundary_re.is_match(inner) {
+                    return caps[0].to_string();
+                }
+                changed = true;
+                let mut result = String::new();
+                let mut last_end = 0usize;
+                for boundary in boundary_re.find_iter(inner) {
+                    let chunk = &inner[last_end..boundary.start()];
+                    if chunk.trim().is_empty() {
+                        result.push_str(chunk);
+                    } else {
+                        result.push_str("<strong>");
+                        result.push_str(chunk);
+                        result.push_str("</strong>");
+                    }
+                    result.push_str(boundary.as_str());
+                    last_end = boundary.end();
+                }
+                let tail = &inner[last_end..];
+                if tail.trim().is_empty() {
+                    result.push_str(tail);
+                } else {
+                    result.push_str("<strong>");
+                    result.push_str(tail);
+                    result.push_str("</strong>");
+                }
+                result
+            })
+            .into_owned();
+        current = next;
+        if !changed {
+            break;
+        }
+    }
+    current
+}
+
+// Issue #120: when a `<p>` contains a `<br>` adjacent to a `<strong>` or
+// `<img>`, split the paragraph at those boundaries so the markdown converter
+// emits separate blocks (`**Caption**\n\n![](x)`) instead of an inline soft
+// break that keeps them on the same line.
+fn split_paragraphs_at_bold_boundaries(html: &str) -> String {
+    let p_re = Regex::new(r"(?is)<p\b([^>]*)>(.*?)</p>").expect("valid regex");
+    let br_re = Regex::new(r"(?is)<br\s*/?>").expect("valid regex");
+    let img_re = Regex::new(r"(?is)<img\b[^>]*/?>").expect("valid regex");
+    let strong_or_img_re = Regex::new(r"(?is)<strong>|<img\b").expect("valid regex");
+
+    p_re.replace_all(html, |caps: &regex::Captures<'_>| {
+        let attrs = caps.get(1).map_or("", |m| m.as_str());
+        let inner = caps.get(2).map_or("", |m| m.as_str());
+        if !br_re.is_match(inner) {
+            return caps[0].to_string();
+        }
+        if !strong_or_img_re.is_match(inner) {
+            return caps[0].to_string();
+        }
+
+        let mut segments: Vec<String> = Vec::new();
+        let mut current = String::new();
+        let mut idx = 0usize;
+        while idx < inner.len() {
+            if let Some(br) = br_re.find_at(inner, idx) {
+                if br.start() == idx {
+                    flush_paragraph_segment(&mut segments, &mut current);
+                    idx = br.end();
+                    continue;
+                }
+            }
+            if let Some(img) = img_re.find_at(inner, idx) {
+                if img.start() == idx {
+                    flush_paragraph_segment(&mut segments, &mut current);
+                    segments.push(img.as_str().to_string());
+                    idx = img.end();
+                    continue;
+                }
+            }
+            // Find the next boundary.
+            let next_br = br_re.find_at(inner, idx).map(|m| m.start());
+            let next_img = img_re.find_at(inner, idx).map(|m| m.start());
+            let next = match (next_br, next_img) {
+                (Some(a), Some(b)) => a.min(b),
+                (Some(a), None) | (None, Some(a)) => a,
+                (None, None) => inner.len(),
+            };
+            current.push_str(&inner[idx..next]);
+            idx = next;
+        }
+        flush_paragraph_segment(&mut segments, &mut current);
+
+        if segments.len() <= 1 {
+            return caps[0].to_string();
+        }
+        let mut out = String::new();
+        for segment in &segments {
+            let _ = write!(out, "<p{attrs}>{segment}</p>");
+        }
+        out
+    })
+    .into_owned()
+}
+
+fn flush_paragraph_segment(segments: &mut Vec<String>, current: &mut String) {
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        segments.push(current.clone());
+    }
+    current.clear();
+}
+
+// Issue #120: drop empty `<strong></strong>` so they cannot pair with a
+// neighbour and emit `****`.
+fn remove_empty_strong(html: &str) -> String {
+    let empty_re = Regex::new(r"(?is)<strong>\s*</strong>").expect("valid regex");
+    empty_re.replace_all(html, "").into_owned()
+}
+
+// Issue #120: merge adjacent `<strong>` siblings (optionally separated by
+// whitespace) into a single bold run so the converter emits `**a b**`
+// instead of `**a** **b**`.
+fn coalesce_adjacent_strong(html: &str) -> String {
+    let adjacent_re = Regex::new(r"(?is)</strong>(\s*)<strong>").expect("valid regex");
+    let mut current = html.to_string();
+    loop {
+        let next = adjacent_re.replace_all(&current, "$1").into_owned();
+        if next == current {
+            return next;
+        }
+        current = next;
+    }
 }
 
 fn convert_class_indented_blockquotes(

--- a/rust/tests/fixtures/bold-coalesce-and-leakage.html
+++ b/rust/tests/fixtures/bold-coalesce-and-leakage.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <body>
+    <!-- Symptom A: two adjacent bold spans -->
+    <p>
+      <span style="font-weight:700">13.1 </span
+      ><span style="font-weight:700">First subsection</span>
+    </p>
+
+    <!-- Symptom B: outer bold ends, inner bold begins, no separator -->
+    <ol>
+      <li><span style="font-weight:700">Item header.</span></li>
+    </ol>
+    <p>
+      <span style="font-weight:700">Note:</span> body text.
+    </p>
+
+    <!-- Symptom C: bold range spans across <br> and <img> -->
+    <p>
+      <span style="font-weight:700"
+        >Caption A:<img alt="" src="data:image/png;base64,iVBORw0KGgo=" /><br />Caption
+        B:<img alt="" src="data:image/png;base64,iVBORw0KGgo=" /></span>
+    </p>
+  </body>
+</html>

--- a/rust/tests/integration/bold_coalesce_and_leakage.rs
+++ b/rust/tests/integration/bold_coalesce_and_leakage.rs
@@ -1,0 +1,79 @@
+use regex::Regex;
+use web_capture::gdocs::{
+    normalize_google_docs_export_markdown, preprocess_google_docs_export_html,
+};
+use web_capture::markdown::convert_html_to_markdown;
+
+const HTML: &str = include_str!("../fixtures/bold-coalesce-and-leakage.html");
+
+fn render() -> String {
+    let preprocessed = preprocess_google_docs_export_html(HTML);
+    let converted =
+        convert_html_to_markdown(&preprocessed.html, None).expect("html->md conversion succeeds");
+    normalize_google_docs_export_markdown(&converted)
+}
+
+#[test]
+fn coalesces_adjacent_bold_spans() {
+    let md = render();
+    assert!(
+        md.contains("**13.1 First subsection**"),
+        "expected single bold run; got:\n{md}"
+    );
+    assert!(
+        !Regex::new(r"\*\*13\.1\*\*\s+\*\*First subsection\*\*")
+            .unwrap()
+            .is_match(&md),
+        "must NOT split into two bold runs; got:\n{md}"
+    );
+}
+
+#[test]
+fn never_emits_quad_asterisk() {
+    let md = render();
+    assert!(
+        !md.contains("****"),
+        "must not emit '****' (empty bold pair); got:\n{md}"
+    );
+}
+
+#[test]
+fn closes_bold_at_block_boundaries() {
+    let md = render();
+    // No single bold run may contain an image. CommonMark bold cannot span
+    // a blank line (`\n\n`), so the inner content is restricted accordingly.
+    // `regex` lacks lookahead, so check structurally: a candidate `**...**`
+    // run violates the rule iff the inner span contains an image and no
+    // intervening blank line.
+    let strong_re = Regex::new(r"\*\*((?:[^*]|\*(?:[^*]|$))*?)\*\*").unwrap();
+    let image_re = Regex::new(r"!\[[^\]]*\]\([^)]+\)").unwrap();
+    for caps in strong_re.captures_iter(&md) {
+        let inner = caps.get(1).map_or("", |m| m.as_str());
+        assert!(
+            !image_re.is_match(inner) || inner.contains("\n\n"),
+            "no bold run may contain an image; got:\n{md}"
+        );
+    }
+    assert!(
+        md.contains("**Caption A:**"),
+        "Caption A must remain bold; got:\n{md}"
+    );
+    assert!(
+        md.contains("**Caption B:**"),
+        "Caption B must remain bold; got:\n{md}"
+    );
+}
+
+#[test]
+fn balanced_double_asterisks() {
+    let md = render();
+    let stripped = Regex::new(r"`[^`]*`|!\[[^\]]*\]\([^)]*\)")
+        .unwrap()
+        .replace_all(&md, "");
+    let count = stripped.matches("**").count();
+    assert_eq!(
+        count % 2,
+        0,
+        "expected even count of `**`; got {count} in:\n{md}"
+    );
+}

--- a/rust/tests/integration/mod.rs
+++ b/rust/tests/integration/mod.rs
@@ -1,5 +1,6 @@
 mod animation;
 mod batch;
+mod bold_coalesce_and_leakage;
 mod browser;
 mod figures;
 mod gdocs;


### PR DESCRIPTION
Fixes #120.

## Summary

`--capture api` (Google Docs export-html → markdown) was emitting structurally broken bold markup. The Google Docs export wraps every styled fragment in its own `<span style="font-weight:700">`, so for the input `<span style="font-weight:700">13.1 </span><span style="font-weight:700">First subsection</span>` the preprocessor produced two independent `<strong>` pairs:

```html
<strong>13.1 </strong> <strong>First subsection</strong>
```

…which Turndown / `html2md` rendered as the two-run sequence `**13.1** **First subsection**`, and neighbouring runs collapsed into stray `****` openers. The same per-span wrapping let bold ranges leak across `<br>` and `<img>` boundaries, producing the unparseable `**Caption A:![](image)Caption B:**`.

The four symptoms from the issue:

- A — `**13.1** **First subsection**` instead of `**13.1 First subsection**`
- B — empty `****` pair between two adjacent bold blocks
- C — bold range spans `<br>`/`<img>`, e.g. `**Caption A:<img>Caption B:**`
- D — `**` opens on its own line / sentence

## Root cause

`hoistInlineStyleSpans` (JS) and `hoist_inline_style_spans` (Rust) wrap each `<span style="font-weight:700">` independently in a fresh `<strong>...</strong>` pair. After hoisting, no pass merges sibling bold runs, removes empty bold pairs, or refuses to keep a bold range open across a block-level boundary. Whatever the export emitted was passed straight to the converter.

## Fix

Both `preprocessGoogleDocsExportHtml` (JS) and `preprocess_google_docs_export_html` (Rust) now run a four-stage cleanup pass after the existing span hoist, before the converter sees the HTML:

1. **`splitStrongAtBlockBoundaries`** — walk every `<strong>`'s contents; whenever a `<br>`, `<img>`, or block-level descendant is encountered, close the current bold run and open a fresh one for the next segment. The boundary node sits between segments rather than inside a bold range.
2. **`splitParagraphsAtBoldBoundaries`** — split the wrapping `<p>` at `<br>` and promote each `<img>` into its own paragraph so CommonMark sees real paragraph breaks (a bold span cannot legally cross `\n\n`).
3. **`removeEmptyStrong`** — drop `<strong></strong>` pairs left over after whitespace-only spans, so they cannot pair with a neighbour and produce `****`.
4. **`coalesceAdjacentStrong`** — merge sibling `<strong>` runs that are separated only by whitespace into a single run, run to fixpoint so chains of three or more siblings collapse.

The result for the issue's Caption A/B example:

```
**Caption A:**

![](data:image/png;base64,...)

**Caption B:**

![](data:image/png;base64,...)
```

— matching the issue's "Wanted" output exactly.

## Tests

New shared HTML fixture covering all three structural symptoms (A, B, C) plus a balance check (D):

- `js/tests/fixtures/bold-coalesce-and-leakage.html` + `js/tests/unit/bold-coalesce-and-leakage.test.js`
- `rust/tests/fixtures/bold-coalesce-and-leakage.html` + `rust/tests/integration/bold_coalesce_and_leakage.rs`

Test C uses a structural check (iterate `**...**` runs, assert none contains an `![](...)` image without an intervening blank line) rather than the issue's literal regex, because CommonMark already prevents a bold span from crossing `\n\n` and the literal regex over-matched the closer of one run + opener of the next when an image sat between them.

## Test plan

- [x] `cd js && node --experimental-vm-modules ./node_modules/.bin/jest tests/unit/bold-coalesce-and-leakage.test.js` — 4/4 pass.
- [x] `cd js && node --experimental-vm-modules ./node_modules/.bin/jest --testPathIgnorePatterns="browser|render-fidelity"` — 300 pass; 5 fail in `tests/e2e/docker.test.js` because `docker` is not installed in the sandbox (pre-existing env limitation, no regression).
- [x] `cd rust && cargo test` — 100 integration + 92 unit + 2 doc + 2 binary tests pass, 0 failed.
- [x] `cd js && npx prettier --check src/gdocs-preprocess.js tests/unit/bold-coalesce-and-leakage.test.js tests/fixtures/bold-coalesce-and-leakage.html .changeset/issue-120-bold-coalesce-and-leakage.md` — all formatted.
- [x] `cd js && npm run lint` — 0 errors (warnings unchanged from `main`).
- [x] `cd rust && cargo fmt --check` — clean.
- [x] `cd rust && cargo clippy --all-targets -- -D warnings` — clean.

## Files changed

- `js/src/gdocs-preprocess.js` — pipeline calls + four cheerio-based helpers (`splitStrongAtBlockBoundaries`, `splitParagraphsAtBoldBoundaries`, `removeEmptyStrong`, `coalesceAdjacentStrong`).
- `rust/src/gdocs.rs` — pipeline calls + four regex-based helpers (`split_strong_at_block_boundaries`, `split_paragraphs_at_bold_boundaries`, `remove_empty_strong`, `coalesce_adjacent_strong`) mirroring the JS behaviour.
- `js/.changeset/issue-120-bold-coalesce-and-leakage.md` — patch-level changeset.
- Tests + fixtures listed above.
- `rust/tests/integration/mod.rs` — register the new module.
- `rust/Cargo.lock` — sync to the existing `0.3.15` `Cargo.toml` version.