### PR TITLE
Expose injectable transports and exact response receipts

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-03T09:28:09.067Z for PR creation at branch issue-147-3e2d2c6145d9 for issue https://github.com/link-assistant/web-capture/issues/147

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-03T09:28:09.067Z for PR creation at branch issue-147-3e2d2c6145d9 for issue https://github.com/link-assistant/web-capture/issues/147

--- a/docs/formalai-contract.md
+++ b/docs/formalai-contract.md
@@ -126,6 +126,23 @@ JSON response:
 recorded. Search transport failures are reported in this JSON object with an
 empty `results` array instead of being silently discarded.
 
+### Library transport and receipt contract
+
+Both packages expose a caller-owned transport boundary for capture and search:
+
+- JavaScript: `captureResponse` / `fetchHtmlReceipt` accept `transport` and
+  `AbortSignal`; `search` accepts the same options and exposes a non-enumerable
+  `result.receipt` to library callers.
+- Rust: `capture_response_with_transport`,
+  `fetch_html_receipt_with_transport`, and `search_with_transport` accept a
+  `Transport`; dropping the returned future cancels the request.
+
+A successful receipt preserves the exact undecoded response bytes, final URL,
+HTTP status, selected content/cache headers, and structured transport
+diagnostics. Search parsing is applied only after the receipt exists, keeping
+`build_search_url` and `parse_search_results` deterministic and allowing a
+downstream content-addressed cache to bind rankings to their source bytes.
+
 Provider catalog:
 
 | Provider     | Default | Source                     | Notes                                                                     |

--- a/js/.changeset/exact-response-receipts.md
+++ b/js/.changeset/exact-response-receipts.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/web-capture': minor
+---
+
+Add caller-owned transports, AbortSignal cancellation, and exact-byte response receipts to capture and search library APIs.

