### PR TITLE
docs: add FormalAI capture contract

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,30 @@
+name: JS/Rust Parity
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+
+jobs:
+  source-test-parity:
+    name: JS/Rust Source and Test Parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.x"
+
+      - name: Check JS/Rust parity
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-js-rust-parity.mjs

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-12T10:32:38.542Z for PR creation at branch issue-135-fcb428bcce44 for issue https://github.com/link-assistant/web-capture/issues/135

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-12T10:32:38.542Z for PR creation at branch issue-135-fcb428bcce44 for issue https://github.com/link-assistant/web-capture/issues/135

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Both implementations expose the same API:
 | `GET /stream?url=<URL>`                                   | Stream content                                                                                                 |
 | `GET /search?q=<QUERY>`                                   | Capture structured search-provider results                                                                     |
 
+FormalAI integration should use the stable HTTP/CLI contract documented in
+[`docs/formalai-contract.md`](docs/formalai-contract.md).
+
 ## CLI Usage
 
 ```bash

--- a/docs/formalai-contract.md
+++ b/docs/formalai-contract.md
@@ -190,7 +190,12 @@ The contract is covered by smoke tests in:
 
 - `js/tests/integration/formalai-contract.test.js`
 - `js/tests/unit/cli.test.js`
+- `rust/tests/integration/formalai_contract.rs`
 
 These tests assert the stable HTTP content types, binary signatures, ZIP
 contents, search JSON diagnostics, provider allow-list, and CLI output shapes
 that FormalAI should depend on.
+
+The `JS/Rust Parity` CI workflow runs `scripts/check-js-rust-parity.mjs` on pull
+requests. It fails when `js/src` or `js/tests` changes without a corresponding
+`rust/src` or `rust/tests` change, and also fails for the reverse direction.

--- a/docs/formalai-contract.md
+++ b/docs/formalai-contract.md
@@ -1,0 +1,196 @@
+# FormalAI Web Capture Contract
+
+This document defines the stable HTTP and CLI surface that FormalAI can depend
+on when using `web-capture` as an optional capture/search component.
+
+The contract covers the shared endpoints requested in issue 135:
+
+- `GET /fetch`
+- `GET /html`
+- `GET /txt`
+- `GET /markdown`
+- `GET /image`
+- `GET /archive`
+- `GET /stream`
+- `GET /search`
+
+The JavaScript package is published as `@link-assistant/web-capture`. The Rust
+crate is published as `web-capture`, but the Rust crate currently declares
+`rust-version = "1.88"`. On June 12, 2026 the maintainer clarified that this
+project should use the latest stable Rust. FormalAI currently declaring Rust
+1.70 should integrate through the CLI or HTTP service unless FormalAI raises
+its Rust toolchain or this project explicitly introduces a lower-MSRV library
+target later.
+
+## Contract Rules
+
+Capture endpoints return the requested artifact directly. They do not wrap
+successful `/html`, `/txt`, `/markdown`, `/image`, `/archive`, `/fetch`, or
+`/stream` responses in JSON because consumers need the raw text or bytes.
+
+The structured response exceptions are:
+
+- `/search`, which returns normalized JSON by default.
+- `/markdown?converter=kreuzberg&format=json`, which returns the structured
+  converter output.
+
+For reproducible FormalAI integration:
+
+- Use HTTP when FormalAI runs `web-capture` as a sidecar or remote service.
+- Use CLI with `-o -` for text-like outputs (`html`, `txt`, `markdown`) when a
+  process boundary is simpler than HTTP.
+- Use CLI `--output <file>` for binary outputs such as screenshots and archives.
+- Parse timestamps as RFC 3339 strings. JavaScript currently emits
+  millisecond-precision ISO strings for `/search`; Rust emits second-precision
+  `Z` timestamps.
+- Treat content type and status code as part of the contract.
+
+## HTTP Endpoints
+
+| Endpoint    | Required query | Stable success shape                                                                                                                                                |
+| ----------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/fetch`    | `url`          | Proxies upstream status, content type, selected headers, and response bytes.                                                                                        |
+| `/stream`   | `url`          | Streams or proxies upstream status, content type, selected headers, and response bytes.                                                                             |
+| `/html`     | `url`          | `200`, `Content-Type: text/html; charset=utf-8`, rendered or fetched HTML with relative URLs normalized to absolute URLs where supported.                           |
+| `/txt`      | `url`          | `200`, `Content-Type: text/plain; charset=utf-8`, `Content-Disposition` attachment, plain text body.                                                                |
+| `/markdown` | `url`          | `200`, `Content-Type: text/markdown`, Markdown body.                                                                                                                |
+| `/image`    | `url`          | `200`, `Content-Type: image/png` by default or `image/jpeg` when requested, binary image bytes.                                                                     |
+| `/archive`  | `url`          | `200`, `Content-Type: application/zip`, ZIP bytes. Default archive contains `document.md` and `document.html`; local assets use relative folders such as `images/`. |
+| `/search`   | `q` or `query` | `200`, `Content-Type: application/json` by default, normalized search JSON.                                                                                         |
+
+Common HTTP parameters:
+
+| Parameter        | Endpoints                | Meaning                                                                               |
+| ---------------- | ------------------------ | ------------------------------------------------------------------------------------- |
+| `url`            | Capture endpoints        | Source URL. Host-only values are normalized by the implementations where supported.   |
+| `engine`         | Browser-backed endpoints | Browser engine where supported, usually `puppeteer` or `playwright` in JavaScript.    |
+| `embedImages`    | `/markdown`, `/archive`  | Keep base64 images inline when supported.                                             |
+| `localImages`    | `/archive`               | Download images into the archive, default `true` unless original links are requested. |
+| `documentFormat` | `/archive`               | `markdown` by default or `html`.                                                      |
+
+Error shape for artifact endpoints:
+
+- Missing required query parameters return `400` with a short text error.
+- Capture/conversion failures return `500` with a short text error.
+- `/fetch` and `/stream` preserve upstream HTTP status when an upstream response
+  exists; transport failures return `500`.
+
+FormalAI should normalize artifact-endpoint failures into its own diagnostic
+object using the request URL as `sourceUrl`, the HTTP status as `status`, and
+the text response body as `error`. Generic capture endpoints do not guarantee
+CAPTCHA classification because they return raw artifacts; use `/search` when
+provider block/CAPTCHA diagnostics are required.
+
+## Search Contract
+
+`GET /search?q=<QUERY>&provider=<PROVIDER>&limit=<N>&format=json|markdown`
+
+CLI equivalent:
+
+```bash
+web-capture search "<QUERY>" --provider <PROVIDER> --limit <N>
+web-capture search "<QUERY>" --provider <PROVIDER> --format markdown
+```
+
+JSON response:
+
+```json
+{
+  "query": "formal methods",
+  "provider": "wikipedia",
+  "captureMode": "fetch",
+  "capturedAt": "2026-05-18T20:30:00.000Z",
+  "results": [
+    {
+      "rank": 1,
+      "title": "Formal methods",
+      "url": "https://en.wikipedia.org/wiki/Formal_methods",
+      "snippet": "mathematically rigorous techniques"
+    }
+  ],
+  "diagnostics": {
+    "status": 200,
+    "blockedByCors": false,
+    "blockedByCaptcha": false,
+    "sourceUrl": "https://en.wikipedia.org/w/rest.php/v1/search/page?q=formal%20methods&limit=10"
+  }
+}
+```
+
+`diagnostics.error` is present when a transport or provider capture failure is
+recorded. Search transport failures are reported in this JSON object with an
+empty `results` array instead of being silently discarded.
+
+Provider catalog:
+
+| Provider     | Default | Source                     | Notes                                                                     |
+| ------------ | ------- | -------------------------- | ------------------------------------------------------------------------- |
+| `wikipedia`  | Yes     | Wikipedia REST search API  | Preferred CORS-friendly provider.                                         |
+| `duckduckgo` | No      | `html.duckduckgo.com/html` | Parsed from provider HTML server-side.                                    |
+| `google`     | No      | Google Search HTML         | Best-effort parser; CAPTCHA/block pages are reported through diagnostics. |
+| `bing`       | No      | Bing Search HTML           | Best-effort parser.                                                       |
+| `brave`      | No      | Brave Search HTML          | Best-effort parser.                                                       |
+
+Provider IDs are a strict allow-list. Unknown providers return `400` over HTTP
+or a non-zero CLI exit.
+
+## web-search Relationship
+
+`web-capture` currently owns the five-provider `/search` catalog above. No
+`web-search`-backed provider catalog is implemented in this repository as of
+June 12, 2026.
+
+If a future `web-search` integration is added for broader provider coverage, it
+should preserve this response shape and either:
+
+- expose additional providers through an explicit catalog, or
+- delegate internally while keeping the existing provider IDs stable.
+
+FormalAI should not assume that providers outside this allow-list exist until
+they are documented or exposed by a machine-readable catalog.
+
+## CLI Contract
+
+Capture mode:
+
+```bash
+web-capture <URL> --format markdown -o -
+web-capture <URL> --format html -o -
+web-capture <URL> --format txt -o -
+web-capture <URL> --archive zip --output capture.zip
+web-capture <URL> --format png --output screenshot.png
+```
+
+Stable CLI behavior:
+
+| Format            | Recommended FormalAI invocation                          | Output shape                                 |
+| ----------------- | -------------------------------------------------------- | -------------------------------------------- |
+| `markdown` / `md` | `web-capture <URL> --format markdown -o -`               | Markdown on stdout.                          |
+| `html`            | `web-capture <URL> --format html -o -`                   | HTML on stdout.                              |
+| `txt` / `text`    | `web-capture <URL> --format txt -o -`                    | Plain text on stdout.                        |
+| `archive` / `zip` | `web-capture <URL> --archive zip --output capture.zip`   | ZIP file bytes at the output path.           |
+| `image` / `png`   | `web-capture <URL> --format png --output screenshot.png` | PNG file bytes at the output path.           |
+| `jpeg`            | JavaScript implementation                                | JPEG file bytes at the output path.          |
+| `search`          | `web-capture search "<QUERY>" --provider wikipedia`      | Normalized search JSON on stdout by default. |
+
+CLI failures use a non-zero exit code and a human-readable stderr message.
+FormalAI should normalize the CLI diagnostic with:
+
+- `status`: process exit code.
+- `sourceUrl`: requested URL or search provider URL when available from the
+  search JSON.
+- `error`: stderr text for failed processes, or `diagnostics.error` from
+  successful `/search` JSON with empty results.
+- `blockedByCaptcha`: `/search.diagnostics.blockedByCaptcha` when using search;
+  otherwise unknown.
+
+## Smoke Tests
+
+The contract is covered by smoke tests in:
+
+- `js/tests/integration/formalai-contract.test.js`
+- `js/tests/unit/cli.test.js`
+
+These tests assert the stable HTTP content types, binary signatures, ZIP
+contents, search JSON diagnostics, provider allow-list, and CLI output shapes
+that FormalAI should depend on.