--- a/js/README.md
+++ b/js/README.md
@@ -568,6 +568,33 @@ const buffer = await page.screenshot({ type: 'png', fullPage: true });
 await browser.close();
 ```
 
+### Exact response receipts and cancellation
+
+Library callers can retain response provenance without decoding the source
+through a text API. A receipt contains the exact `Buffer` body, final URL, HTTP
+status, selected cache/content headers, and structured diagnostics:
+
+```javascript
+import { fetchHtmlReceipt, search } from '@link-assistant/web-capture';
+
+const controller = new AbortController();
+const receipt = await fetchHtmlReceipt('https://example.com', {
+  signal: controller.signal,
+  // transport: ({ url, method, headers, signal }) => myTransport(...),
+});
+
+const result = await search({
+  query: 'formal methods',
+  signal: controller.signal,
+});
+console.log(receipt.status, result.receipt.body, result.receipt.finalUrl);
+```
+
+`transport` may return either a Fetch-compatible `Response` or a materialized
+receipt. The search receipt is available to library callers as
+`result.receipt`; it is intentionally non-enumerable so the stable `/search`
+JSON response does not duplicate the full provider body.
+
 ## License
 
 [Unlicense](../LICENSE) — This is free and unencumbered software released into the public domain. You are free to copy, modify, publish, use, compile, sell, or distribute this software for any purpose, commercial or non-commercial, and by any means. See [https://unlicense.org](https://unlicense.org) for details.

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -81,6 +81,13 @@ export {
   SEARCH_PROVIDERS,
 } from './search.js';
 export {
+  captureResponse,
+  fetchTransport,
+  CaptureTransportError,
+  RECEIPT_HEADERS,
+} from './transport.js';
+export { fetchHtml, fetchHtmlReceipt } from './lib.js';
+export {
   captureSharedDialog,
   formatSharedDialogAsDemoMemory,
   formatSharedDialogAsMarkdown,

--- a/js/src/lib.js
+++ b/js/src/lib.js
@@ -11,6 +11,7 @@ import { isFormulaImage, isMathElement, extractFormula } from './latex.js';
 import { extractMetadata } from './metadata.js';
 import { postProcessMarkdown } from './postprocess.js';
 import { retry } from './retry.js';
+import { captureResponse, fetchTransport } from './transport.js';
 
 const STACKPRINTER_RETRIES = 3;
 const STACKPRINTER_RETRY_BASE_DELAY_MS = 1000;
@@ -19,7 +20,7 @@ const HTML_FETCH_HEADERS = {
   'accept-encoding': 'identity',
 };
 
-export async function fetchHtml(url) {
+export async function fetchHtml(url, options = {}) {
   if (!url) {
     throw new Error('Missing URL parameter');
   }
@@ -33,8 +34,16 @@ export async function fetchHtml(url) {
     return await fetchStackPrinterHtml(stackPrinterUrl);
   }
 
-  const response = await fetchHtmlResponse(url);
-  return response.text();
+  const receipt = await fetchHtmlReceipt(url, options);
+  return receipt.body.toString('utf8');
+}
+
+/** Return an undecoded, exact-byte receipt for a document fetch. */
+export function fetchHtmlReceipt(url, options = {}) {
+  return captureResponse(url, {
+    ...options,
+    headers: { ...HTML_FETCH_HEADERS, ...options.headers },
+  });
 }
 
 export function getGoogleDriveFileId(url) {
@@ -216,9 +225,7 @@ async function fetchStackPrinterHtml(url) {
 }
 
 function fetchHtmlResponse(url) {
-  return fetch(url, {
-    headers: HTML_FETCH_HEADERS,
-  });
+  return fetchTransport({ url, headers: HTML_FETCH_HEADERS });
 }
 
 function isStackPrinterTransientError(html) {

--- a/js/src/search.js
+++ b/js/src/search.js
@@ -19,10 +19,10 @@
  * @module search
  */
 
-import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
 import he from 'he';
 import { URL } from 'url';
+import { captureResponse, fetchTransport } from './transport.js';
 
 /** Providers understood by the search contract. */
 export const SEARCH_PROVIDERS = [
@@ -310,7 +310,9 @@ export function formatSearchAsMarkdown(result) {
  * @param {string} [options.provider=wikipedia] - Provider id
  * @param {number} [options.limit=10] - Max results to return
  * @param {string} [options.captureMode=fetch] - Reported capture mode
- * @param {Function} [options.fetchImpl=fetch] - Fetch implementation (injectable for tests)
+ * @param {Function} [options.transport] - Receipt transport (injectable)
+ * @param {AbortSignal} [options.signal] - Caller cancellation signal
+ * @param {Function} [options.fetchImpl] - Legacy Fetch-compatible injection
  * @param {Function} [options.now] - Clock returning an ISO timestamp (injectable for tests)
  * @returns {Promise<Object>} Normalized search result object
  */
@@ -319,7 +321,9 @@ export async function search({
   provider = DEFAULT_PROVIDER,
   limit = DEFAULT_LIMIT,
   captureMode = 'fetch',
-  fetchImpl = fetch,
+  transport,
+  signal,
+  fetchImpl,
   now = () => new Date().toISOString(),
 } = {}) {
   if (!query || !String(query).trim()) {
@@ -342,7 +346,14 @@ export async function search({
 
   let results = [];
   try {
-    const response = await fetchImpl(sourceUrl, {
+    const effectiveTransport = transport
+      ? transport
+      : fetchImpl
+        ? ({ url, ...init }) => fetchImpl(url, init)
+        : fetchTransport;
+    const receipt = await captureResponse(sourceUrl, {
+      transport: effectiveTransport,
+      signal,
       headers: {
         'User-Agent': USER_AGENT,
         Accept:
@@ -352,16 +363,33 @@ export async function search({
         'Accept-Language': 'en-US,en;q=0.9',
       },
     });
-    diagnostics.status = response.status;
-    const body = await response.text();
+    diagnostics.status = receipt.status;
+    const body = receipt.body.toString('utf8');
     const parsed = parseSearchResults(provider, body, { limit });
     results = parsed.results;
     diagnostics.blockedByCaptcha = parsed.blockedByCaptcha;
+    const result = {
+      query,
+      provider,
+      captureMode,
+      capturedAt,
+      results,
+      diagnostics,
+    };
+    // Library callers can bind parsed results to the exact receipt without
+    // inflating the stable HTTP /search JSON representation.
+    Object.defineProperty(result, 'receipt', {
+      value: receipt,
+      enumerable: false,
+    });
+    return result;
   } catch (err) {
     // A network/transport failure from a server context is reported as an
     // error status; browser CORS failures surface the same way and are flagged.
     diagnostics.status = diagnostics.status || 0;
     diagnostics.error = err.message;
+    diagnostics.errorKind = err.diagnostics?.errorKind || 'transport';
+    diagnostics.blockedByCors = diagnostics.errorKind === 'cors_or_transport';
   }
 
   return {

--- a/js/src/transport.js
+++ b/js/src/transport.js
@@ -1,0 +1,108 @@
+import fetch from 'node-fetch';
+
+export const RECEIPT_HEADERS = [
+  'cache-control',
+  'content-encoding',
+  'content-length',
+  'content-type',
+  'etag',
+  'last-modified',
+  'location',
+];
+
+function selectedHeaders(headers) {
+  const selected = {};
+  for (const name of RECEIPT_HEADERS) {
+    const value =
+      typeof headers?.get === 'function' ? headers.get(name) : headers?.[name];
+    if (value !== null && value !== undefined) {
+      selected[name] = String(value);
+    }
+  }
+  return selected;
+}
+
+function classifyTransportError(error, signal) {
+  if (signal?.aborted || error?.name === 'AbortError') {
+    return 'cancelled';
+  }
+  if (error?.name === 'TimeoutError' || error?.type === 'request-timeout') {
+    return 'timeout';
+  }
+  if (error instanceof TypeError) {
+    return 'cors_or_transport';
+  }
+  return 'transport';
+}
+
+export class CaptureTransportError extends Error {
+  constructor(error, url, signal) {
+    super(error?.message || String(error));
+    this.name = 'CaptureTransportError';
+    this.cause = error;
+    this.diagnostics = {
+      outcome: 'error',
+      errorKind: classifyTransportError(error, signal),
+      sourceUrl: url,
+      error: this.message,
+    };
+  }
+}
+
+/** Default caller-replaceable transport. Dropping/aborting `signal` cancels fetch. */
+export function fetchTransport({ url, method = 'GET', headers, signal }) {
+  return fetch(url, { method, headers, signal });
+}
+
+/**
+ * Capture an HTTP response without decoding its body.
+ *
+ * A custom transport receives `{url, method, headers, signal}` and may return
+ * either a Fetch `Response` or an already materialized receipt. The returned
+ * body is a Buffer containing the exact response bytes.
+ */
+export async function captureResponse(
+  url,
+  { transport = fetchTransport, signal, headers = {} } = {}
+) {
+  if (!url) {
+    throw new Error('Missing URL parameter');
+  }
+  const request = { url, method: 'GET', headers, signal };
+  try {
+    const response = await transport(request);
+    if (
+      response?.body !== null &&
+      response?.body !== undefined &&
+      response?.finalUrl &&
+      response?.diagnostics
+    ) {
+      return { ...response, body: Buffer.from(response.body) };
+    }
+    if (
+      !response ||
+      (typeof response.arrayBuffer !== 'function' &&
+        typeof response.text !== 'function')
+    ) {
+      throw new TypeError(
+        'Transport must return a Response or response receipt'
+      );
+    }
+    const body =
+      typeof response.arrayBuffer === 'function'
+        ? Buffer.from(await response.arrayBuffer())
+        : Buffer.from(await response.text());
+    return {
+      body,
+      finalUrl: response.url || url,
+      status: response.status,
+      headers: selectedHeaders(response.headers),
+      diagnostics: { outcome: 'response' },
+    };
+  } catch (error) {
+    if (error instanceof CaptureTransportError) {
+      throw error;
+    }
+    throw new CaptureTransportError(error, url, signal);
+  }
+}

--- a/js/tests/unit/fetch-html.test.js
+++ b/js/tests/unit/fetch-html.test.js
@@ -1,5 +1,6 @@
 import nock from 'nock';
-import { fetchHtml } from '../../src/lib.js';
+import { jest } from '@jest/globals';
+import { fetchHtml, fetchHtmlReceipt } from '../../src/lib.js';
 
 afterEach(() => {
   nock.cleanAll();
@@ -19,6 +20,35 @@ describe('fetchHtml', () => {
 
     await expect(fetchHtml('https://example.com/article')).resolves.toContain(
       'ok'
+    );
+  });
+
+  it('returns an exact-byte receipt through an injectable transport', async () => {
+    const body = Buffer.from([0x00, 0xff, 0x41]);
+    const transport = jest.fn(async ({ url, signal }) => ({
+      body,
+      finalUrl: `${url}/final`,
+      status: 206,
+      headers: { 'content-type': 'application/octet-stream', etag: 'v1' },
+      diagnostics: { outcome: 'response' },
+      signal,
+    }));
+    const controller = new globalThis.AbortController();
+
+    const receipt = await fetchHtmlReceipt('https://example.com/bytes', {
+      transport,
+      signal: controller.signal,
+    });
+
+    expect(Buffer.from(receipt.body)).toEqual(body);
+    expect(receipt).toMatchObject({
+      finalUrl: 'https://example.com/bytes/final',
+      status: 206,
+      headers: { 'content-type': 'application/octet-stream', etag: 'v1' },
+      diagnostics: { outcome: 'response' },
+    });
+    expect(transport).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal })
     );
   });
 });

--- a/js/tests/unit/search.test.js
+++ b/js/tests/unit/search.test.js
@@ -4,6 +4,7 @@
  * Parsers are pure functions tested against fixtures; the orchestrating
  * `search()` is exercised with an injected fetch so no network is required.
  */
+import { jest } from '@jest/globals';
 
 import {
   search,
@@ -203,6 +204,57 @@ describe('search module (#130)', () => {
       });
       expect(result.results).toEqual([]);
       expect(result.diagnostics.error).toBe('network down');
+    });
+
+    it('returns the source receipt and forwards caller cancellation', async () => {
+      const body = Buffer.from(WIKI_JSON);
+      const controller = new globalThis.AbortController();
+      const transport = jest.fn(async ({ url, signal }) => ({
+        body,
+        finalUrl: `${url}&redirected=true`,
+        status: 200,
+        headers: { 'content-type': 'application/json', etag: 'search-v1' },
+        diagnostics: { outcome: 'response' },
+        signal,
+      }));
+
+      const result = await search({
+        query: 'formal-ai',
+        transport,
+        signal: controller.signal,
+        now: fixedNow,
+      });
+
+      expect(Buffer.from(result.receipt.body)).toEqual(body);
+      expect(result.receipt.finalUrl).toContain('redirected=true');
+      expect(result.receipt.headers.etag).toBe('search-v1');
+      expect(transport).toHaveBeenCalledWith(
+        expect.objectContaining({ signal: controller.signal })
+      );
+    });
+
+    it('classifies AbortSignal cancellation in structured diagnostics', async () => {
+      const controller = new globalThis.AbortController();
+      controller.abort();
+      const transport = async ({ signal }) => {
+        expect(signal).toBe(controller.signal);
+        const error = new Error('cancelled by caller');
+        error.name = 'AbortError';
+        throw error;
+      };
+
+      const result = await search({
+        query: 'formal-ai',
+        transport,
+        signal: controller.signal,
+        now: fixedNow,
+      });
+
+      expect(result.diagnostics).toMatchObject({
+        status: 0,
+        errorKind: 'cancelled',
+        error: 'cancelled by caller',
+      });
     });
 
     it('rejects an empty query', async () => {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "web-capture"
-version = "0.3.33"
+version = "0.3.34"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/rust/README.md
+++ b/rust/README.md
@@ -315,6 +315,34 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
+### Exact response receipts, custom transports, and cancellation
+
+`fetch_html_receipt` returns undecoded bytes together with the final URL, HTTP
+status, selected cache/content headers, and structured diagnostics.
+`fetch_html_receipt_with_transport` and `search_with_transport` accept any
+caller-owned implementation of `Transport`; `ReqwestTransport::new` also lets a
+caller supply its configured `reqwest::Client`.
+
+```rust,no_run
+use web_capture::{fetch_html_receipt_with_transport, ReqwestTransport};
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let transport = ReqwestTransport::new(reqwest::Client::new());
+let receipt = fetch_html_receipt_with_transport(
+    "https://example.com",
+    &transport,
+).await?;
+assert_eq!(receipt.status, 200);
+println!("{}: {} bytes", receipt.final_url, receipt.body.len());
+# Ok(())
+# }
+```
+
+Rust cancellation follows future lifetime semantics: dropping the future
+returned by a capture or search function cancels its in-flight transport
+future. `search_with_transport` returns `SearchCapture`, pairing deterministic
+parsed rankings with the exact `ResponseReceipt` they came from.
+
 ## Testing
 
 ```bash

--- a/rust/src/html.rs
+++ b/rust/src/html.rs
@@ -2,6 +2,8 @@
 //!
 //! This module provides functions for fetching, parsing, and processing HTML content.
 
+use std::collections::BTreeMap;
+
 use crate::{Result, WebCaptureError};
 use regex::Regex;
 use tracing::{debug, info};
@@ -35,7 +37,7 @@ pub async fn fetch_html(url: &str) -> Result<String> {
     let client = reqwest::Client::builder()
         .user_agent(USER_AGENT)
         .build()
-        .map_err(|e| WebCaptureError::FetchError(e.to_string()))?;
+        .map_err(|error| WebCaptureError::FetchError(error.to_string()))?;
 
     let response = client
         .get(url)
@@ -43,15 +45,40 @@ pub async fn fetch_html(url: &str) -> Result<String> {
         .header("Accept-Charset", "utf-8")
         .send()
         .await
-        .map_err(|e| WebCaptureError::FetchError(e.to_string()))?;
+        .map_err(|error| WebCaptureError::FetchError(error.to_string()))?;
 
     let html = response
         .text()
         .await
-        .map_err(|e| WebCaptureError::FetchError(e.to_string()))?;
+        .map_err(|error| WebCaptureError::FetchError(error.to_string()))?;
 
     info!("Successfully fetched HTML ({} bytes)", html.len());
     Ok(html)
+}
+
+/// Fetch an undecoded response through caller-owned transport.
+pub async fn fetch_html_receipt_with_transport(
+    url: &str,
+    transport: &dyn crate::transport::Transport,
+) -> std::result::Result<crate::transport::ResponseReceipt, crate::transport::TransportError> {
+    let request = crate::transport::TransportRequest {
+        url: url.to_string(),
+        method: "GET".to_string(),
+        headers: BTreeMap::from([
+            ("user-agent".to_string(), USER_AGENT.to_string()),
+            ("accept-encoding".to_string(), "identity".to_string()),
+            ("accept-language".to_string(), "en-US,en;q=0.9".to_string()),
+            ("accept-charset".to_string(), "utf-8".to_string()),
+        ]),
+    };
+    crate::transport::capture_response_with_transport(request, transport).await
+}
+
+/// Fetch an undecoded response through the default reqwest transport.
+pub async fn fetch_html_receipt(
+    url: &str,
+) -> std::result::Result<crate::transport::ResponseReceipt, crate::transport::TransportError> {
+    fetch_html_receipt_with_transport(url, &crate::transport::ReqwestTransport::default()).await
 }
 
 /// Convert relative URLs to absolute URLs in HTML content

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -52,6 +52,7 @@ pub mod search;
 pub mod shared_dialog;
 pub mod stackoverflow;
 pub mod themed_image;
+pub mod transport;
 pub mod verify;
 pub mod xpaste;
 
@@ -109,6 +110,21 @@ pub type Result<T> = std::result::Result<T, WebCaptureError>;
 /// Returns an error if the fetch fails or the response cannot be decoded
 pub async fn fetch_html(url: &str) -> Result<String> {
     html::fetch_html(url).await
+}
+
+/// Fetch an undecoded HTML response receipt through caller-owned transport.
+pub async fn fetch_html_receipt_with_transport(
+    url: &str,
+    transport: &dyn transport::Transport,
+) -> std::result::Result<transport::ResponseReceipt, transport::TransportError> {
+    html::fetch_html_receipt_with_transport(url, transport).await
+}
+
+/// Fetch an undecoded HTML response receipt through the default transport.
+pub async fn fetch_html_receipt(
+    url: &str,
+) -> std::result::Result<transport::ResponseReceipt, transport::TransportError> {
+    html::fetch_html_receipt(url).await
 }
 
 /// Render HTML content from a URL using a headless browser
@@ -537,6 +553,10 @@ fn extract_attr(tag: &str, attr: &str) -> Option<String> {
 // Re-export commonly used types
 pub use browser::BrowserEngine;
 pub use search::{
-    search, SearchDiagnostics, SearchResult, SearchResultItem, DEFAULT_LIMIT, DEFAULT_PROVIDER,
-    SEARCH_PROVIDERS,
+    search, search_with_transport, SearchCapture, SearchDiagnostics, SearchResult,
+    SearchResultItem, DEFAULT_LIMIT, DEFAULT_PROVIDER, SEARCH_PROVIDERS,
+};
+pub use transport::{
+    capture_response, capture_response_with_transport, ReqwestTransport, ResponseReceipt,
+    Transport, TransportDiagnostics, TransportError, TransportRequest, RECEIPT_HEADERS,
 };

--- a/rust/src/search.rs
+++ b/rust/src/search.rs
@@ -21,6 +21,7 @@
 
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use url::form_urlencoded::byte_serialize;
 
 const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -65,6 +66,14 @@ pub struct SearchResult {
     pub captured_at: String,
     pub results: Vec<SearchResultItem>,
     pub diagnostics: SearchDiagnostics,
+}
+
+/// Parsed rankings paired with the exact provider response used to derive them.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchCapture {
+    pub result: SearchResult,
+    pub receipt: crate::transport::ResponseReceipt,
 }
 
 /// Returns true if `provider` is one of the supported providers.
@@ -409,38 +418,19 @@ pub async fn search(
         source_url: source_url.clone(),
         error: None,
     };
-    let mut results = Vec::new();
-
-    let accept = if provider == "wikipedia" {
-        "application/json"
-    } else {
-        "text/html,application/xhtml+xml"
-    };
-
-    match reqwest::Client::builder().user_agent(USER_AGENT).build() {
-        Ok(client) => {
-            match client
-                .get(&source_url)
-                .header("Accept", accept)
-                .header("Accept-Language", "en-US,en;q=0.9")
-                .send()
-                .await
-            {
-                Ok(response) => {
-                    diagnostics.status = response.status().as_u16();
-                    match response.text().await {
-                        Ok(body) => {
-                            let (parsed, blocked) = parse_search_results(provider, &body, limit);
-                            results = parsed;
-                            diagnostics.blocked_by_captcha = blocked;
-                        }
-                        Err(e) => diagnostics.error = Some(e.to_string()),
-                    }
-                }
-                Err(e) => diagnostics.error = Some(e.to_string()),
-            }
-        }
-        Err(e) => diagnostics.error = Some(e.to_string()),
+    let transport = crate::transport::ReqwestTransport::default();
+    match search_with_transport(
+        query,
+        provider,
+        limit,
+        capture_mode,
+        captured_at,
+        &transport,
+    )
+    .await
+    {
+        Ok(capture) => return Ok(capture.result),
+        Err(error) => diagnostics.error = Some(error.to_string()),
     }
 
     Ok(SearchResult {
@@ -448,9 +438,70 @@ pub async fn search(
         provider: provider.to_string(),
         capture_mode: capture_mode.to_string(),
         captured_at: captured_at.to_string(),
-        results,
+        results: Vec::new(),
         diagnostics,
     })
+}
+
+/// Search through caller-owned transport and return the exact source receipt.
+///
+/// Dropping this future cancels the in-flight transport future. This provides
+/// cancellation without coupling the public API to a particular async runtime.
+pub async fn search_with_transport(
+    query: &str,
+    provider: &str,
+    limit: usize,
+    capture_mode: &str,
+    captured_at: &str,
+    transport: &dyn crate::transport::Transport,
+) -> std::result::Result<SearchCapture, crate::transport::TransportError> {
+    if query.trim().is_empty() {
+        return Err(crate::transport::TransportError {
+            kind: "invalid_request".to_string(),
+            message: "Missing `query` parameter".to_string(),
+            source_url: String::new(),
+        });
+    }
+    let source_url = build_search_url(provider, query, limit).map_err(|message| {
+        crate::transport::TransportError {
+            kind: "invalid_request".to_string(),
+            message,
+            source_url: String::new(),
+        }
+    })?;
+    let accept = if provider == "wikipedia" {
+        "application/json"
+    } else {
+        "text/html,application/xhtml+xml"
+    };
+    let request = crate::transport::TransportRequest {
+        url: source_url.clone(),
+        method: "GET".to_string(),
+        headers: BTreeMap::from([
+            ("user-agent".to_string(), USER_AGENT.to_string()),
+            ("accept".to_string(), accept.to_string()),
+            ("accept-language".to_string(), "en-US,en;q=0.9".to_string()),
+            ("accept-encoding".to_string(), "identity".to_string()),
+        ]),
+    };
+    let receipt = crate::transport::capture_response_with_transport(request, transport).await?;
+    let body = String::from_utf8_lossy(&receipt.body);
+    let (results, blocked_by_captcha) = parse_search_results(provider, &body, limit);
+    let result = SearchResult {
+        query: query.to_string(),
+        provider: provider.to_string(),
+        capture_mode: capture_mode.to_string(),
+        captured_at: captured_at.to_string(),
+        results,
+        diagnostics: SearchDiagnostics {
+            status: receipt.status,
+            blocked_by_cors: false,
+            blocked_by_captcha,
+            source_url,
+            error: None,
+        },
+    };
+    Ok(SearchCapture { result, receipt })
 }
 
 #[cfg(test)]

--- a/rust/src/transport.rs
+++ b/rust/src/transport.rs
@@ -1,0 +1,175 @@
+//! Caller-owned HTTP transport and exact-byte response receipts.
+
+use std::{collections::BTreeMap, future::Future, pin::Pin};
+
+use serde::{Deserialize, Serialize};
+
+/// Headers retained in portable response receipts.
+pub const RECEIPT_HEADERS: [&str; 7] = [
+    "cache-control",
+    "content-encoding",
+    "content-length",
+    "content-type",
+    "etag",
+    "last-modified",
+    "location",
+];
+
+/// Owned request passed to an injectable transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportRequest {
+    pub url: String,
+    pub method: String,
+    pub headers: BTreeMap<String, String>,
+}
+
+/// Structured transport outcome attached to a successful receipt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TransportDiagnostics {
+    pub outcome: String,
+}
+
+impl TransportDiagnostics {
+    #[must_use]
+    pub fn response() -> Self {
+        Self {
+            outcome: "response".to_string(),
+        }
+    }
+}
+
+/// Undecoded response bytes and provenance metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ResponseReceipt {
+    pub body: Vec<u8>,
+    pub final_url: String,
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    pub diagnostics: TransportDiagnostics,
+}
+
+/// Structured failure when no HTTP response receipt exists.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
+#[error("{message}")]
+#[serde(rename_all = "camelCase")]
+pub struct TransportError {
+    pub kind: String,
+    pub message: String,
+    pub source_url: String,
+}
+
+pub type TransportFuture<'a> =
+    Pin<Box<dyn Future<Output = std::result::Result<ResponseReceipt, TransportError>> + Send + 'a>>;
+
+/// Injectable asynchronous transport.
+///
+/// Cancellation is explicit through normal Rust future lifetime semantics:
+/// dropping the future returned by [`Transport::execute`] cancels the request.
+pub trait Transport: Send + Sync {
+    fn execute(&self, request: TransportRequest) -> TransportFuture<'_>;
+}
+
+impl<F, Fut> Transport for F
+where
+    F: Fn(TransportRequest) -> Fut + Send + Sync,
+    Fut: Future<Output = std::result::Result<ResponseReceipt, TransportError>> + Send + 'static,
+{
+    fn execute(&self, request: TransportRequest) -> TransportFuture<'_> {
+        Box::pin(self(request))
+    }
+}
+
+/// Default reqwest implementation. Callers may supply an already configured client.
+#[derive(Debug, Clone)]
+pub struct ReqwestTransport {
+    client: reqwest::Client,
+}
+
+impl ReqwestTransport {
+    #[must_use]
+    pub const fn new(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Default for ReqwestTransport {
+    fn default() -> Self {
+        Self::new(reqwest::Client::new())
+    }
+}
+
+impl Transport for ReqwestTransport {
+    fn execute(&self, request: TransportRequest) -> TransportFuture<'_> {
+        Box::pin(async move {
+            let method =
+                reqwest::Method::from_bytes(request.method.as_bytes()).map_err(|error| {
+                    TransportError {
+                        kind: "invalid_request".to_string(),
+                        message: error.to_string(),
+                        source_url: request.url.clone(),
+                    }
+                })?;
+            let mut builder = self.client.request(method, &request.url);
+            for (name, value) in &request.headers {
+                builder = builder.header(name, value);
+            }
+            let response = builder.send().await.map_err(|error| TransportError {
+                kind: if error.is_timeout() {
+                    "timeout"
+                } else if error.is_connect() {
+                    "connect"
+                } else {
+                    "transport"
+                }
+                .to_string(),
+                message: error.to_string(),
+                source_url: request.url.clone(),
+            })?;
+            let status = response.status().as_u16();
+            let final_url = response.url().to_string();
+            let headers = RECEIPT_HEADERS
+                .iter()
+                .filter_map(|name| {
+                    response
+                        .headers()
+                        .get(*name)
+                        .and_then(|value| value.to_str().ok())
+                        .map(|value| ((*name).to_string(), value.to_string()))
+                })
+                .collect();
+            let body = response
+                .bytes()
+                .await
+                .map_err(|error| TransportError {
+                    kind: "body".to_string(),
+                    message: error.to_string(),
+                    source_url: request.url,
+                })?
+                .to_vec();
+            Ok(ResponseReceipt {
+                body,
+                final_url,
+                status,
+                headers,
+                diagnostics: TransportDiagnostics::response(),
+            })
+        })
+    }
+}
+
+/// Capture an HTTP response through caller-supplied transport without decoding it.
+pub async fn capture_response_with_transport(
+    request: TransportRequest,
+    transport: &dyn Transport,
+) -> std::result::Result<ResponseReceipt, TransportError> {
+    transport.execute(request).await
+}
+
+/// Capture an HTTP response with the default reqwest transport.
+pub async fn capture_response(
+    request: TransportRequest,
+) -> std::result::Result<ResponseReceipt, TransportError> {
+    capture_response_with_transport(request, &ReqwestTransport::default()).await
+}

--- a/rust/tests/integration/mod.rs
+++ b/rust/tests/integration/mod.rs
@@ -21,5 +21,6 @@ mod search;
 mod stackoverflow_download;
 mod strip_base64_empty_alt;
 mod themed_image;
+mod transport;
 mod wikipedia_download;
 mod xpaste;

--- a/rust/tests/integration/search.rs
+++ b/rust/tests/integration/search.rs
@@ -4,11 +4,13 @@
 //! without making network calls (parsers are pure; only error paths of the
 //! async orchestrator are checked).
 
+use std::collections::BTreeMap;
 use web_capture::search::{
     build_search_url, format_search_as_markdown, parse_search_results, SearchDiagnostics,
     SearchResult, SearchResultItem,
 };
 use web_capture::{search, SEARCH_PROVIDERS};
+use web_capture::{search_with_transport, ResponseReceipt, TransportDiagnostics};
 
 const WIKI_JSON: &str = r#"{"pages":[
     {"id":1,"key":"Formal_methods","title":"Formal methods","excerpt":"the <b>study</b>","description":"x"}
@@ -98,4 +100,34 @@ async fn rejects_empty_query() {
 async fn rejects_unknown_provider() {
     let err = search("x", "yahoo", 10, "fetch", "t").await;
     assert!(err.unwrap_err().contains("Unknown search provider"));
+}
+
+#[tokio::test]
+async fn injectable_search_transport_returns_exact_receipt() {
+    let expected = WIKI_JSON.as_bytes().to_vec();
+    let transport = move |request: web_capture::TransportRequest| {
+        let body = expected.clone();
+        async move {
+            assert!(request.url.contains("en.wikipedia.org"));
+            Ok(ResponseReceipt {
+                body,
+                final_url: format!("{}&redirected=true", request.url),
+                status: 200,
+                headers: BTreeMap::from([
+                    ("content-type".into(), "application/json".into()),
+                    ("etag".into(), "search-v1".into()),
+                ]),
+                diagnostics: TransportDiagnostics::response(),
+            })
+        }
+    };
+
+    let capture = search_with_transport("formal-ai", "wikipedia", 1, "fetch", "t", &transport)
+        .await
+        .unwrap();
+
+    assert_eq!(capture.receipt.body, WIKI_JSON.as_bytes());
+    assert!(capture.receipt.final_url.ends_with("&redirected=true"));
+    assert_eq!(capture.result.results.len(), 1);
+    assert_eq!(capture.result.diagnostics.status, 200);
 }

--- a/rust/tests/integration/transport.rs
+++ b/rust/tests/integration/transport.rs
@@ -1,0 +1,68 @@
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use web_capture::{
+    fetch_html_receipt_with_transport, ResponseReceipt, TransportDiagnostics, TransportRequest,
+};
+
+#[tokio::test]
+async fn html_receipt_preserves_exact_bytes_and_metadata() {
+    let transport = |request: TransportRequest| async move {
+        assert_eq!(request.url, "https://example.com/bytes");
+        Ok(ResponseReceipt {
+            body: vec![0x00, 0xff, 0x41],
+            final_url: "https://example.com/final".into(),
+            status: 206,
+            headers: BTreeMap::from([
+                ("content-type".into(), "application/octet-stream".into()),
+                ("etag".into(), "v1".into()),
+            ]),
+            diagnostics: TransportDiagnostics::response(),
+        })
+    };
+
+    let receipt = fetch_html_receipt_with_transport("https://example.com/bytes", &transport)
+        .await
+        .unwrap();
+
+    assert_eq!(receipt.body, [0x00, 0xff, 0x41]);
+    assert_eq!(receipt.final_url, "https://example.com/final");
+    assert_eq!(receipt.status, 206);
+    assert_eq!(receipt.headers["etag"], "v1");
+}
+
+#[tokio::test]
+async fn dropping_capture_future_cancels_injected_transport() {
+    struct DropSignal(Arc<AtomicBool>);
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let transport_cancelled = Arc::clone(&cancelled);
+    let transport = move |_request: TransportRequest| {
+        let signal = DropSignal(Arc::clone(&transport_cancelled));
+        async move {
+            let _signal = signal;
+            std::future::pending::<Result<ResponseReceipt, web_capture::TransportError>>().await
+        }
+    };
+
+    {
+        let capture = fetch_html_receipt_with_transport("https://example.com/pending", &transport);
+        tokio::pin!(capture);
+        tokio::select! {
+            result = &mut capture => panic!("pending transport unexpectedly completed: {result:?}"),
+            () = tokio::task::yield_now() => {}
+        }
+    }
+
+    assert!(cancelled.load(Ordering::SeqCst));
+}


### PR DESCRIPTION
## Summary

Fixes #147.

- adds a shared exact-byte response receipt contract with final URL, status, selected headers, and structured diagnostics
- exposes caller-owned JavaScript transport injection and AbortSignal cancellation while keeping the existing HTTP `/search` payload stable
- exposes a Rust `Transport` abstraction, caller-owned `ReqwestTransport`, explicit drop-future cancellation semantics, and receipt-bearing search results
- preserves deterministic `build_search_url` and `parse_search_results` behavior
- documents the portable FormalAI integration contract for JavaScript and Rust

## Root cause and reproduction

The previous Rust capture/search paths constructed their own clients, while JavaScript capture owned its fetch operation and search injection did not expose response metadata or a cancellation contract. Both paths decoded response text before downstream callers could retain an exact receipt.

The new regression tests inject a binary response containing `00 ff 41`, a redirected final URL, status, and selected headers. They verify exact byte preservation, transport injection, JavaScript signal forwarding and abort diagnostics, and Rust cancellation by dropping a pending capture future.

## Validation

- `npm run check`
- `npm test -- --runInBand tests/unit/fetch-html.test.js tests/unit/search.test.js tests/integration/formalai-contract.test.js` (27 passed)
- `cargo test` (253 passed)
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `node scripts/check-js-rust-parity.mjs`
- `node scripts/validate-changeset.mjs`
- `git diff --check`

A broader local JavaScript run passed 489 tests and skipped 42. Thirteen environment-dependent browser/Docker tests could not run because the local Playwright Chromium bundle and Docker service are unavailable; the repository CI provisions its browser dependency.

## Screenshots

Not applicable; this is a transport/API change with no visual UI impact.