--- a/js/.changeset/formalai-contract.md
+++ b/js/.changeset/formalai-contract.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': patch
+---
+
+Document the FormalAI-compatible capture/search contract and add smoke tests for stable HTTP and CLI response shapes.

--- a/js/README.md
+++ b/js/README.md
@@ -127,6 +127,8 @@ parsing. For very large or slow documents, tune the wait with
 ## API Endpoints (Server Mode)
 
 Start the server with `web-capture --serve` and use the endpoints below.
+FormalAI integration should use the stable HTTP/CLI contract documented in
+[`../docs/formalai-contract.md`](../docs/formalai-contract.md).
 
 ### HTML Endpoint
 

--- a/js/tests/helpers/search-fixture.cjs
+++ b/js/tests/helpers/search-fixture.cjs
@@ -1,0 +1,17 @@
+const nock = require('nock');
+
+nock('https://en.wikipedia.org')
+  .persist()
+  .get('/w/rest.php/v1/search/page')
+  .query(true)
+  .reply(200, {
+    pages: [
+      {
+        id: 1,
+        key: 'Formal_methods',
+        title: 'Formal methods',
+        excerpt: 'the study of <b>formal</b> methods',
+        description: 'rigorous techniques',
+      },
+    ],
+  });

--- a/js/tests/integration/formalai-contract.test.js
+++ b/js/tests/integration/formalai-contract.test.js
@@ -1,0 +1,214 @@
+/**
+ * Smoke tests for the FormalAI-facing HTTP contract (issue #135).
+ *
+ * These tests intentionally assert the stable response shapes documented in
+ * docs/formalai-contract.md rather than endpoint internals.
+ */
+
+import request from 'supertest';
+import nock from 'nock';
+import unzipper from 'unzipper';
+import { app, SEARCH_PROVIDERS } from '../../src/index.js';
+
+const HTML = `<!doctype html>
+<html>
+  <head><title>FormalAI fixture</title></head>
+  <body><h1>FormalAI Fixture</h1><p>Stable HTTP shape.</p></body>
+</html>`;
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const WIKI_JSON = {
+  pages: [
+    {
+      id: 1,
+      key: 'Formal_methods',
+      title: 'Formal methods',
+      excerpt: 'the study of <b>formal</b> methods',
+      description: 'rigorous techniques',
+    },
+  ],
+};
+
+function parseBinary(res, callback) {
+  const chunks = [];
+  res.on('data', (chunk) => chunks.push(chunk));
+  res.on('end', () => callback(null, Buffer.concat(chunks)));
+}
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe('FormalAI HTTP contract (#135)', () => {
+  it('returns stable text artifact shapes for /html, /txt, and /markdown', async () => {
+    nock('https://formalai.example').get('/page').reply(200, HTML, {
+      'content-type': 'text/html; charset=utf-8',
+    });
+    const html = await request(app)
+      .get('/html')
+      .query({ url: 'https://formalai.example/page' })
+      .expect(200)
+      .expect('Content-Type', /text\/html/);
+    expect(html.text).toContain('<h1>FormalAI Fixture</h1>');
+
+    nock('https://formalai.example')
+      .get('/text')
+      .reply(200, 'FormalAI plain text', {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+    const text = await request(app)
+      .get('/txt')
+      .query({ url: 'https://formalai.example/text' })
+      .expect(200)
+      .expect('Content-Type', /text\/plain/);
+    expect(text.headers['content-disposition']).toContain('.txt');
+    expect(text.text).toBe('FormalAI plain text');
+
+    nock('https://formalai.example').get('/markdown').reply(200, HTML, {
+      'content-type': 'text/html; charset=utf-8',
+    });
+    const markdown = await request(app)
+      .get('/markdown')
+      .query({ url: 'https://formalai.example/markdown' })
+      .expect(200)
+      .expect('Content-Type', /text\/markdown/);
+    expect(markdown.text).toContain('FormalAI Fixture');
+    expect(markdown.text).toContain('Stable HTTP shape.');
+  });
+
+  it('preserves upstream status and content for /fetch and /stream', async () => {
+    nock('https://formalai.example')
+      .get('/fetch-source')
+      .reply(203, 'fetch body', {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+    const fetched = await request(app)
+      .get('/fetch')
+      .query({ url: 'https://formalai.example/fetch-source' })
+      .expect(203)
+      .expect('Content-Type', /text\/plain/);
+    expect(fetched.text).toBe('fetch body');
+
+    nock('https://formalai.example')
+      .get('/stream-source')
+      .reply(206, 'stream body', {
+        'content-type': 'text/plain; charset=utf-8',
+      });
+    const streamed = await request(app)
+      .get('/stream')
+      .query({ url: 'https://formalai.example/stream-source' })
+      .expect(206)
+      .expect('Content-Type', /text\/plain/);
+    expect(streamed.text).toBe('stream body');
+  });
+
+  it('returns stable binary artifact shapes for /image and /archive', async () => {
+    nock('https://drive.google.com')
+      .get('/uc')
+      .query({ export: 'download', id: 'formalaiimage' })
+      .reply(200, PNG, { 'content-type': 'image/png' });
+    const image = await request(app)
+      .get('/image')
+      .query({
+        url: 'https://drive.google.com/file/d/formalaiimage/view',
+      })
+      .buffer(true)
+      .parse(parseBinary)
+      .expect(200)
+      .expect('Content-Type', /image\/png/);
+    expect(image.headers['content-disposition']).toContain(
+      'google-drive-formalaiimage.png'
+    );
+    expect(image.body.subarray(0, 8)).toEqual(PNG);
+
+    nock('https://formalai.example').get('/archive').reply(200, HTML, {
+      'content-type': 'text/html; charset=utf-8',
+    });
+    const archive = await request(app)
+      .get('/archive')
+      .query({
+        url: 'https://formalai.example/archive',
+        localImages: 'false',
+      })
+      .buffer(true)
+      .parse(parseBinary)
+      .expect(200)
+      .expect('Content-Type', /application\/zip/);
+    expect(archive.body[0]).toBe(0x50);
+    expect(archive.body[1]).toBe(0x4b);
+    const zip = await unzipper.Open.buffer(archive.body);
+    expect(zip.files.map((file) => file.path)).toEqual(
+      expect.arrayContaining(['document.md', 'document.html'])
+    );
+  });
+
+  it('returns normalized /search JSON diagnostics and the documented provider catalog', async () => {
+    expect(SEARCH_PROVIDERS).toEqual([
+      'wikipedia',
+      'duckduckgo',
+      'google',
+      'bing',
+      'brave',
+    ]);
+
+    nock('https://en.wikipedia.org')
+      .get('/w/rest.php/v1/search/page')
+      .query(true)
+      .reply(200, WIKI_JSON);
+
+    const res = await request(app)
+      .get('/search')
+      .query({ q: 'formal-ai', provider: 'wikipedia', limit: 1 })
+      .expect(200)
+      .expect('Content-Type', /application\/json/);
+
+    expect(res.body).toMatchObject({
+      query: 'formal-ai',
+      provider: 'wikipedia',
+      captureMode: 'fetch',
+      results: [
+        {
+          rank: 1,
+          title: 'Formal methods',
+          url: 'https://en.wikipedia.org/wiki/Formal_methods',
+          snippet: 'the study of formal methods',
+        },
+      ],
+      diagnostics: {
+        status: 200,
+        blockedByCors: false,
+        blockedByCaptcha: false,
+      },
+    });
+    expect(res.body.capturedAt).toEqual(expect.any(String));
+    expect(res.body.diagnostics.sourceUrl).toContain('en.wikipedia.org');
+  });
+
+  it('keeps normalized /search diagnostics when provider capture fails', async () => {
+    nock('https://en.wikipedia.org')
+      .get('/w/rest.php/v1/search/page')
+      .query(true)
+      .replyWithError(new Error('provider offline'));
+
+    const res = await request(app)
+      .get('/search')
+      .query({ q: 'formal-ai', provider: 'wikipedia', limit: 1 })
+      .expect(200)
+      .expect('Content-Type', /application\/json/);
+
+    expect(res.body).toMatchObject({
+      query: 'formal-ai',
+      provider: 'wikipedia',
+      captureMode: 'fetch',
+      results: [],
+      diagnostics: {
+        status: 0,
+        blockedByCors: false,
+        blockedByCaptcha: false,
+      },
+    });
+    expect(res.body.diagnostics.sourceUrl).toContain('en.wikipedia.org');
+    expect(res.body.diagnostics.error).toContain('provider offline');
+  });
+});

--- a/js/tests/unit/cli.test.js
+++ b/js/tests/unit/cli.test.js
@@ -1,7 +1,7 @@
 // Unit tests for CLI argument parsing and functionality
 import { spawn } from 'child_process';
 import http from 'node:http';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join, resolve } from 'path';
 import packageJson from '../../package.json' with { type: 'json' };
@@ -9,11 +9,12 @@ import packageJson from '../../package.json' with { type: 'json' };
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const cliPath = resolve(__dirname, '../../bin/web-capture.js');
+const searchFixturePath = resolve(__dirname, '../helpers/search-fixture.cjs');
 
 // Helper function to run CLI and capture output
 function runCli(args, options = {}) {
   return new Promise((resolve, reject) => {
-    const proc = spawn('node', [cliPath, ...args], {
+    const proc = spawn(process.execPath, [cliPath, ...args], {
       cwd: options.cwd || dirname(cliPath),
       env: { ...process.env, ...options.env },
     });
@@ -36,13 +37,14 @@ function runCli(args, options = {}) {
   });
 }
 
-function startFixtureServer() {
+function startFixtureServer({
+  body = '<!doctype html><html><body><h1>Issue 68</h1><p>Captured from positional URL.</p></body></html>',
+  contentType = 'text/html; charset=utf-8',
+} = {}) {
   return new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(
-        '<!doctype html><html><body><h1>Issue 68</h1><p>Captured from positional URL.</p></body></html>'
-      );
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(body);
     });
 
     server.on('error', reject);
@@ -254,5 +256,100 @@ describe('CLI', () => {
       expect(result.stdout).toContain('--output');
       expect(result.stdout).toContain('-o');
     });
+  });
+
+  describe('FormalAI-compatible CLI contract', () => {
+    test('writes HTML, Markdown, and text captures to stdout with -o -', async () => {
+      const { server, url } = await startFixtureServer({
+        body: '<!doctype html><html><body><h1>FormalAI Fixture</h1><p>Stable CLI shape.</p></body></html>',
+      });
+
+      try {
+        const html = await runCli([url, '--format', 'html', '--output', '-']);
+        expect(html.code).toBe(0);
+        expect(html.stdout).toContain('<h1>FormalAI Fixture</h1>');
+
+        const markdown = await runCli([
+          url,
+          '--format',
+          'markdown',
+          '--output',
+          '-',
+        ]);
+        expect(markdown.code).toBe(0);
+        expect(markdown.stdout).toContain('FormalAI Fixture');
+        expect(markdown.stdout).toContain('Stable CLI shape.');
+
+        const text = await runCli([url, '--format', 'txt', '--output', '-']);
+        expect(text.code).toBe(0);
+        expect(text.stdout).toContain('FormalAI Fixture');
+      } finally {
+        await stopFixtureServer(server);
+      }
+    }, 20000);
+
+    test('writes archive captures as ZIP files for binary CLI consumers', async () => {
+      const outputDir = mkdtempSync(join(process.cwd(), 'formalai-cli-'));
+      const outputPath = join(outputDir, 'capture.zip');
+      const { server, url } = await startFixtureServer({
+        body: '<!doctype html><html><body><h1>FormalAI Archive</h1></body></html>',
+      });
+
+      try {
+        const result = await runCli([
+          url,
+          '--archive',
+          'zip',
+          '--output',
+          outputPath,
+        ]);
+
+        expect(result.code).toBe(0);
+        const zipBytes = readFileSync(outputPath);
+        expect(zipBytes.length).toBeGreaterThan(50);
+        expect(zipBytes[0]).toBe(0x50);
+        expect(zipBytes[1]).toBe(0x4b);
+      } finally {
+        await stopFixtureServer(server);
+        rmSync(outputDir, { recursive: true, force: true });
+      }
+    }, 20000);
+
+    test('emits normalized search JSON from the search subcommand', async () => {
+      const nodeOptions = [
+        process.env.NODE_OPTIONS,
+        `--require=${searchFixturePath}`,
+      ]
+        .filter(Boolean)
+        .join(' ');
+      const result = await runCli(
+        ['search', 'formal-ai', '--provider', 'wikipedia', '--limit', '1'],
+        {
+          env: { NODE_OPTIONS: nodeOptions },
+        }
+      );
+
+      expect(result.code).toBe(0);
+      const body = JSON.parse(result.stdout);
+      expect(body).toMatchObject({
+        query: 'formal-ai',
+        provider: 'wikipedia',
+        captureMode: 'fetch',
+      });
+      expect(body.results).toEqual([
+        {
+          rank: 1,
+          title: 'Formal methods',
+          url: 'https://en.wikipedia.org/wiki/Formal_methods',
+          snippet: 'the study of formal methods',
+        },
+      ]);
+      expect(body.diagnostics).toMatchObject({
+        status: 200,
+        blockedByCors: false,
+        blockedByCaptcha: false,
+      });
+      expect(body.diagnostics.sourceUrl).toContain('en.wikipedia.org');
+    }, 20000);
   });
 });

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "web-capture"
-version = "0.3.26"
+version = "0.3.29"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/rust/README.md
+++ b/rust/README.md
@@ -88,6 +88,7 @@ FormalAI integration should use the stable HTTP/CLI contract documented in
 - **HTML**: `GET /html?url=<URL>`
 - **Text**: `GET /txt?url=<URL>` (xpaste.pro paste URLs normalize to `/raw`)
 - **PNG screenshot**: `GET /image?url=<URL>`
+- **Archive**: `GET /archive?url=<URL>` (ZIP containing `document.md` and `document.html`)
 - **Search**: `GET /search?q=<QUERY>&provider=<PROVIDER>&format=json|markdown`
 
 For xpaste.pro paste URLs, `/markdown` captures the visual paste page in visible

--- a/rust/README.md
+++ b/rust/README.md
@@ -77,6 +77,9 @@ web-capture --serve --port 8080
 
 ### API Endpoints (Server Mode)
 
+FormalAI integration should use the stable HTTP/CLI contract documented in
+[`../docs/formalai-contract.md`](../docs/formalai-contract.md).
+
 - **Markdown**: `GET /markdown?url=<URL>` (original links kept, base64 stripped by default)
 - **Markdown (kreuzberg)**: `GET /markdown?url=<URL>&converter=kreuzberg`
 - **Markdown (structured JSON)**: `GET /markdown?url=<URL>&converter=kreuzberg&format=json`

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -419,6 +419,7 @@ async fn start_server(port: u16) -> anyhow::Result<()> {
         .route("/markdown", get(markdown_handler))
         .route("/txt", get(txt_handler))
         .route("/image", get(image_handler))
+        .route("/archive", get(archive_handler))
         .route("/fetch", get(fetch_handler))
         .route("/stream", get(stream_handler))
         .route("/animation", get(animation_handler))
@@ -436,6 +437,7 @@ async fn start_server(port: u16) -> anyhow::Result<()> {
     info!("  GET /markdown?url=<URL>&converter=kreuzberg&format=json - Structured Markdown conversion");
     info!("  GET /txt?url=<URL>        - Fetch text content");
     info!("  GET /image?url=<URL>      - Screenshot page as PNG");
+    info!("  GET /archive?url=<URL>    - Capture page as ZIP archive");
     info!("  GET /fetch?url=<URL>      - Proxy fetch content");
     info!("  GET /stream?url=<URL>     - Stream content");
     info!("  GET /animation?url=<URL>  - Capture animation frames");
@@ -832,6 +834,47 @@ fn zip_response(url: &str, bytes: Vec<u8>) -> Response {
             .insert(header::CONTENT_DISPOSITION, value);
     }
     response
+}
+
+/// Archive endpoint handler
+async fn archive_handler(Query(params): Query<UrlQuery>) -> Response {
+    let url = match normalize_url(&params.url) {
+        Ok(url) => url,
+        Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
+    };
+
+    let html = match fetch_html(&url).await {
+        Ok(html) => html,
+        Err(e) => {
+            error!("Failed to fetch HTML for archive: {}", e);
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Error fetching HTML").into_response();
+        }
+    };
+
+    let bytes = match web_capture::archive::build_zip_from_html(&html, &url) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            error!("Failed to create archive: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Error creating ZIP archive",
+            )
+                .into_response();
+        }
+    };
+
+    (
+        StatusCode::OK,
+        [
+            ("Content-Type", "application/zip"),
+            (
+                "Content-Disposition",
+                "attachment; filename=\"capture.zip\"",
+            ),
+        ],
+        bytes,
+    )
+        .into_response()
 }
 
 /// Image/screenshot endpoint handler

--- a/rust/tests/integration/formalai_contract.rs
+++ b/rust/tests/integration/formalai_contract.rs
@@ -1,0 +1,615 @@
+//! Smoke tests for the FormalAI-facing Rust HTTP/CLI contract (issue #135).
+//!
+//! These tests assert the same public response shapes as the JavaScript
+//! `FormalAI` contract tests, using the compiled Rust binary where practical.
+
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
+use std::net::TcpListener as StdTcpListener;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+
+use reqwest::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, Command};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, Duration, Instant};
+use web_capture::search::{
+    parse_search_results, SearchDiagnostics, SearchResult, SEARCH_PROVIDERS,
+};
+
+const HTML: &str = "<!doctype html><html><head><title>FormalAI fixture</title></head><body><h1>FormalAI Fixture</h1><p>Stable Rust shape.</p></body></html>";
+const WIKI_JSON: &str = r#"{"pages":[{"id":1,"key":"Formal_methods","title":"Formal methods","excerpt":"the study of <b>formal</b> methods","description":"rigorous techniques"}]}"#;
+
+#[tokio::test]
+async fn formalai_http_text_artifact_shapes() {
+    let fixture = FixtureServer::start([
+        FixtureResponse::new("/page", 200, "text/html; charset=utf-8", HTML),
+        FixtureResponse::new(
+            "/text",
+            200,
+            "text/plain; charset=utf-8",
+            "FormalAI plain text",
+        ),
+        FixtureResponse::new("/markdown", 200, "text/html; charset=utf-8", HTML),
+    ])
+    .await;
+    let web_capture = WebCaptureServer::start().await;
+    let client = reqwest::Client::new();
+
+    let html = client
+        .get(web_capture.endpoint("/html"))
+        .query(&[("url", fixture.url("/page"))])
+        .send()
+        .await
+        .expect("request /html");
+    assert_eq!(html.status(), 200);
+    assert_header_contains(&html, CONTENT_TYPE.as_str(), "text/html");
+    let html_body = html.text().await.expect("read /html body");
+    assert!(html_body.contains("<h1>FormalAI Fixture</h1>"));
+
+    let text = client
+        .get(web_capture.endpoint("/txt"))
+        .query(&[("url", fixture.url("/text"))])
+        .send()
+        .await
+        .expect("request /txt");
+    assert_eq!(text.status(), 200);
+    assert_header_contains(&text, CONTENT_TYPE.as_str(), "text/plain");
+    assert_header_contains(&text, CONTENT_DISPOSITION.as_str(), ".txt");
+    assert_eq!(
+        text.text().await.expect("read /txt body"),
+        "FormalAI plain text"
+    );
+
+    let markdown = client
+        .get(web_capture.endpoint("/markdown"))
+        .query(&[("url", fixture.url("/markdown"))])
+        .send()
+        .await
+        .expect("request /markdown");
+    assert_eq!(markdown.status(), 200);
+    assert_header_contains(&markdown, CONTENT_TYPE.as_str(), "text/markdown");
+    let markdown_body = markdown.text().await.expect("read /markdown body");
+    assert!(markdown_body.contains("FormalAI Fixture"));
+    assert!(markdown_body.contains("Stable Rust shape."));
+
+    web_capture.shutdown().await;
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn formalai_http_proxy_and_archive_shapes() {
+    let fixture = FixtureServer::start([
+        FixtureResponse::new(
+            "/fetch-source",
+            203,
+            "text/plain; charset=utf-8",
+            "fetch body",
+        ),
+        FixtureResponse::new(
+            "/stream-source",
+            206,
+            "text/plain; charset=utf-8",
+            "stream body",
+        ),
+        FixtureResponse::new("/archive", 200, "text/html; charset=utf-8", HTML),
+    ])
+    .await;
+    let web_capture = WebCaptureServer::start().await;
+    let client = reqwest::Client::new();
+
+    let fetched = client
+        .get(web_capture.endpoint("/fetch"))
+        .query(&[("url", fixture.url("/fetch-source"))])
+        .send()
+        .await
+        .expect("request /fetch");
+    assert_eq!(fetched.status(), 203);
+    assert_header_contains(&fetched, CONTENT_TYPE.as_str(), "text/plain");
+    assert_eq!(
+        fetched.text().await.expect("read /fetch body"),
+        "fetch body"
+    );
+
+    let streamed = client
+        .get(web_capture.endpoint("/stream"))
+        .query(&[("url", fixture.url("/stream-source"))])
+        .send()
+        .await
+        .expect("request /stream");
+    assert_eq!(streamed.status(), 206);
+    assert_header_contains(&streamed, CONTENT_TYPE.as_str(), "text/plain");
+    assert_eq!(
+        streamed.text().await.expect("read /stream body"),
+        "stream body"
+    );
+
+    let archive = client
+        .get(web_capture.endpoint("/archive"))
+        .query(&[("url", fixture.url("/archive"))])
+        .send()
+        .await
+        .expect("request /archive");
+    assert_eq!(archive.status(), 200);
+    assert_header_contains(&archive, CONTENT_TYPE.as_str(), "application/zip");
+    let bytes = archive.bytes().await.expect("read /archive body");
+    assert_eq!(&bytes[..2], b"PK");
+    assert_zip_entries(bytes.as_ref(), &["document.md", "document.html"]);
+
+    web_capture.shutdown().await;
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn formalai_http_image_shape_when_browser_is_available() {
+    if !chrome_available() {
+        eprintln!(
+            "Skipping FormalAI /image contract test because Chrome/Chromium is not installed"
+        );
+        return;
+    }
+
+    let fixture = FixtureServer::start([FixtureResponse::new(
+        "/image",
+        200,
+        "text/html; charset=utf-8",
+        HTML,
+    )])
+    .await;
+    let web_capture = WebCaptureServer::start().await;
+    let client = reqwest::Client::new();
+
+    let image = client
+        .get(web_capture.endpoint("/image"))
+        .query(&[("url", fixture.url("/image"))])
+        .send()
+        .await
+        .expect("request /image");
+    assert_eq!(image.status(), 200);
+    assert_header_contains(&image, CONTENT_TYPE.as_str(), "image/png");
+    let bytes = image.bytes().await.expect("read /image body");
+    assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+
+    web_capture.shutdown().await;
+    fixture.shutdown().await;
+}
+
+#[tokio::test]
+async fn formalai_cli_text_and_archive_shapes() {
+    let fixture = FixtureServer::start([FixtureResponse::new(
+        "/capture",
+        200,
+        "text/html; charset=utf-8",
+        HTML,
+    )])
+    .await;
+
+    let html = run_cli(&[
+        &fixture.url("/capture"),
+        "--capture",
+        "api",
+        "--format",
+        "html",
+        "--output",
+        "-",
+    ])
+    .await;
+    assert!(html.status.success(), "HTML CLI failed: {}", html.stderr);
+    assert!(html.stdout.contains("<h1>FormalAI Fixture</h1>"));
+
+    let markdown = run_cli(&[
+        &fixture.url("/capture"),
+        "--capture",
+        "api",
+        "--format",
+        "markdown",
+        "--output",
+        "-",
+    ])
+    .await;
+    assert!(
+        markdown.status.success(),
+        "Markdown CLI failed: {}",
+        markdown.stderr
+    );
+    assert!(markdown.stdout.contains("FormalAI Fixture"));
+    assert!(markdown.stdout.contains("Stable Rust shape."));
+
+    let text = run_cli(&[&fixture.url("/capture"), "--format", "txt", "--output", "-"]).await;
+    assert!(text.status.success(), "text CLI failed: {}", text.stderr);
+    assert!(text.stdout.contains("FormalAI Fixture"));
+
+    let archive = run_cli_bytes(&[
+        &fixture.url("/capture"),
+        "--capture",
+        "api",
+        "--archive",
+        "zip",
+        "--output",
+        "-",
+    ])
+    .await;
+    assert!(
+        archive.status.success(),
+        "archive CLI failed: {}",
+        archive.stderr
+    );
+    assert_eq!(&archive.stdout[..2], b"PK");
+    assert_zip_entries(&archive.stdout, &["document.md", "document.html"]);
+
+    fixture.shutdown().await;
+}
+
+#[test]
+fn formalai_search_json_contract_shape() {
+    assert_eq!(
+        SEARCH_PROVIDERS,
+        ["wikipedia", "duckduckgo", "google", "bing", "brave"]
+    );
+
+    let (results, blocked) = parse_search_results("wikipedia", WIKI_JSON, 1);
+    assert!(!blocked);
+    assert_eq!(results.len(), 1);
+
+    let result = SearchResult {
+        query: "formal-ai".to_string(),
+        provider: "wikipedia".to_string(),
+        capture_mode: "fetch".to_string(),
+        captured_at: "2026-05-18T20:30:00Z".to_string(),
+        results,
+        diagnostics: SearchDiagnostics {
+            status: 200,
+            blocked_by_cors: false,
+            blocked_by_captcha: false,
+            source_url: "https://en.wikipedia.org/w/rest.php/v1/search/page?q=formal-ai&limit=1"
+                .to_string(),
+            error: None,
+        },
+    };
+
+    let value = serde_json::to_value(result).expect("serialize search result");
+    assert_eq!(value["query"], "formal-ai");
+    assert_eq!(value["provider"], "wikipedia");
+    assert_eq!(value["captureMode"], "fetch");
+    assert_eq!(value["results"][0]["rank"], 1);
+    assert_eq!(value["results"][0]["title"], "Formal methods");
+    assert_eq!(
+        value["results"][0]["url"],
+        "https://en.wikipedia.org/wiki/Formal_methods"
+    );
+    assert_eq!(
+        value["results"][0]["snippet"],
+        "the study of formal methods"
+    );
+    assert_eq!(value["diagnostics"]["status"], 200);
+    assert_eq!(value["diagnostics"]["blockedByCors"], false);
+    assert_eq!(value["diagnostics"]["blockedByCaptcha"], false);
+    assert!(value["diagnostics"]["sourceUrl"]
+        .as_str()
+        .expect("sourceUrl")
+        .contains("en.wikipedia.org"));
+}
+
+#[test]
+fn formalai_search_failure_diagnostics_shape() {
+    let result = SearchResult {
+        query: "formal-ai".to_string(),
+        provider: "wikipedia".to_string(),
+        capture_mode: "fetch".to_string(),
+        captured_at: "2026-05-18T20:30:00Z".to_string(),
+        results: Vec::new(),
+        diagnostics: SearchDiagnostics {
+            status: 0,
+            blocked_by_cors: false,
+            blocked_by_captcha: false,
+            source_url: "https://en.wikipedia.org/w/rest.php/v1/search/page?q=formal-ai&limit=1"
+                .to_string(),
+            error: Some("provider offline".to_string()),
+        },
+    };
+
+    let value = serde_json::to_value(result).expect("serialize search result");
+    assert_eq!(value["results"].as_array().expect("results").len(), 0);
+    assert_eq!(value["diagnostics"]["status"], 0);
+    assert_eq!(value["diagnostics"]["blockedByCors"], false);
+    assert_eq!(value["diagnostics"]["blockedByCaptcha"], false);
+    assert_eq!(value["diagnostics"]["error"], "provider offline");
+}
+
+struct CliTextOutput {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+struct CliBytesOutput {
+    status: std::process::ExitStatus,
+    stdout: Vec<u8>,
+    stderr: String,
+}
+
+async fn run_cli(args: &[&str]) -> CliTextOutput {
+    let output = Command::new(web_capture_binary())
+        .args(args)
+        .env_remove("RUST_LOG")
+        .output()
+        .await
+        .expect("run web-capture CLI");
+
+    CliTextOutput {
+        status: output.status,
+        stdout: String::from_utf8(output.stdout).expect("CLI stdout should be UTF-8"),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+async fn run_cli_bytes(args: &[&str]) -> CliBytesOutput {
+    let output = Command::new(web_capture_binary())
+        .args(args)
+        .env_remove("RUST_LOG")
+        .output()
+        .await
+        .expect("run web-capture CLI");
+
+    CliBytesOutput {
+        status: output.status,
+        stdout: output.stdout,
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+fn assert_header_contains(response: &reqwest::Response, name: &str, expected: &str) {
+    let value = response
+        .headers()
+        .get(name)
+        .unwrap_or_else(|| panic!("missing {name} header"))
+        .to_str()
+        .unwrap_or_else(|error| panic!("invalid {name} header: {error}"));
+    assert!(
+        value.contains(expected),
+        "expected {name} header to contain {expected:?}, got {value:?}"
+    );
+}
+
+fn assert_zip_entries(bytes: &[u8], expected_entries: &[&str]) {
+    let mut zip = zip::ZipArchive::new(Cursor::new(bytes)).expect("open ZIP");
+    let names = (0..zip.len())
+        .map(|index| {
+            zip.by_index(index)
+                .expect("read ZIP entry")
+                .name()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+
+    for expected in expected_entries {
+        assert!(
+            names.iter().any(|name| name == expected),
+            "expected ZIP entry {expected:?}, got {names:?}"
+        );
+    }
+
+    let mut markdown = String::new();
+    zip.by_name("document.md")
+        .expect("document.md entry")
+        .read_to_string(&mut markdown)
+        .expect("read document.md");
+    assert!(markdown.contains("FormalAI Fixture"));
+}
+
+fn web_capture_binary() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_web-capture") {
+        return PathBuf::from(path);
+    }
+
+    let mut path = std::env::current_exe().expect("current test executable");
+    path.pop();
+    if path.file_name().is_some_and(|name| name == "deps") {
+        path.pop();
+    }
+    path.push(if cfg!(windows) {
+        "web-capture.exe"
+    } else {
+        "web-capture"
+    });
+    path
+}
+
+fn chrome_available() -> bool {
+    std::env::var_os("WEB_CAPTURE_CHROME_PATH").is_some()
+        || [
+            "google-chrome",
+            "google-chrome-stable",
+            "chromium",
+            "chromium-browser",
+            "chrome",
+        ]
+        .iter()
+        .any(|candidate| {
+            std::process::Command::new(candidate)
+                .arg("--version")
+                .output()
+                .is_ok()
+        })
+}
+
+struct WebCaptureServer {
+    base_url: String,
+    child: Option<Child>,
+}
+
+impl WebCaptureServer {
+    async fn start() -> Self {
+        let port = unused_port();
+        let mut child = Command::new(web_capture_binary())
+            .arg("--serve")
+            .arg("--port")
+            .arg(port.to_string())
+            .env("RUST_LOG", "error")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("start web-capture server");
+        let base_url = format!("http://127.0.0.1:{port}");
+        let client = reqwest::Client::new();
+        let deadline = Instant::now() + Duration::from_secs(10);
+
+        loop {
+            if let Some(status) = child.try_wait().expect("poll web-capture server") {
+                panic!("web-capture server exited before becoming ready: {status}");
+            }
+
+            if client
+                .get(format!("{base_url}/search"))
+                .send()
+                .await
+                .is_ok()
+            {
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "web-capture server did not become ready"
+            );
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        Self {
+            base_url,
+            child: Some(child),
+        }
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+        }
+    }
+}
+
+impl Drop for WebCaptureServer {
+    fn drop(&mut self) {
+        if let Some(child) = &mut self.child {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+fn unused_port() -> u16 {
+    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().expect("read local addr").port()
+}
+
+#[derive(Clone)]
+struct FixtureResponse {
+    path: String,
+    status: u16,
+    content_type: String,
+    body: Vec<u8>,
+}
+
+impl FixtureResponse {
+    fn new(path: &str, status: u16, content_type: &str, body: impl AsRef<[u8]>) -> Self {
+        Self {
+            path: path.to_string(),
+            status,
+            content_type: content_type.to_string(),
+            body: body.as_ref().to_vec(),
+        }
+    }
+}
+
+struct FixtureServer {
+    base_url: String,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl FixtureServer {
+    async fn start<const N: usize>(responses: [FixtureResponse; N]) -> Self {
+        let responses = Arc::new(
+            responses
+                .into_iter()
+                .map(|response| (response.path.clone(), response))
+                .collect::<HashMap<_, _>>(),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fixture server");
+        let addr = listener.local_addr().expect("fixture local addr");
+        let (shutdown, mut shutdown_rx) = oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    accepted = listener.accept() => {
+                        let Ok((mut stream, _)) = accepted else {
+                            break;
+                        };
+                        let responses = Arc::clone(&responses);
+                        tokio::spawn(async move {
+                            let mut request = [0_u8; 2048];
+                            let Ok(size) = stream.read(&mut request).await else {
+                                return;
+                            };
+                            let request = String::from_utf8_lossy(&request[..size]);
+                            let target = request
+                                .lines()
+                                .next()
+                                .and_then(|line| line.split_whitespace().nth(1))
+                                .unwrap_or("/");
+                            let path = target.split('?').next().unwrap_or(target);
+                            let response = responses.get(path).cloned().unwrap_or_else(|| {
+                                FixtureResponse::new(path, 404, "text/plain; charset=utf-8", "not found")
+                            });
+                            let header = format!(
+                                "HTTP/1.1 {} OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                                response.status,
+                                response.content_type,
+                                response.body.len()
+                            );
+                            let _ = stream.write_all(header.as_bytes()).await;
+                            let _ = stream.write_all(&response.body).await;
+                        });
+                    }
+                }
+            }
+        });
+
+        Self {
+            base_url: format!("http://{addr}"),
+            shutdown: Some(shutdown),
+            handle: Some(handle),
+        }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for FixtureServer {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
+}

--- a/rust/tests/integration/mod.rs
+++ b/rust/tests/integration/mod.rs
@@ -5,6 +5,7 @@ mod bold_coalesce_and_leakage;
 mod browser;
 mod extract_images_with_title;
 mod figures;
+mod formalai_contract;
 mod gdocs;
 mod gdocs_image_parity;
 mod gdocs_public_doc;

--- a/scripts/check-js-rust-parity.mjs
+++ b/scripts/check-js-rust-parity.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+/**
+ * Enforce JS/Rust parity for shared source and test changes.
+ *
+ * If a PR changes JavaScript source/tests, it must also change Rust
+ * source/tests. If it changes Rust source/tests, it must also change
+ * JavaScript source/tests. Documentation, release metadata, workflows, and
+ * scripts are intentionally ignored by this guard.
+ */
+
+import { execFileSync } from "child_process";
+
+const JS_PARITY_PATHS = ["js/src/", "js/tests/"];
+const RUST_PARITY_PATHS = ["rust/src/", "rust/tests/"];
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function splitLines(output) {
+  return output ? output.split("\n").filter(Boolean) : [];
+}
+
+function diffFiles(base, head) {
+  return splitLines(git(["diff", "--name-only", `${base}...${head}`]));
+}
+
+function fallbackDiffFiles() {
+  try {
+    return splitLines(git(["diff", "--name-only", "HEAD^", "HEAD"]));
+  } catch {
+    return splitLines(git(["ls-tree", "--name-only", "-r", "HEAD"]));
+  }
+}
+
+function changedFiles() {
+  const baseSha = process.env.GITHUB_BASE_SHA;
+  const headSha = process.env.GITHUB_HEAD_SHA || "HEAD";
+
+  if (baseSha) {
+    return diffFiles(baseSha, headSha);
+  }
+
+  const baseRef = process.env.GITHUB_BASE_REF || "main";
+  try {
+    git(["fetch", "origin", baseRef, "--depth=1"]);
+    return diffFiles(`origin/${baseRef}`, headSha);
+  } catch {
+    return fallbackDiffFiles();
+  }
+}
+
+function matchingFiles(files, prefixes) {
+  return files.filter((file) =>
+    prefixes.some((prefix) => file.startsWith(prefix)),
+  );
+}
+
+function printFiles(title, files) {
+  console.log(title);
+  if (files.length === 0) {
+    console.log("  (none)");
+    return;
+  }
+  for (const file of files) {
+    console.log(`  ${file}`);
+  }
+}
+
+const files = changedFiles();
+const jsFiles = matchingFiles(files, JS_PARITY_PATHS);
+const rustFiles = matchingFiles(files, RUST_PARITY_PATHS);
+const issues = [];
+
+console.log("Checking JS/Rust source and test parity.\n");
+printFiles("Changed files:", files);
+console.log("");
+printFiles("JS source/test changes:", jsFiles);
+console.log("");
+printFiles("Rust source/test changes:", rustFiles);
+console.log("");
+
+if (jsFiles.length > 0 && rustFiles.length === 0) {
+  issues.push(
+    "JavaScript source/tests changed without corresponding Rust source/tests.",
+  );
+}
+
+if (rustFiles.length > 0 && jsFiles.length === 0) {
+  issues.push(
+    "Rust source/tests changed without corresponding JavaScript source/tests.",
+  );
+}
+
+if (issues.length > 0) {
+  for (const issue of issues) {
+    console.error(`::error::${issue}`);
+  }
+  console.error(
+    "Update the other implementation or add equivalent tests so both language packages stay in sync.",
+  );
+  process.exit(1);
+}
+
+console.log("JS/Rust source and test parity check passed.");


### PR DESCRIPTION
## Summary

Fixes #135.

- Documents the stable FormalAI HTTP/CLI contract for `/fetch`, `/html`, `/txt`, `/markdown`, `/image`, `/archive`, `/stream`, and `/search`.
- Documents the `/search` provider catalog, `web-search` relationship, diagnostics expectations, and Rust MSRV integration guidance.
- Adds JS smoke tests for FormalAI HTTP and CLI response shapes, including normalized search failure diagnostics.
- Adds Rust FormalAI smoke tests for HTTP, CLI, search JSON, provider catalog, and failure diagnostics.
- Implements the Rust HTTP `/archive` route so the documented shared contract is available in both implementations.
- Adds a `JS/Rust Parity` CI check that fails when `js/src` or `js/tests` changes without corresponding `rust/src` or `rust/tests` changes, and vice versa.

## Tests

- `cargo test --test integration formalai_contract -- --nocapture`
- `cargo test --all-features --verbose`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npx -y node@22 --experimental-vm-modules ./node_modules/.bin/jest --runTestsByPath tests/integration/formalai-contract.test.js tests/unit/cli.test.js`
- `npx -y node@22 --experimental-vm-modules ./node_modules/.bin/jest --testPathIgnorePatterns="docker.test.js"`
- `npx -y node@22 ./node_modules/.bin/eslint .` (0 errors; existing complexity warnings)
- `npx -y node@22 ./node_modules/.bin/prettier --check .`
- `npx -y node@22 js/node_modules/prettier/bin/prettier.cjs --check .github/workflows/parity.yml scripts/check-js-rust-parity.mjs docs/formalai-contract.md rust/README.md`
- `npx -y node@22 scripts/validate-changeset.mjs`
- `npx -y node@22 ./node_modules/.bin/jscpd .`
- `env GITHUB_BASE_SHA=$(git merge-base main HEAD) GITHUB_HEAD_SHA=HEAD node scripts/check-js-rust-parity.mjs`
